### PR TITLE
Allow rename only if permissions are given to the user

### DIFF
--- a/apps/files/src/components/FileList.vue
+++ b/apps/files/src/components/FileList.vue
@@ -153,7 +153,7 @@ export default {
         { icon: 'edit',
           handler: this.changeName,
           isEnabled: function (item) {
-            return true
+            return item.canRename()
           } },
         { icon: 'file_download',
           handler: this.downloadFile,

--- a/apps/files/src/store.js
+++ b/apps/files/src/store.js
@@ -55,13 +55,16 @@ function _buildFile (file) {
     permissions: file['fileInfo']['{http://owncloud.org/ns}permissions'],
     sharePermissions: file['fileInfo']['{http://open-collaboration-services.org/ns}share-permissions'],
     canUpload: function () {
-      return this.permissions.indexOf('C') > 0
+      return this.permissions.indexOf('C') >= 0
     },
     canDownload: function () {
       return this.type !== 'folder'
     },
     canBeDeleted: function () {
-      return this.permissions.indexOf('D') > 0
+      return this.permissions.indexOf('D') >= 0
+    },
+    canRename: function () {
+      return this.permissions.indexOf('N') >= 0
     }
   })
 }


### PR DESCRIPTION
## Description
Allow rename only if permissions are granted

## Related Issue
- fixes -#793

## How Has This Been Tested?
- :hand: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...