### PR TITLE
Use If-Not-Match: * to prevent overwrite of new uploaded file

### DIFF
--- a/apps/files/src/components/FilesTopBar.vue
+++ b/apps/files/src/components/FilesTopBar.vue
@@ -109,6 +109,8 @@ export default {
     },
     headers () {
       return {
+        // will trigger 412 precondition failed if a file already exists
+        'If-None-Match': '*',
         'Authorization': 'Bearer ' + this.getToken
       }
     },


### PR DESCRIPTION
## Description
We need to prevent data loss at any time. It is not allowed to overwrite a file silently.

## Related Issue
- refs #476 

## How Has This Been Tested?
- create a file on the server - e.g. via the old webui 
- do not reload phoenix
- create the same file in phoenix
- see an error poping up

## Screenshot
![Screenshot from 2019-04-23 16-56-24](https://user-images.githubusercontent.com/1005065/56591322-d2810680-65e8-11e9-8d12-cd26a701e6d3.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Add owncloud server version check
- [ ] Add acceptance tests
- [x] update js-owncloud-client
- [ ] add header check on reupload (once implemented in the ui)