### PR TITLE
Add htaccess to define caching in browsers

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,12 @@
+
+# BEGIN Caching
+<ifModule mod_headers.c>
+    <filesMatch "\\.(ico|jpg|jpeg|png|gif|ttf|otf|woff|woff2|eot|svg)$">
+    Header set Cache-Control "max-age=1, private, must-revalidate"
+    </filesMatch>
+    <filesMatch "\\.(css|js|json|html)$">
+    Header set Cache-Control "max-age=1, private, must-revalidate"
+    </filesMatch>
+</ifModule>
+# END Caching
+

--- a/Makefile.release
+++ b/Makefile.release
@@ -10,7 +10,7 @@ endif
 app_name=phoenix
 build_dir=$(CURDIR)/build
 dist_dir=$(build_dir)/dist
-src_files=README.md CHANGELOG.md LICENSE manifest.json index.html core/fonts themes/* core/css/core.css core/js/core.bundle.js node_modules/requirejs/require.js apps/files/js/files.bundle.js apps/markdown-editor/js/*.js
+src_files=README.md CHANGELOG.md LICENSE manifest.json .htaccess index.html core/fonts themes/* core/css/core.css core/js/core.bundle.js node_modules/requirejs/require.js apps/files/js/files.bundle.js apps/markdown-editor/js/*.js
 src_dirs=appinfo img
 all_src=$(src_dirs) $(src_files)
 
@@ -45,8 +45,10 @@ dist: javascript distdir sign package
 javascript:
 	$(YARN) install
 	$(YARN) run build:prod
-	$(YARN) install --prefix apps/files
-	$(YARN) run build:prod --prefix apps/files
+	$(YARN) --cwd apps/files install
+	$(YARN) --cwd apps/files run build
+	$(YARN) --cwd apps/markdown-editor install
+	$(YARN) --cwd apps/markdown-editor build
 
 .PHONY: distdir
 distdir:


### PR DESCRIPTION
## Description
Phoenix assets are usually cached for a long time in browsers - this causes issues when deploying new versions.
The htaccess file holds a config to basically disable caching for some file types.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...