### PR TITLE
Fixed opening of pdf viewer and wrong components names

### DIFF
--- a/apps/files/src/components/FilesApp.vue
+++ b/apps/files/src/components/FilesApp.vue
@@ -70,6 +70,10 @@ export default {
     },
 
     openFileActionBar (file) {
+      this.openFile({
+        client: this.$client,
+        filePath: file.path
+      })
       let actions = this.extensions(file.extension)
       actions = actions.map(action => {
         return {

--- a/apps/pdf-viewer/src/PdfViewer.vue
+++ b/apps/pdf-viewer/src/PdfViewer.vue
@@ -1,6 +1,6 @@
 <template lang="html">
   <div>
-    <v-progress-linear v-if="loading" indeterminate></v-progress-linear>
+    <oc-progress v-if="loading" :max="100" indeterminate></oc-progress>
     <pdf v-if="!loading" :page="currentPage" @error="error" @num-pages="loadPages" :src="content"></pdf>
   </div>
 </template>
@@ -45,6 +45,7 @@ export default {
   },
   methods: {
     ...mapActions('PDFViewer', ['loadPages']),
+    ...mapActions(['showNotification']),
     closeApp () {
       this.$router.push({
         path: '/files/list/home'

--- a/apps/pdf-viewer/src/PdfViewer.vue
+++ b/apps/pdf-viewer/src/PdfViewer.vue
@@ -15,6 +15,9 @@ export default {
       this.closeApp()
       return
     }
+
+    this.changePage(1)
+
     const url = this.$client.files.getFileUrl(this.activeFile.path)
 
     let headers = new Headers()
@@ -44,7 +47,7 @@ export default {
     }
   },
   methods: {
-    ...mapActions('PDFViewer', ['loadPages']),
+    ...mapActions('PDFViewer', ['loadPages', 'changePage']),
     ...mapActions(['showNotification']),
     closeApp () {
       this.$router.push({

--- a/apps/pdf-viewer/src/PdfViewerTopbar.vue
+++ b/apps/pdf-viewer/src/PdfViewerTopbar.vue
@@ -1,20 +1,18 @@
 <template>
-  <oc-top-bar>
-    <template slot="left">
+  <oc-topbar variation="secondary">
+    <oc-topbar-item slot="left">
       <oc-icon name="application-pdf"></oc-icon>
-    </template>
+    </oc-topbar-item>
     <template slot="title">
-      <span style="line-height: 65px;">{{ activeFile.path.substr(1) }}</span>
+      <oc-topbar-item>{{ activeFile.path.substr(1) }}</oc-topbar-item>
     </template>
-    <template slot="action_pages">
-      <div v-if="!loading">
-        <oc-input v-model="page" type="number" /> /{{ pageCount }}
-      </div>
-    </template>
-    <template slot="action_close">
+    <oc-topbar-item slot="right">
+      <oc-topbar-item v-if="!loading">
+        <oc-text-input v-model.number="page" type="number" :min="1" :max="pageCount" />&nbsp;/{{ pageCount }}
+      </oc-topbar-item>
       <oc-button icon="close" @click="closeApp"></oc-button>
-    </template>
-  </oc-top-bar>
+    </oc-topbar-item>
+  </oc-topbar>
 </template>
 <script>
 // TODO put active Page and max Pages into store

--- a/apps/pdf-viewer/src/app.js
+++ b/apps/pdf-viewer/src/app.js
@@ -21,7 +21,7 @@ const routes = [{
 const appInfo = {
   name: 'PDFViewer',
   id: 'pdf-viewer',
-  icon: 'ocft icon-application-pdf',
+  icon: 'application-pdf',
   isFileEditor: true,
   extensions: [{
     extension: 'pdf'


### PR DESCRIPTION
## Description
Fixed opening of pdf viewer and wrong components names and added reset of current page when switching between different pdf files.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 