### PR TITLE
global & local file search

### DIFF
--- a/apps/files/src/components/FileList.vue
+++ b/apps/files/src/components/FileList.vue
@@ -43,7 +43,9 @@
         </v-list-tile-action>
         <v-list-tile-avatar>
           <v-icon>{{ fileTypeIcon(item) }}</v-icon>
-        </v-list-tile-avatar>        <v-list-tile-content
+        </v-list-tile-avatar>
+        <v-list-tile-content
+          v-if="!atSearchPage"
           @click="item.extension === false ? navigateTo('files-list', item.path.substr(1)) : openFileActionBar(item)"
           style="cursor: pointer"
         >
@@ -51,7 +53,15 @@
           <v-list-tile-sub-title class="text--primary">{{ item.size | fileSize }}</v-list-tile-sub-title>
           <v-list-tile-sub-title>{{ item.mdate | formDateFromNow }}</v-list-tile-sub-title>
         </v-list-tile-content>
-
+        <v-list-tile-content
+          v-else
+          @click="item.extension === false ? navigateTo('files-list', item.path.substr(1)) : openFileActionBar(item)"
+          style="cursor: pointer"
+        >
+          <v-list-tile-title>{{ item.name }}</v-list-tile-title>
+          <v-list-tile-sub-title class="text--primary">{{ getBaseDirectory(item.path) }}</v-list-tile-sub-title>
+          <v-list-tile-sub-title>{{ item.mdate | formDateFromNow }} | {{ item.size | fileSize }}</v-list-tile-sub-title>
+        </v-list-tile-content>
         <v-list-tile-action
           v-for="(action, index) in actions"
           :key="index">
@@ -104,6 +114,9 @@ export default {
         file: item
       })
     },
+    getBaseDirectory (filePath) {
+      return filePath.match(/^(.*[/])/)[0].slice(0, -1)
+    },
     openFileActionBar (file) {
       this.$emit('FileAction', file)
     },
@@ -118,7 +131,7 @@ export default {
     }
   },
   computed: {
-    ...mapGetters('Files', ['selectedFiles']),
+    ...mapGetters('Files', ['selectedFiles', 'atSearchPage']),
     ...mapGetters(['getToken', 'fileSideBars']),
     all () {
       return this.selectedFiles.length === this.fileData.length

--- a/apps/files/src/mixins.js
+++ b/apps/files/src/mixins.js
@@ -9,7 +9,7 @@ export default {
         return ''
       }
       if (isNaN(int)) {
-        return '???'
+        return '?'
       }
       return filesize(int * 100, {
         round: 2

--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -4,9 +4,11 @@ const localLaunchUrl = process.env.SERVER_HOST || 'http://localhost:8300'
 module.exports = {
   page_objects_path: './tests/acceptance/pageObjects',
   test_settings: {
-    SHORT_WAIT_TIME:     1000,
-    LONG_WAIT_TIME:     10000,
-    LONGER_WAIT_TIME:  100000,
+    "default": {
+      "globals": {
+        "waitForConditionTimeout": 10000
+      }
+    },
     local: {
       launch_url: localLaunchUrl,
       webdriver: {

--- a/src/components/form/SearchBar.vue
+++ b/src/components/form/SearchBar.vue
@@ -1,6 +1,8 @@
 <template>
-  <v-text-field :label="label" append-icon="search"
-    @input="onSearch" :value="searchQuery" autofocus="autofocus"></v-text-field>
+  <v-text-field :label="label" append-icon="search" :loading="loading"
+    @input="onType" :value="searchQuery" autofocus="autofocus"
+    @keydown.enter="onSearch" @click:append="onSearch">
+  </v-text-field>
 </template>
 
 <script>
@@ -17,7 +19,25 @@ export default {
       required: false,
       default: ''
     },
+    // native autofocus
     autofocus: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    // search while typing
+    autosearch: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    // do not automatically trim whitespaces around search term
+    noTrim: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    loading: {
       type: Boolean,
       required: false,
       default: false
@@ -28,8 +48,13 @@ export default {
   }),
   methods: {
     onSearch (query) {
-      this.query = query
-      this.$emit('search', query)
+      this.$emit('search', this.query)
+    },
+    onType (query) {
+      this.query = (!this.noTrim) ? query.trim() : query
+      // use input event to support model directive
+      this.$emit('input', query)
+      if (this.autosearch) this.onSearch(query)
     }
   },
   computed: {

--- a/tests/acceptance/stepDefinitions/loginContext.js
+++ b/tests/acceptance/stepDefinitions/loginContext.js
@@ -23,7 +23,7 @@ Then('the user logs in with username {string} and password {string} using the we
   (username, password) => {
     const loginPage = client.page.ownCloudLoginPage()
     return loginPage
-      .waitForElementVisible('@usernameInput', client.SHORT_WAIT_TIME)
+      .waitForElementVisible('@usernameInput')
       .setValue('@usernameInput', OC_USER || username)
       .setValue('@passwordInput', OC_PASS || password)
       .click('@loginSubmitButton')
@@ -34,7 +34,7 @@ When('the user authorizes access to phoenix',
     const loginPage = client
       .page.ownCloudAuthorizePage()
     return loginPage
-      .waitForElementPresent('@authorizeButton', client.SHORT_WAIT_TIME)
+      .waitForElementPresent('@authorizeButton')
       .click('@authorizeButton')
   })
 
@@ -42,7 +42,7 @@ Then('the files table should be displayed',
   () => {
     const filesPage = client.page.filesPage()
     return filesPage
-      .waitForElementVisible('@filesTable', client.LONGER_WAIT_TIME * 3)
+      .waitForElementVisible('@filesTable')
   })
 
 Then('the files table should not be empty',
@@ -50,5 +50,5 @@ Then('the files table should not be empty',
     const filesPage = client.page.filesPage()
     return filesPage
     // even the loading indicator is gone the table might not be rendered yet
-      .waitForElementVisible('@fileRows', client.LONG_WAIT_TIME)
+      .waitForElementVisible('@fileRows')
   })

--- a/tests/acceptance/stepDefinitions/loginContext.js
+++ b/tests/acceptance/stepDefinitions/loginContext.js
@@ -42,7 +42,7 @@ Then('the files table should be displayed',
   () => {
     const filesPage = client.page.filesPage()
     return filesPage
-      .waitForElementVisible('@filesTable', client.LONGER_WAIT_TIME)
+      .waitForElementVisible('@filesTable', client.LONGER_WAIT_TIME * 3)
   })
 
 Then('the files table should not be empty',


### PR DESCRIPTION
## Description
search for files in files app via ownCloud search. Filter local folder, even in searched folder list!
The local file filter filters the search result, if search term is inside the search-bar.
SearchBar need's keydown Enter, File Filter work's onType.
Integrates special view for search results. It's using the search-bar component.

**:warning:Including Heavy FileApp state refactoring!**

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #516
- Fixes #662
- refs #665
- replace pr #588 
- replace pr #607 

## Motivation and Context
global search now hide's the breadcrumb & changes the file row design.
It's parent folder is only shown in search mode.
I've found some issues related to our refactoring, i've almost solved them all. I needed to put some files-state derived data into the store, so we're able to map them in few components.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- open Files app
- type 'md'
- see markdown files

## Screenshots

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [X] Code changes


