### PR TITLE
Fix totalSize showing 0 bytes on FileInfoSidebar

### DIFF
--- a/apps/files/src/components/FileInfoSidebar.vue
+++ b/apps/files/src/components/FileInfoSidebar.vue
@@ -53,7 +53,7 @@ export default {
   computed: {
     ...mapGetters('Files', ['selectedFiles']),
     accumulatedFilesSize () {
-      return reduce(this.items, (sum, n) => {
+      return reduce(this.selectedFiles, (sum, n) => {
         return sum + n.size
       }, 0)
     }


### PR DESCRIPTION
## Description
This PR fixes FileInfoSideBar.vue always showing 0 bytes.



## How Has This Been Tested?
Manually

## Screenshots (if appropriate):
Before the fix:
![screenshot from 2019-01-16 21-48-11](https://user-images.githubusercontent.com/20378877/51263241-f62a2480-19db-11e9-8c25-673363fe474e.png)


After the fix:
![screenshot from 2019-01-16 21-52-26](https://user-images.githubusercontent.com/20378877/51263248-fa564200-19db-11e9-9c76-7f0712bd3628.png)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests