### PR TITLE
Show nothing if the file size is unknown

### DIFF
--- a/apps/files/src/mixins.js
+++ b/apps/files/src/mixins.js
@@ -6,7 +6,7 @@ export default {
   filters: {
     fileSize (int) {
       if (int < 0) {
-        return 'Pending ...'
+        return ''
       }
       if (isNaN(int)) {
         return '???'


### PR DESCRIPTION
## Description
In some cases the folder size needs to be computed in the backend and takes time (e.g. files external the user has to move into all folders).
Instead of showing 'Pending ...' which has no meaning to the user we simply show nothing.


## How Has This Been Tested?
- :hand: 

## Screenshots (if appropriate):
![screenshot from 2019-01-24 10-21-04](https://user-images.githubusercontent.com/1005065/51668144-d4bfce80-1fc1-11e9-9778-c419e3f20010.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...