### PR TITLE
:boom: Failing case: vue and vue-template-compiler have a version missmatch

### DIFF
--- a/apps/files/package.json
+++ b/apps/files/package.json
@@ -29,7 +29,7 @@
     "eslint-plugin-standard": "^4.0.0",
     "eslint-plugin-vue": "^5.2.2",
     "vue-loader": "^15.7.0",
-    "vue-template-compiler": "^2.6.7",
+    "vue-template-compiler": "2.6.6",
     "webpack": "^4.29.6",
     "webpack-cli": "^3.2.3",
     "webpack-merge": "^4.2.1"

--- a/apps/files/yarn.lock
+++ b/apps/files/yarn.lock
@@ -4747,10 +4747,10 @@ vue-style-loader@^4.1.0:
     hash-sum "^1.0.2"
     loader-utils "^1.0.2"
 
-vue-template-compiler@^2.6.7:
-  version "2.6.7"
-  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.6.7.tgz#7f6c14eacf3c912d28d33b029cde706d9756e00c"
-  integrity sha512-ZjxJLr6Lw2gj6aQGKwBWTxVNNd28/qggIdwvr5ushrUHUvqgbHD0xusOVP2yRxT4pX3wRIJ2LfxjgFT41dEtoQ==
+vue-template-compiler@2.6.6:
+  version "2.6.6"
+  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.6.6.tgz#a807acbf3d51971d3721d75ecb1b927b517c1a02"
+  integrity sha512-OakxDGyrmMQViCjkakQFbDZlG0NibiOzpLauOfyCUVRQc9yPmTqpiz9nF0VeA+dFkXegetw0E5x65BFhhLXO0A==
   dependencies:
     de-indent "^1.0.2"
     he "^1.1.0"


### PR DESCRIPTION
## Description
vue is managed in the phoenix parent project
vue-template-compiler is managed in the apps

In case the versions missmatch: :boom: 

```
ERROR in ./src/components/FileInfoVersions.vue
Module Error (from ./node_modules/vue-loader/lib/index.js):


Vue packages version mismatch:

- vue@2.6.7
- vue-template-compiler@2.6.6

This may cause things to work incorrectly. Make sure to use the same version for both.
If you are using vue-loader@>=10.0, simply update vue-template-compiler.
If you are using vue-loader@<10.0 or vueify, re-installing vue-loader/vueify should bump vue-template-compiler to the latest.

 @ ./src/default.js 129:0-65 146:15-31
 @ multi core-js/modules/es6.promise core-js/modules/es6.array.iterator ./src/default.js
```

## Motivation and Context
Apps/plugins need to be developed independent of phoenix
We need to find a way that updating vue+tools in phoenix do not break all apps/plugins

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...