### PR TITLE
[files] Fix error handling on upload and success handling in sub folder

### DIFF
--- a/apps/files/src/FileUpload.js
+++ b/apps/files/src/FileUpload.js
@@ -8,7 +8,7 @@ class FileUpload {
 
   upload (file, additionalData = {}) {
     let xhr = new XMLHttpRequest()
-    xhr.responseType = 'json'
+    xhr.responseType = 'text'
 
     // Headers
     xhr.open(this.type, this.url + encodeURIComponent(file.name), true)
@@ -17,9 +17,12 @@ class FileUpload {
     // Events
     xhr.upload.addEventListener('progress', this.onProgress, false)
     let promise = new Promise((resolve, reject) => {
-      xhr.onload = e =>
-        xhr.status >= 200 && xhr.status < 400 ? resolve(e) : reject(e)
-      xhr.onerror = e => reject(e)
+      xhr.onload = e => {
+        xhr.status >= 200 && xhr.status < 400 ? resolve(e) : reject(new Error(xhr.statusText))
+      }
+      xhr.onerror = e => {
+        reject(e)
+      }
     })
 
     // Start upload

--- a/apps/files/src/components/FilesApp.vue
+++ b/apps/files/src/components/FilesApp.vue
@@ -170,16 +170,25 @@ export default {
     },
 
     onFileSuccess (event, file) {
-      this.$client.files.fileInfo(file.name, davProperties).then(fileInfo => {
-        this.fileUploadProgress = 0
-        this.fileUploadName = ''
-        this.addFiles({
-          files: [fileInfo]
+      this.$nextTick().then(() => {
+        const filePath = ((this.item === 'home') ? '' : this.item) + '/' + file.name
+        this.$client.files.fileInfo(filePath, davProperties).then(fileInfo => {
+          this.fileUploadProgress = 0
+          this.fileUploadName = ''
+          this.addFiles({
+            files: [fileInfo]
+          })
+        }).catch(() => {
+          this.fileUploadProgress = 0
+          this.fileUploadName = ''
+          this.getFolder()
         })
       })
     },
 
     onFileError (error) {
+      this.fileUploadProgress = 0
+      this.fileUploadName = ''
       this.showNotification({
         title: this.$gettext('File upload failed ....'),
         desc: error,


### PR DESCRIPTION
## Description
1. Error handling on upload was not properly implemented
2. Successful upload into a subfolder was buggy as well

## How Has This Been Tested?
1. try to upload into a readonly folder or upload where the user has no quota - error notification shall pop up
2. try uploading into a subfolder. progess bar shall disappear and file shall be visible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...