### PR TITLE
Add markdown-editor to dist

### DIFF
--- a/Makefile.release
+++ b/Makefile.release
@@ -10,7 +10,7 @@ endif
 app_name=phoenix
 build_dir=$(CURDIR)/build
 dist_dir=$(build_dir)/dist
-src_files=README.md CHANGELOG.md LICENSE manifest.json index.html core/fonts themes/* core/css/core.css core/js/core.bundle.js node_modules/requirejs/require.js sw.js apps/files/js/files.bundle.js core/gfx/cloud-logo-invert.svg
+src_files=README.md CHANGELOG.md LICENSE manifest.json index.html core/fonts themes/* core/css/core.css core/js/core.bundle.js node_modules/requirejs/require.js sw.js apps/files/js/files.bundle.js apps/markdown-editor/js/*.js core/gfx/cloud-logo-invert.svg
 src_dirs=appinfo img
 all_src=$(src_dirs) $(src_files)
 


### PR DESCRIPTION
## Description
The markdown editor shall be release as well ...

## Motivation and Context
Because being the first app which which integrates into the open file action selector we better release it

## How Has This Been Tested?
- call make release

