### PR TITLE
Add spinner for file/folder creation dialog

### DIFF
--- a/apps/files/src/components/FilesTopBar.vue
+++ b/apps/files/src/components/FilesTopBar.vue
@@ -227,7 +227,9 @@ export default {
               type: 'error'
             })
           })
-          .finally(() => this.fileFolderCreationLoading = false)
+          .finally(() => {
+            this.fileFolderCreationLoading = false
+          })
       }
     },
     addNewFile (fileName) {
@@ -246,7 +248,9 @@ export default {
               type: 'error'
             })
           })
-          .finally(() => this.fileFolderCreationLoading = false)
+          .finally(() => {
+            this.fileFolderCreationLoading = false
+          })
       }
     },
     onFileSuccess (event, file) {

--- a/apps/files/src/components/FilesTopBar.vue
+++ b/apps/files/src/components/FilesTopBar.vue
@@ -96,8 +96,10 @@
       </template>
     </oc-app-top-bar>
     <oc-dialog-prompt :oc-active="createFolder" v-model="newFolderName"
+                      :ocLoading="fileFolderCreationLoading"
                       ocTitle="Create new folder ..." @oc-confirm="addNewFolder" @oc-cancel="createFolder = false; newFolderName = ''"></oc-dialog-prompt>
     <oc-dialog-prompt :oc-active="createFile" v-model="newFileName"
+                      :ocLoading="fileFolderCreationLoading"
                       ocTitle="Create new file ..." @oc-confirm="addNewFile" @oc-cancel="createFile = false; newFileName = ''"></oc-dialog-prompt>
   </div>
 </template>
@@ -131,7 +133,8 @@ export default {
     fileUploadProgress: 0,
     createFile: false,
     path: '',
-    searchedFiles: []
+    searchedFiles: [],
+    fileFolderCreationLoading: false
   }),
   computed: {
     ...mapGetters(['getToken', 'extensions']),
@@ -210,6 +213,7 @@ export default {
     },
     addNewFolder (folderName) {
       if (folderName !== '') {
+        this.fileFolderCreationLoading = true
         this.$client.files.createFolder(((this.item === 'home') ? '' : this.item) + '/' + folderName)
           .then(() => {
             this.createFolder = false
@@ -223,11 +227,12 @@ export default {
               type: 'error'
             })
           })
+          .finally(() => this.fileFolderCreationLoading = false)
       }
     },
     addNewFile (fileName) {
-      this.createFile = !this.createFile
       if (fileName !== '') {
+        this.fileFolderCreationLoading = true
         this.$client.files.putFileContents(((this.item === 'home') ? '' : this.item) + '/' + fileName, '')
           .then(() => {
             this.getFolder()
@@ -241,6 +246,7 @@ export default {
               type: 'error'
             })
           })
+          .finally(() => this.fileFolderCreationLoading = false)
       }
     },
     onFileSuccess (event, file) {

--- a/apps/files/src/components/ocDialogPrompt.vue
+++ b/apps/files/src/components/ocDialogPrompt.vue
@@ -5,6 +5,8 @@
       <v-card-text v-if="ocContent">{{ ocContent }}</v-card-text>
       <v-card-text>
         <v-text-field
+          :loading="ocLoading"
+          :disabled="ocLoading"
           autofocus
           v-model="inputValue"
           ref="input"
@@ -13,8 +15,8 @@
       </v-card-text>
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn flat @click="onCancel">{{ ocCancelText }}</v-btn>
-        <v-btn flat @click="onConfirm">{{ ocConfirmText }}</v-btn>
+        <v-btn :disabled="ocLoading" flat @click="onCancel">{{ ocCancelText }}</v-btn>
+        <v-btn :disabled="ocLoading" flat @click="onConfirm">{{ ocConfirmText }}</v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>
@@ -31,6 +33,7 @@ export default {
     ocInputMaxlength: [String, Number],
     ocInputPlaceholder: [String, Number],
     ocContent: String,
+    ocLoading: { type: Boolean, default: false },
     ocConfirmText: {
       type: String,
       default: 'Ok'


### PR DESCRIPTION
## Description
Add spinner for file/folder creation dialogs.

## Related Issue
- Fixes #419

## Motivation and Context
To make UX more interactive

## How Has This Been Tested?
Tested locally, manually

## Screenshots (if appropriate):
![ezgif com-optimize 1](https://user-images.githubusercontent.com/20378877/53745581-624ae400-3ec7-11e9-9c3a-4d5b7441b033.gif)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
