### PR TITLE
Style consistency: Add missing semicolons

### DIFF
--- a/apps/demo/src/ButtonRowItem.vue
+++ b/apps/demo/src/ButtonRowItem.vue
@@ -13,5 +13,5 @@ export default {
 			return this.$store.getters['files/SELECTED'];
 		}
 	}
-}
+};
 </script>

--- a/apps/demo/src/DemoShowConfig.vue
+++ b/apps/demo/src/DemoShowConfig.vue
@@ -20,5 +20,5 @@ export default {
 			return this.$root.config;
 		}
 	}
-}
+};
 </script>

--- a/apps/demo/src/app.js
+++ b/apps/demo/src/app.js
@@ -9,14 +9,14 @@ const navItems = [{
 	route: {
 		name: 'demo-show-config'
 	}
-}]
+}];
 
 
 // --- Components --------------------------------------------------------------
 
 const ShowConfig = () => ({
 	component: import ('./DemoShowConfig.vue')
-})
+});
 
 import ButtonRowItem from './ButtonRowItem.vue';
 
@@ -26,7 +26,7 @@ const routes = [{
 	path: `/${pkg.name}`,
 	component: ShowConfig,
 	name: 'demo-show-config'
-}]
+}];
 
 const plugins = [{
 	extend: "filesDetailsButtonRow",

--- a/apps/files/src/components/File-Details-Buttonrow.vue
+++ b/apps/files/src/components/File-Details-Buttonrow.vue
@@ -70,7 +70,7 @@ export default {
 					link.click();
 					document.body.removeChild(link);
 				}).catch(err => {
-					console.log(err)
+					console.log(err);
 				})
 			}
 		},
@@ -86,7 +86,7 @@ export default {
 						parentFiles.indexOf(files[i]), 1
 					);
 				}).catch(err => {
-					console.log(err)
+					console.log(err);
 				})
 			}
 		},
@@ -108,7 +108,7 @@ export default {
 					let parentFiles = this.$parent.$parent.$data.files;
 					parentFiles[parentFiles.indexOf(file)].name = newName;
 				}).catch(err => {
-					console.log(err)
+					console.log(err);
 				})
 			}else {
 				this.$uikit.notification({
@@ -119,5 +119,5 @@ export default {
 			}
 		}
 	}
-}
+};
 </script>

--- a/apps/files/src/components/File-Details.vue
+++ b/apps/files/src/components/File-Details.vue
@@ -89,7 +89,7 @@ export default {
 			let size = 0;
 
 			_each(this.files, (e) => {
-				size = size + e.size
+				size = size + e.size;
 			});
 
 			return size;
@@ -100,14 +100,14 @@ export default {
 		file() {
 			let filesSelected = this.$store.getters['files/SELECTED'];
 			if (_size(filesSelected) !== 1)
-				return false
+				return false;
 
 			return filesSelected[0];
 		},
 		files() {
 			let filesSelected = this.$store.getters['files/SELECTED'];
 			if (_size(filesSelected) === 1)
-				return false
+				return false;
 
 			return filesSelected;
 		}

--- a/apps/files/src/components/Tile.vue
+++ b/apps/files/src/components/Tile.vue
@@ -42,7 +42,7 @@ export default {
 			return this.$gettext(string);
 		}
 	}
-}
+};
 </script>
 <style scoped>
 	.category {

--- a/apps/servstat/src/Indicator.vue
+++ b/apps/servstat/src/Indicator.vue
@@ -83,5 +83,5 @@ export default {
 			})
 		}
 	}
-}
+};
 </script>

--- a/apps/servstat/src/app.js
+++ b/apps/servstat/src/app.js
@@ -9,7 +9,7 @@ const navItems = [{
 	route        : {
 		name : 'servstat'
 	}
-}]
+}];
 
 
 // --- Components --------------------------------------------------------------
@@ -24,7 +24,7 @@ const string = {
 			return this.$root.config.server;
 		}
 	}
-}
+};
 
 const ip = {
 	name : "ServstatIp",
@@ -42,7 +42,7 @@ const routes = [{
 	path : `/${pkg.name}`,
 	component : ip,
 	name : 'servstat'
-}]
+}];
 
 const plugins = [{
 	extend: "phoenixNavbarRight",
@@ -56,4 +56,4 @@ export default define({
 	routes,
 	plugins,
 	navItems
-})
+});

--- a/src/default.js
+++ b/src/default.js
@@ -41,7 +41,7 @@ Vue.component('drop', Drop);
 Axios.get('config.json').then(config => {
 
 	let apps = _map(config.data.apps, (app) => {
-		return `./apps/${app}/js/${app}.bundle.js`
+		return `./apps/${app}/js/${app}.bundle.js`;
 	})
 
 	requirejs(apps, function() {

--- a/src/default.js
+++ b/src/default.js
@@ -42,7 +42,7 @@ Axios.get('config.json').then(config => {
 
 	let apps = _map(config.data.apps, (app) => {
 		return `./apps/${app}/js/${app}.bundle.js`;
-	})
+	});
 
 	requirejs(apps, function() {
 

--- a/src/store.js
+++ b/src/store.js
@@ -27,4 +27,4 @@ const Store = new Vuex.Store({
 	}
 });
 
-export default Store
+export default Store;


### PR DESCRIPTION
Semicolons are unnecessary in Javascript in most cases. Some propose to get rid of them (e.g. the so called "Standard" JS recommendation) while others disagree and point out that using semicolons all the time brings more consistency as there are also edge cases where they are still necessary.

While I actually prefer the semicolon-less style in my own code, the matter of fact is that in this project semicolons are used throughout. This change adds the semicolons where they were forgotten in order to have a consistent style of coding.