### PR TITLE
Fixed links in breadcrumbs

### DIFF
--- a/apps/files/src/components/FilesTopBar.vue
+++ b/apps/files/src/components/FilesTopBar.vue
@@ -271,7 +271,7 @@ export default {
       for (let i = 0; i < pathSplit.length; i++) {
         breadcrumb.index = i
         breadcrumb.text = pathSplit.slice(0, i + 1)[i]
-        breadcrumb.route = '/' + pathSplit.slice(0, i + 1).join('/')
+        breadcrumb.to = '/files/list/' + pathSplit.slice(0, i + 1).join('/')
         if (i === 0 && breadcrumb.text === 'home') {
           continue
         }


### PR DESCRIPTION
## Description
Renamed route in breadcrumps to 'to' because of ods component. Also edit base path because the link ignored files/list.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 