### PR TITLE
Filter search term in open folder

### DIFF
--- a/apps/files/src/components/FilesApp.vue
+++ b/apps/files/src/components/FilesApp.vue
@@ -6,7 +6,7 @@
           <v-breadcrumbs class="pa-0" :items="activeRoute">
             <template slot="item" slot-scope="props">
               <drop >
-                <v-icon @click="navigateTo('files-list', props.item.route)" v-if="props.item.text === 'home'" large>
+                <v-icon @click="navigateTo('files-list', 'home')" v-if="props.item.text === 'home'" large>
                   home
                 </v-icon>
                 <span @click="navigateTo('files-list', props.item.route)" v-else class="heading font-weight-bold" style="cursor: pointer">
@@ -20,6 +20,9 @@
                           ocTitle="Create new folder ..." @oc-confirm="addNewFolder" @oc-cancel="createFolder = false; newFolderName = ''"></oc-dialog-prompt>
         <oc-dialog-prompt :oc-active="createFile" v-model="newFileName"
                           ocTitle="Create new file ..." @oc-confirm="addNewFile" @oc-cancel="createFile = false; newFileName = ''"></oc-dialog-prompt>
+                          <v-flex xs2>
+                            <search-bar @search="onSearch" :value="searchQuery" />
+                          </v-flex>
           <v-menu offset-y >
           <v-progress-circular
              slot="activator"
@@ -120,6 +123,7 @@ import FileDetails from './FileDetails.vue'
 import FileActionsTab from './FileactionsTab.vue'
 import FileList from './FileList.vue'
 import FileUpload from './FileUpload.vue'
+import SearchBar from 'oc_components/form/SearchBar.vue'
 import OcDialogPrompt from './ocDialogPrompt.vue'
 import { filter } from 'lodash'
 import { mapActions, mapGetters, mapState } from 'vuex'
@@ -143,6 +147,7 @@ export default {
     FileActionsTab,
     FileList,
     FileUpload,
+    SearchBar,
     OcDialogPrompt
   },
   data () {
@@ -157,6 +162,7 @@ export default {
       fileName: '',
       selected: [],
       loading: false,
+      searchQuery: '',
       filters: [
         {
           name: 'Files',
@@ -288,18 +294,25 @@ export default {
           })
       }
     },
-
     ifFiltered (item) {
       for (let filter of this.filters) {
         if (item.type === filter.tag) {
-          return filter.value
+          if (!filter.value) return false
         } else if (item.name.startsWith('.')) {
-          return this.filters[2].value
+          // show hidden files ?
+          if (this.filters[2].value) return false
         }
       }
+      // respect search query for local search
+      if (this.searchQuery && !item.name.toLowerCase().includes(this.searchQuery.toLowerCase())) return false
+      return true
     },
-
+    onSearch (query) {
+      console.log('onSearch', query)
+      this.searchQuery = query
+    },
     getFolder () {
+      this.searchQuery = ''
       if (!this.iAmActive) {
         return false
       }

--- a/apps/files/webpack.common.js
+++ b/apps/files/webpack.common.js
@@ -1,6 +1,7 @@
+const integratePhoenix = require('../../webpack-phoenix-integration')
 const VueLoaderPlugin = require('vue-loader/lib/plugin')
 
-module.exports = {
+module.exports = integratePhoenix({
     plugins: [
         new VueLoaderPlugin(),
     ],
@@ -33,4 +34,4 @@ module.exports = {
             ]
         }]
     }
-}
+})

--- a/src/components/form/SearchBar.vue
+++ b/src/components/form/SearchBar.vue
@@ -1,5 +1,6 @@
 <template>
-  <v-text-field :label="label" append-icon="search" @input="onSearch" :value="searchQuery"></v-text-field>
+  <v-text-field :label="label" append-icon="search"
+    @input="onSearch" :value="searchQuery" autofocus="autofocus"></v-text-field>
 </template>
 
 <script>
@@ -15,6 +16,11 @@ export default {
       type: String,
       required: false,
       default: ''
+    },
+    autofocus: {
+      type: Boolean,
+      required: false,
+      default: false
     }
   },
   data: () => ({

--- a/src/components/form/SearchBar.vue
+++ b/src/components/form/SearchBar.vue
@@ -1,0 +1,40 @@
+<template>
+  <v-text-field :label="label" append-icon="search" @input="onSearch" :value="searchQuery"></v-text-field>
+</template>
+
+<script>
+
+export default {
+  props: {
+    value: {
+      type: String,
+      required: false,
+      default: null
+    },
+    label: {
+      type: String,
+      required: false,
+      default: ''
+    }
+  },
+  data: () => ({
+    query: ''
+  }),
+  methods: {
+    onSearch (query) {
+      this.query = query
+      this.$emit('search', query)
+    }
+  },
+  computed: {
+    searchQuery () {
+      // please don't treat empty string the same as null...
+      return (this.value === null) ? this.query : this.value
+    }
+  }
+}
+</script>
+
+<style>
+
+</style>

--- a/webpack-phoenix-integration.js
+++ b/webpack-phoenix-integration.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const path = require('path')
+
+function integratePhoenix (webpackConfig) {
+  let phoenixWebpackConfig = {
+    resolve: {
+      alias: {
+        'oc_components': path.join(__dirname, 'src/components'),
+        'oc_mixins': path.join(__dirname, 'src/mixins'),
+        'oc_router$': path.join(__dirname, 'src/router')
+      }
+    }
+  }
+  return Object.assign(webpackConfig, phoenixWebpackConfig)
+}
+module.exports = integratePhoenix


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
The second commit is the offline-search functionality for open folder.
To be able to reuse the SearchBar, i've designed some webpack alias magic to use inside app's build systems, visible in the first commit of this PR.
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- refs #172 
- close #517

## Motivation and Context
We need some way Interface in Phoenix which apps can use to import Models, Services, Mixins, etc...
One possible solution is to outsource them & publish them on npm, so we could import them in phoenix same as in apps. This may be an idea if our pattern library is available & grown, but we need some way to use them right now. To avoid proliferation of incorrect settings, i've created a little helper script located in phoenix root directory. Apps can wrap their webpack config up & it get's enriched with some nice path aliases.
I could adopt some more helper & mixin code if we got some interface for loading them in apps...
<!--- Why is this change required? What problem does it solve? -->
## Screenshots:
![filenamefilter](https://user-images.githubusercontent.com/7268689/51685481-ad332b00-1fee-11e9-8562-8f770c0c6589.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] New feature (non-breaking change which adds functionality)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [X] Code changes
- [X] Documentation ticket referenced

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] adopt UI. it's a filter function 
- [ ] talk about the new path aliases
