### PR TITLE
[files] Allow sidebars to register a quick access button to the file …

### DIFF
--- a/apps/files/src/components/FileDetails.vue
+++ b/apps/files/src/components/FileDetails.vue
@@ -25,25 +25,25 @@
       <v-spacer />
     </v-layout>
     <v-tabs
-    v-model="active"
-    color="primary lighten-5"
-    dark
-    slider-color="yellow"
+      v-model="active"
+      color="primary lighten-5"
+      dark
+      slider-color="yellow"
     >
-    <v-tab
-    v-for="tab of fileSideBars"
-    :key="tab.name"
-    ripple
-    >
-    {{ tab.name }}
-  </v-tab>
+      <v-tab
+        v-for="tab of fileSideBars"
+        :key="tab.name"
+        ripple
+      >
+        {{ tab.name }}
+      </v-tab>
       <v-tab-item
-              v-for="tab of fileSideBars"
-              :key="tab.name"
+        v-for="tab of fileSideBars"
+        :key="tab.name"
       >
         <component :is="tab.component"></component>
       </v-tab-item>
-</v-tabs>
+    </v-tabs>
 </v-layout>
 </v-navigation-drawer>
 </template>
@@ -60,7 +60,7 @@ export default {
     return {
       drawer: false,
       tabName: '',
-      active: this.getLength
+      active: 0
     }
   },
   components: {
@@ -69,6 +69,9 @@ export default {
     ...mapActions('Files', ['deleteFiles']),
     close () {
       this.$emit('reset')
+    },
+    showSidebar (sideBarName) {
+      this.active = Object.keys(this.fileSideBars).indexOf(sideBarName)
     },
     downloadFiles () {
       this.downloadFile(this.items[0])
@@ -83,9 +86,6 @@ export default {
   computed: {
     ...mapGetters(['getToken', 'fileSideBars']),
 
-    getLength () {
-      return this.items.length
-    },
     getTabName () {
       if (this.items.length === 0) {
         return ''

--- a/apps/files/src/components/FileList.vue
+++ b/apps/files/src/components/FileList.vue
@@ -52,16 +52,12 @@
           <v-list-tile-sub-title>{{ item.mdate | formDateFromNow }}</v-list-tile-sub-title>
         </v-list-tile-content>
 
-        <v-list-tile-action>
+        <v-list-tile-action
+          v-for="(action, index) in actions"
+          :key="index">
           <v-btn icon
-            @click="downloadFile(item)">
-            <v-icon>file_download</v-icon>
-          </v-btn>
-        </v-list-tile-action>
-        <v-list-tile-action>
-          <v-btn icon
-          @click="deleteFile(item)">
-            <v-icon>delete</v-icon>
+            @click="action.handler(item, action.handlerData)">
+            <v-icon>{{ action.icon }}</v-icon>
           </v-btn>
         </v-list-tile-action>
 
@@ -116,13 +112,30 @@ export default {
         client: this.$client,
         files: [file]
       })
+    },
+    openSideBar (file, sideBarName) {
+      this.$emit('sideBarOpen', file, sideBarName)
     }
   },
   computed: {
     ...mapGetters('Files', ['selectedFiles']),
-    ...mapGetters(['getToken']),
+    ...mapGetters(['getToken', 'fileSideBars']),
     all () {
       return this.selectedFiles.length === this.fileData.length
+    },
+    actions () {
+      let actions = [
+        { icon: 'file_download', handler: this.downloadFile },
+        { icon: 'delete', handler: this.deleteFile }
+      ]
+      for (let sideBarName in this.fileSideBars) {
+        let sideBar = this.fileSideBars[sideBarName]
+        if (sideBar.quickAccess) {
+          actions.push({ icon: sideBar.quickAccess.icon, handler: this.openSideBar, handlerData: sideBarName })
+        }
+      }
+
+      return actions
     }
   }
 }

--- a/apps/files/src/components/FilesApp.vue
+++ b/apps/files/src/components/FilesApp.vue
@@ -81,10 +81,10 @@
       <v-layout row fill-height>
         <v-flex :class="{'xs12': selectedFiles.length === 0, 'xs6': selectedFiles.length > 0 }" pa-0 fill-height>
           <v-progress-linear v-if="loading" :indeterminate="true"></v-progress-linear>
-          <file-list @toggle="toggleFileSelect" @FileAction="openFileActionBar" :fileData="filteredFiles" />
+          <file-list @toggle="toggleFileSelect" @FileAction="openFileActionBar" :fileData="filteredFiles" @sideBarOpen="openSideBar"/>
         </v-flex>
         <v-flex v-if="selectedFiles.length > 0" xs6 pa-0>
-          <file-details :items="selectedFiles" :starsEnabled="false" :checkboxEnabled="false"/>
+          <file-details :items="selectedFiles" :starsEnabled="false" :checkboxEnabled="false" ref="fileDetails"/>
         </v-flex>
         <file-actions-tab :sheet="showActionBar" :file="fileAction" @close="showActionBar = !showActionBar"/>
       </v-layout>
@@ -207,6 +207,14 @@ export default {
       })
       this.showActionBar = true
       this.fileAction = file
+    },
+
+    openSideBar (file, sideBarName) {
+      this.resetFileSelection()
+      this.addFileSelection(file)
+      this.$nextTick().then(() => {
+        this.$refs.fileDetails.showSidebar(sideBarName)
+      })
     },
 
     addNewFile (fileName) {


### PR DESCRIPTION
…list

## Description
Some file sidebar tabs have some importance over others and need to be accessible by the user quickly with one click. A action button can be added by a tab to allow this.

## How Has This Been Tested?
- :hand: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...