### PR TITLE
Display error page in case config.json could not be loaded - page nee…

### DIFF
--- a/src/default.js
+++ b/src/default.js
@@ -5,6 +5,7 @@ import Vue from 'vue'
 // --- Components ---
 
 import Phoenix from './Phoenix.vue'
+import errorPage from './pages/initError.vue'
 
 // --- Adding global libraries ---
 
@@ -114,6 +115,13 @@ Vue.component('drop', Drop);
       })
     })
   } catch (err) {
-    alert(err)
+    /* eslint-disable no-new */
+    new Vue({
+      el: '#owncloud',
+      data: {
+        error: err
+      },
+      render: h => h(errorPage)
+    })
   }
 })()

--- a/src/pages/initError.vue
+++ b/src/pages/initError.vue
@@ -1,0 +1,31 @@
+<template>
+  <div>
+    <v-app>
+      <v-alert
+        :value="true"
+        color="error"
+        icon="error">
+        Error in initializing the application ....<br>
+        {{ error}}
+      </v-alert>
+    </v-app>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'errorPage',
+
+  data () {
+    return {
+    }
+  },
+  computed: {
+    error () {
+      return this.$parent.$options.data().error.message
+    }
+  },
+  methods: {
+  }
+}
+</script>


### PR DESCRIPTION
…d love

## Description
Some minimalistic page in case config.json cannot be loaded

## Related Issue
- refs #515 

## How Has This Been Tested?
- remove config.json
- load phoenix in browser
- see an error page

## Screenshots (if appropriate):
![screenshot from 2019-01-18 16-52-24](https://user-images.githubusercontent.com/1005065/51397414-75853880-1b41-11e9-91fe-1b3d718a53c9.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...