### PR TITLE
Bugfix/menu alignment

### DIFF
--- a/apps/files/src/components/FileUpload.vue
+++ b/apps/files/src/components/FileUpload.vue
@@ -1,7 +1,9 @@
 <template>
   <li @click="triggerUpload">
-    <oc-icon name="cloud_upload"></oc-icon>
-    <span v-translate>Upload</span>
+    <div class="uk-flex uk-flex-middle">
+      <oc-icon name="cloud_upload" class="uk-margin-small-right"></oc-icon>
+      <span v-translate>Upload</span>
+    </div>
     <input id="fileUploadInput" type="file" name="file" @change="onChangeInputFile" multiple ref="input" />
   </li>
 </template>

--- a/apps/files/src/components/FilesTopBar.vue
+++ b/apps/files/src/components/FilesTopBar.vue
@@ -27,13 +27,14 @@
         </oc-menu>
 
         <oc-menu v-if="this.canUpload">
-          <oc-button id="new-file-menu-btn" text="+ New" slot="activator" variation="primary"></oc-button>
-          <!-- TODO: replace with oc-list elements-->
-          <ul class="uk-nav uk-dropdown-nav uk-nav-default">
+          <oc-button id="new-file-menu-btn" slot="activator" variation="primary" type="button">
+            <translate>+ New</translate>
+          </oc-button>
+          <template slot="subnav">
             <file-upload :url='url' :headers="headers" @success="onFileSuccess" @error="onFileError" @progress="onFileProgress"></file-upload>
-            <li @click="createFolder = true" id="new-folder-btn"><a href="#"><oc-icon name="create_new_folder"/><translate>Create new folder ...</translate></a></li>
-            <li @click="createFile = true" id="new-file-btn"><a href="#"><oc-icon name="save"/><translate>Create new file ...</translate></a></li>
-          </ul>
+            <oc-menu-item @click="createFolder = true" id="new-folder-btn" icon="create_new_folder"><translate>Create new folder ...</translate></oc-menu-item>
+            <oc-menu-item @click="createFile = true" id="new-file-btn" icon="save"><translate>Create new file ...</translate></oc-menu-item>
+          </template>
         </oc-menu>
         <span v-if="!this.canUpload" v-translate>You have no permission to upload.</span>
       </div>


### PR DESCRIPTION
## Description
Added oc-menu-items into the menu and wrapped upload link with flex for right alignment.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #898 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: manually

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/25989331/55729095-c35d5e80-5a15-11e9-9ed6-7ad95b465735.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Fix alignment of filter menu (Part of issue #901)