### PR TITLE
Introduce OcAppSidebar, OcAppNavbar and OcAppContent

### DIFF
--- a/apps/files/src/components/FileDetails.vue
+++ b/apps/files/src/components/FileDetails.vue
@@ -1,55 +1,46 @@
 <template>
-  <v-navigation-drawer
-  v-model="drawer"
-  class="grey lighten-2"
-  right
-  floating
-  permanent
-  style="width:100%"
-  >
-  <v-layout column>
-    <v-layout primary row>
-      <v-flex>
-        <v-icon color="white" class="pl-4" medium>folder</v-icon>
-      </v-flex>
-      <v-flex white--text align-self-center>
-        <span class="subheading"> {{ getTabName }} </span>
-      </v-flex>
-    </v-layout>
-    <v-layout primary row>
-      <v-spacer />
-      <v-btn @click.native="deleteSelectedFiles" flat><v-icon color="white" medium>delete</v-icon></v-btn>
-      <v-spacer />
-      <v-btn @click.native="downloadFiles" v-if="items.length <= 1" flat><v-icon color="white" medium>cloud_download</v-icon></v-btn>
-      <v-btn disabled v-else flat><v-icon color="white" medium>archive</v-icon></v-btn>
-      <v-spacer />
-    </v-layout>
-    <v-tabs
-      v-model="active"
-      color="primary lighten-5"
-      dark
-      slider-color="yellow"
-    >
-      <v-tab
-        v-for="tab of fileSideBars"
-        :key="tab.name"
-        ripple
+  <oc-app-side-bar>
+    <template slot="title">
+      <span>{{ getTabName }}</span>
+    </template>
+    <template slot="headerContent">
+      <v-layout primary row>
+        <v-spacer />
+        <v-btn @click.native="deleteSelectedFiles" flat><v-icon color="white" medium>delete</v-icon></v-btn>
+        <v-spacer />
+        <v-btn @click.native="downloadFiles" v-if="items.length <= 1" flat><v-icon color="white" medium>cloud_download</v-icon></v-btn>
+        <v-btn disabled v-else flat><v-icon color="white" medium>archive</v-icon></v-btn>
+        <v-spacer />
+      </v-layout>
+    </template>
+    <template slot="content">
+      <v-tabs
+        v-model="active"
+        color="primary lighten-5"
+        dark
+        slider-color="yellow"
       >
-        {{ tab.name }}
-      </v-tab>
-      <v-tab-item
-        v-for="tab of fileSideBars"
-        :key="tab.name"
-      >
-        <component :is="tab.component"></component>
-      </v-tab-item>
-    </v-tabs>
-</v-layout>
-</v-navigation-drawer>
+        <v-tab
+          v-for="tab of fileSideBars"
+          :key="tab.name"
+          ripple
+        >
+          {{ tab.name }}
+        </v-tab>
+        <v-tab-item
+          v-for="tab of fileSideBars"
+          :key="tab.name"
+        >
+          <component :is="tab.component"></component>
+        </v-tab-item>
+      </v-tabs>
+    </template>
+  </oc-app-side-bar>
 </template>
 
 <script>
 import Mixins from '../mixins'
+import OcAppSideBar from 'oc_components/OcAppSideBar.vue'
 import { mapActions, mapGetters } from 'vuex'
 
 export default {
@@ -64,6 +55,7 @@ export default {
     }
   },
   components: {
+    OcAppSideBar
   },
   methods: {
     ...mapActions('Files', ['deleteFiles']),
@@ -85,12 +77,15 @@ export default {
   },
   computed: {
     ...mapGetters(['getToken', 'fileSideBars']),
-
     getTabName () {
       if (this.items.length === 0) {
         return ''
       }
-      return (this.items.length > 1) ? this.$gettext('Multiple Files') : this.items[0].name
+      if (this.items.length > 1) {
+        return this.$gettext('Multiple Files')
+      } else {
+        return (this.items[0].name.length > 16) ? `${this.items[0].name.substr(0, 10)}...` : this.items[0].name
+      }
     }
   }
 }

--- a/apps/files/src/components/FileInfoSidebar.vue
+++ b/apps/files/src/components/FileInfoSidebar.vue
@@ -9,7 +9,7 @@
                     <v-icon large>folder</v-icon>
                 </v-list-tile-avatar>
 
-                <v-list-tile-title>{{ tile.name }}</v-list-tile-title>
+                <v-list-tile-title>{{ tile.name.substr(0, 20) }}...</v-list-tile-title>
                 <v-list-tile-sub-title>{{ tile.size | fileSize }}</v-list-tile-sub-title>
             </v-list-tile>
         </v-layout>
@@ -33,7 +33,7 @@
                     <v-icon large>folder</v-icon>
                 </v-list-tile-avatar>
 
-                <v-list-tile-title>{{ tile.name }}</v-list-tile-title>
+                <v-list-tile-title>{{ tile.name.substr(0, 20) }}...</v-list-tile-title>
                 <v-list-tile-sub-title>{{ tile.size | fileSize }}</v-list-tile-sub-title>
             </v-list-tile>
         </v-layout>

--- a/apps/files/src/components/FilesApp.vue
+++ b/apps/files/src/components/FilesApp.vue
@@ -1,24 +1,21 @@
   <template>
-    <v-content>
-      <v-container id="files-app" fluid pa-0>
-      <v-layout row fill-height>
-        <v-flex :class="{'xs12': selectedFiles.length === 0, 'xs6': selectedFiles.length > 0 }" pa-0 fill-height>
+    <div class="oc-app" id="files-app">
+      <oc-app-content>
+        <template slot="content">
           <v-progress-linear v-if="loading" :indeterminate="true"></v-progress-linear>
           <file-list @toggle="toggleFileSelect" @FileAction="openFileActionBar" :fileData="filteredFiles" @sideBarOpen="openSideBar"/>
-        </v-flex>
-        <v-flex v-if="selectedFiles.length > 0" xs6 pa-0>
-          <file-details :items="selectedFiles" :starsEnabled="false" :checkboxEnabled="false" ref="fileDetails"/>
-        </v-flex>
-        <file-actions-tab :sheet="showActionBar" :file="fileAction" @close="showActionBar = !showActionBar"/>
-      </v-layout>
-    </v-container>
-    </v-content>
+        </template>
+      </oc-app-content>
+      <file-actions-tab :sheet="showActionBar" :file="fileAction" @close="showActionBar = !showActionBar"/>
+      <file-details v-if="selectedFiles.length > 0" :items="selectedFiles" :starsEnabled="false" :checkboxEnabled="false" ref="fileDetails"/>
+  </div>
   </template>
 
 <script>
 import Mixins from '../mixins'
 import FileDetails from './FileDetails.vue'
 import FileActionsTab from './FileactionsTab.vue'
+import OcAppContent from 'oc_components/OcAppContent.vue'
 import FileList from './FileList.vue'
 import { filter } from 'lodash'
 import { mapActions, mapGetters, mapState } from 'vuex'
@@ -45,6 +42,7 @@ export default {
   components: {
     FileDetails,
     FileActionsTab,
+    OcAppContent,
     FileList
   },
   data () {

--- a/src/Phoenix.vue
+++ b/src/Phoenix.vue
@@ -62,6 +62,28 @@ export default {
 </script>
 
 <style>
+  .oc-app {
+    display: grid;
+    height: 100%;
+    grid-template-columns: auto 1fr auto;
+    grid-template-rows: 1fr;
+    grid-template-areas: "ocAppNavbar ocAppContent ocAppSidebar";
+  }
+  .oc-app-navbar {
+    max-width: 20vw;
+    grid-area: ocAppNavbar;
+  }
+
+  .oc-app-sidebar {
+    min-width: 280px;
+    max-width: 20vw;
+    grid-area: ocAppSidebar;
+  }
+
+  .oc-app-content {
+    max-width: 100%;
+    grid-area: ocAppContent;
+  }
   .grid-container {
     display: grid;
     grid-template-columns: auto 1.5fr;
@@ -77,7 +99,6 @@ export default {
   }
   .sidebar { grid-area: sidebar;
             background-color: brown;
-            width: 300px;
             overflow: auto;
             transition: all 1s; }
 

--- a/src/components/OcAppContent.vue
+++ b/src/components/OcAppContent.vue
@@ -1,0 +1,14 @@
+<template>
+  <div class="oc-app-content">
+      <slot name="content"></slot>
+  </div>
+</template>
+<script>
+export default {
+  data: () => ({
+
+  })
+}
+</script>
+<style scoped>
+</style>

--- a/src/components/OcAppNavBar.vue
+++ b/src/components/OcAppNavBar.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="oc-app-navbar">
+    <div class="content">
+      <slot name="content"></slot>
+    </div>
+  </div>
+</template>
+<script>
+export default {
+  data: () => ({
+
+  })
+}
+</script>
+<style scoped>
+.content {
+  width: 20vw;
+}
+</style>

--- a/src/components/OcAppSideBar.vue
+++ b/src/components/OcAppSideBar.vue
@@ -1,0 +1,105 @@
+<template>
+  <div class="oc-app-sidebar">
+    <div class="sidebar-container">
+      <div class="header primary">
+        <div class="icon">
+          <slot name="icon">
+            <v-icon color="white" large>{{ icon }}</v-icon>
+          </slot>
+        </div>
+        <div class="title">
+          <slot name="title">
+            <span>Heading</span>
+          </slot>
+        </div>
+        <div v-if="!disableAction" class="action">
+          <slot name="action">
+            <button @click="$emit('close', $event)"><v-icon color="white" large>close</v-icon></button>
+          </slot>
+        </div>
+        <div class="headerContent">
+          <slot name="headerContent"></slot>
+        </div>
+      </div>
+      <div class="body">
+        <slot name="content"></slot>
+      </div>
+      <div class="footer">
+        <slot name="footer"></slot>
+      </div>
+    </div>
+  </div>
+</template>
+<script>
+export default {
+  props: {
+    icon: {
+      default: 'folder',
+      type: String
+    },
+    disableAction: {
+      default: false,
+      type: Boolean
+    }
+  }
+}
+</script>
+<style scoped>
+.sidebar-container {
+  display: grid;
+  width: 20vw;
+  grid-template-columns: 1fr;
+  grid-template-rows: 0.5fr 5fr 0.5fr;
+  grid-template-areas: "header" "body" "footer";
+}
+
+.header {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-rows: 1fr 1fr;
+  grid-template-areas: "iconArea title headerAction" "headerContent headerContent headerContent";
+  grid-area: header;
+}
+
+.headerContent {
+  grid-area: headerContent;
+}
+
+.action {
+  grid-area: headerAction;
+  padding: 1em;
+}
+
+.action button {
+  float: right;
+}
+
+.action button:hover {
+  border-radius: 46%;
+  background-color: rgba(200, 200, 200, .5);
+}
+
+.icon {
+  grid-area: iconArea;
+  padding: 1em;
+}
+
+.title {
+  grid-area: title;
+  text-align: center;
+  color:white;
+}
+.title span,p {
+  font-size: .8em;
+  line-height: 60px;
+}
+.body { grid-area: body; }
+
+.footer {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-rows: 1fr;
+  grid-template-areas: ". . .";
+  grid-area: footer;
+}
+</style>


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This Commit will Introduce OcAppSidebar component with a reference implementation in files-app.
As befor OcAppSidebar can be used as base component and can be extended by slots.
All slots are inspirated by current Sidebar appearance and are open for discussion!

#### OcAppSidebar
* Position: Right-hand side of app content
* Width: 20vw
* Slots:
    * icon - left upper icon
    * title - title
    * action - right upper action slot, can be disabled
    * headerContent - row below actual header
    * content - the full content area
    * footer - footer area not used now

#### OcAppContent introduced
* Position: centered 
* Width: All available space
* Slots: Content - is there more we need?

#### OcAppNavbar introduced
* Position: Left-hand side of app content
* Width: same as sidebar
* Slots: Content - more tbd

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Refs #433 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Most of the existing UI is based on vuetify which make us depend on a framework. We want to offer developers the possible chance to use base components like OcAppTopbar and OcAppSidebar to get easy layout and positioning inside phoenix app.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :hand: 

## Screenshots:
![screenshot_2019-02-14 owncloud phoenix](https://user-images.githubusercontent.com/37431066/52753513-3094da80-2ff7-11e9-8508-afa0e9b5c2d4.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt


## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes

## ToDo:
- [ ] define layout for OcAppNavbar
- [ ] define usage for OcAppNavbar

## Important Note:
merge #664 before this