### PR TITLE
allow custom credentials in acceptance-tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Run `yarn install`
 
 ## Run
 
-- optionally: `export SERVER_HOST=0.0.0.0:8300`
+- optionally provide custom domain name: `export SERVER_HOST=0.0.0.0:8300`
 - run a webpack dev server `yarn run watch`
 
 ## Run acceptance tests
-
+- optionally provide custom credentials: `export OC_USER=admin && export OC_PASS=admin`
 - build, configure and run phoenix
 - install the Chrome browser
 - run `yarn run acceptance-tests`

--- a/tests/acceptance/stepDefinitions/loginContext.js
+++ b/tests/acceptance/stepDefinitions/loginContext.js
@@ -1,5 +1,8 @@
 const { client } = require('nightwatch-api');
 const { Given, Then, When } = require('cucumber');
+// respect custom credentials via env vars
+const OC_USER = process.env.OC_USER || null
+const OC_PASS = process.env.OC_PASS || null
 
 Given(/^the user has browsed to the login page$/,
 	() => {
@@ -26,8 +29,8 @@ When('the user logs in with username {string} and password {string} using the we
 			.page.ownCloudLoginPage();
 		return loginPage
 		.waitForElementVisible('@usernameInput', 1000)
-		.setValue('@usernameInput', username)
-		.setValue('@passwordInput', password)
+		.setValue('@usernameInput', OC_USER || username)
+		.setValue('@passwordInput', OC_PASS || password)
 		.click('@loginSubmitButton');
 	});
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
respect custom env vars for oc credentials, which enhances local & drone acceptance testing.
the default credentials for testing against new containers remains untouched.

## Motivation and Context
improved security for testing. my dev cloud has no `admin` user & i need to use a preinstalled oc instance for maximal testing performance.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- `yarn acceptance-tests`
- `export OC_USER=username && export OC_PASS=entropie && yarn acceptance-tests`

## Types of changes
- [X] New feature (non-breaking change which adds functionality)
- [X] Tests

## Checklist:
- [X] Code changes
- [X] Acceptance tests improved