### PR TITLE
use oc-left-menu for main owncloud menu

### DIFF
--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -1,70 +1,11 @@
 <template>
-  <div></div>
-  <!--<v-navigation-drawer-->
-        <!--v-model="sidebarIsVisible"-->
-        <!--absolute-->
-        <!--temporary-->
-        <!--clipped-->
-        <!--style='top: 50px;z-index: 999;'>-->
-        <!--<v-list class="pt-0" dense>-->
-          <!--<v-list-tile-->
-            <!--v-for="(n, nid) in nav"-->
-            <!--:key="nid"-->
-            <!--@click="navigateTo(n.route)">-->
-              <!--<v-list-tile-action>-->
-                <!--<v-icon>{{ n.iconMaterial }}</v-icon>-->
-              <!--</v-list-tile-action>-->
-              <!--<v-list-tile-content>-->
-                <!--<v-list-tile-title>{{ n.name }}</v-list-tile-title>-->
-              <!--</v-list-tile-content>-->
-          <!--</v-list-tile>-->
-
-          <!--<v-divider></v-divider>-->
-
-          <!--<v-list-group-->
-                      <!--v-for="item in menuData"-->
-                      <!--v-model="item.active"-->
-                      <!--:key="item.title"-->
-                      <!--no-action-->
-                    <!--&gt;-->
-
-                      <!--<v-list-tile slot="activator">-->
-                        <!--<v-list-tile-action>-->
-                          <!--<v-icon>{{ item.icon }}</v-icon>-->
-                        <!--</v-list-tile-action>-->
-                        <!--<v-list-tile-content>-->
-                          <!--<v-list-tile-title>{{ item.title }}</v-list-tile-title>-->
-                        <!--</v-list-tile-content>-->
-                      <!--</v-list-tile>-->
-                      <!--<v-list-tile-->
-                        <!--v-for="subItem in item.subItems"-->
-                        <!--:key="subItem.title"-->
-                        <!--@click="notImplemented()"-->
-                      <!--&gt;-->
-                        <!--<v-list-tile-content>-->
-                          <!--<v-list-tile-title>{{ subItem.title }}</v-list-tile-title>-->
-                        <!--</v-list-tile-content>-->
-
-                        <!--<v-list-tile-action>-->
-                          <!--<v-icon>{{ subItem.action }}</v-icon>-->
-                        <!--</v-list-tile-action>-->
-                      <!--</v-list-tile>-->
-                    <!--</v-list-group>-->
-
-            <!--<v-divider ></v-divider>-->
-
-            <!--<v-list-tile-->
-              <!--@click="logout()">-->
-              <!--<v-list-tile-action>-->
-                <!--<v-icon>exit_to_app</v-icon>-->
-              <!--</v-list-tile-action>-->
-              <!--<v-list-tile-content>-->
-                <!--<v-list-tile-title><translate :translate-params="{name: configuration.theme.general.name}">Exit %{name}</translate></v-list-tile-title>-->
-              <!--</v-list-tile-content>-->
-            <!--</v-list-tile>-->
-
-        <!--</v-list>-->
-      <!--</v-navigation-drawer>-->
+  <oc-left-menu name="coreMenu" v-model="sidebarIsVisible" @close="sidebarIsVisible = false">
+    <template slot="default">
+      <oc-sidebar-nav-item v-for="(n, nid) in nav" :key="nid" :text="n.name" :icon="n.iconMaterial" :target="n.route" />
+      <oc-sidebar-nav-divider />
+      <oc-sidebar-nav-item text="Exit ownCloud" active icon="exit_to_app" target="login" />
+    </template>
+  </oc-left-menu>
 </template>
 
 <script>
@@ -72,8 +13,7 @@ import { mapActions, mapGetters } from 'vuex'
 export default {
   data () {
     return {
-      menuData: {
-      }
+      isOpen: false
     }
   },
   computed: {

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -1,11 +1,11 @@
 <template>
-  <oc-left-menu name="coreMenu" v-model="sidebarIsVisible" @close="sidebarIsVisible = false">
+  <oc-application-menu name="coreMenu" v-model="sidebarIsVisible" @close="sidebarIsVisible = false">
     <template slot="default">
       <oc-sidebar-nav-item v-for="(n, nid) in nav" :key="nid" :text="n.name" :icon="n.iconMaterial" :target="n.route.name" />
       <oc-sidebar-nav-divider />
-      <oc-sidebar-nav-item :text="_logoutItemText" active icon="exit_to_app" target="login" />
+      <oc-sidebar-nav-item :text="_logoutItemText" active icon="exit_to_app" @click="logout()" />
     </template>
-  </oc-left-menu>
+  </oc-application-menu>
 </template>
 
 <script>

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -1,9 +1,9 @@
 <template>
   <oc-left-menu name="coreMenu" v-model="sidebarIsVisible" @close="sidebarIsVisible = false">
     <template slot="default">
-      <oc-sidebar-nav-item v-for="(n, nid) in nav" :key="nid" :text="n.name" :icon="n.iconMaterial" :target="n.route" />
+      <oc-sidebar-nav-item v-for="(n, nid) in nav" :key="nid" :text="n.name" :icon="n.iconMaterial" :target="n.route.name" />
       <oc-sidebar-nav-divider />
-      <oc-sidebar-nav-item text="Exit ownCloud" active icon="exit_to_app" target="login" />
+      <oc-sidebar-nav-item :text="_logoutItemText" active icon="exit_to_app" target="login" />
     </template>
   </oc-left-menu>
 </template>
@@ -32,6 +32,9 @@ export default {
         }
         this.toggleSidebar(newVal)
       }
+    },
+    _logoutItemText () {
+      return this.$gettextInterpolate(this.$gettext('Exit %{product}'), { product: this.configuration.theme.general.name })
     }
   },
   methods: {

--- a/src/components/Top-Bar.vue
+++ b/src/components/Top-Bar.vue
@@ -1,29 +1,12 @@
 <template>
   <oc-topbar variation="primary">
-    <oc-topbar-logo icon="menu" title="Files" slot="left" @click="onClick"></oc-topbar-logo>
-
+    <oc-topbar-logo icon="menu" title="Files" slot="left" @click="toggleSidebar(!isSidebarVisible)"></oc-topbar-logo>
     <oc-topbar-item slot="title">
       <oc-img :src="configuration.theme.logo.big" style="height: 60px" />
     </oc-topbar-item>
-
     <oc-topbar-item slot="right">
       <oc-icon name="account_circle" color="white"></oc-icon>
       <span>{{ user.displayname }}</span>
-      <!--<v-menu offset-y v-if="configuration.state !== 'working'">-->
-        <!--<v-icon slot="activator" color="error" x-large>info</v-icon>-->
-        <!--<v-list-->
-          <!--class="primary white&#45;&#45;text text-xs-center"-->
-          <!--v-for="app in configuration.corrupted"-->
-          <!--:key="app">-->
-          <!--<h4 class="pa-3">Corrupted apps</h4>-->
-          <!--<v-list-tile>-->
-            <!--<v-list-tile-title class="text-xs-center">-->
-              <!--{{ parseApp(app) }}-->
-            <!--</v-list-tile-title>-->
-          <!--</v-list-tile>-->
-        <!--</v-list>-->
-      <!--</v-menu>-->
-
     </oc-topbar-item>
   </oc-topbar>
 </template>
@@ -54,7 +37,7 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(['configuration']),
+    ...mapGetters(['configuration', 'isSidebarVisible']),
     ...mapState(['user']),
     extendNavbarRight () {
       return this.getPlugins('phoenixNavbarRight')


### PR DESCRIPTION
<img width="613" alt="Screenshot 2019-03-27 at 16 31 28" src="https://user-images.githubusercontent.com/660805/55094184-ca977a80-50ad-11e9-9e4b-602eef093582.png">

 - burger bar toggles menu
 - close button works
 - menu items loaded from root navItems provided by apps
 - logout hardcoded 

Relies on https://github.com/owncloud/owncloud-design-system/pull/121

 - [ ] Needs some improvment to the sidear element to allow pushing to routes with params. 
 - [x] Branded owncloud product name
 - [ ] What app icon names are used? `material` in the config key doesnt make much sense.