### PR TITLE
Add translations to markdown-editor and pdf-viewer

### DIFF
--- a/apps/markdown-editor/src/MarkdownEditor.vue
+++ b/apps/markdown-editor/src/MarkdownEditor.vue
@@ -34,13 +34,14 @@ import marked from 'marked'
 export default {
   name: 'MarkdownEditor',
   mounted () {
+    this.text = this.$gettext('# is Loading...')
     this.$store.dispatch('openFile', {
       client: this.$client,
       filePath: this.filePath
     }).then((f) => (this.text = f))
   },
   data: () => ({
-    text: '# is Loading...',
+    text: '',
     isTouched: false
   }),
   computed: {

--- a/l10n/Makefile
+++ b/l10n/Makefile
@@ -4,7 +4,7 @@ NODE_BINDIR = ../node_modules/.bin
 export PATH := $(NODE_BINDIR):$(PATH)
 
 # Where to find apps (it can be multiple paths).
-APPS =  ../apps/files
+APPS =  ../apps/files ../apps/pdf-viewer ../apps/markdown-editor
 
 # Where to find core folder
 CORE = ../src


### PR DESCRIPTION
## Description
- Sync translations for markdown-editor and pdf-viewer
- Translation string in markdown-editor

## Related Issue
- refs #584 

## How Has This Been Tested?
- run make l10n-read
- see template.pot in the apps l10n folders

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...