### PR TITLE
The sample file must be usable directly

### DIFF
--- a/config.json.sample
+++ b/config.json.sample
@@ -3,7 +3,6 @@
 	"theme": "owncloud",
 	"version": "0.1.0",
 	"apps" : [
-		"demo",
-		"servstat"
+		"files"
 	]
 }


### PR DESCRIPTION
Currently if one copies the sample file, it's missing the files app and
the demo and servstat apps do not compile.

Better fix the sample config to contain at least the files app then.