### PR TITLE
Move drag-drop init before attempt to load config and init app

### DIFF
--- a/src/default.js
+++ b/src/default.js
@@ -30,6 +30,13 @@ import VueRouter   from 'vue-router';
 Vue.use(VueEvents);
 Vue.use(VueRouter);
 
+// --- Drag Drop ----
+
+import { Drag, Drop } from 'vue-drag-drop';
+
+Vue.component('drag', Drag);
+Vue.component('drop', Drop);
+
 // --- Router ----
 
 Axios.get('config.json').then(config => {
@@ -73,11 +80,3 @@ Axios.get('config.json').then(config => {
 }).catch(err => {
 	alert(err);
 });
-
-
-// --- Drag Drop ----
-
-import { Drag, Drop } from 'vue-drag-drop';
-
-Vue.component('drag', Drag);
-Vue.component('drop', Drop);


### PR DESCRIPTION
Move the registration of the drag and drop components so that it is ensured that this is done before the app is initialized.