### PR TITLE
allow to specify external selenium host

### DIFF
--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -32,9 +32,9 @@ module.exports = {
         port: SELENIUM_PORT,
         cli_args: ['--port=' + SELENIUM_PORT]
       },
-      screenshots : {
-        enabled : true,
-        path : "tests/reports/screenshots",
+      screenshots: {
+        enabled: true,
+        path: 'tests/reports/screenshots',
         on_failure: true
       },
       desiredCapabilities: {

--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -4,6 +4,9 @@ let LOCAL_BACKEND_URL = process.env.BACKEND_HOST || 'http://localhost:8080'
 const BACKEND_ADMIN_USERNAME = process.env.BACKEND_USERNAME || 'admin'
 const BACKEND_ADMIN_PASSWORD = process.env.BACKEND_PASSWORD || 'admin'
 LOCAL_BACKEND_URL = LOCAL_BACKEND_URL.startsWith('http') ? LOCAL_BACKEND_URL : 'http://' + LOCAL_BACKEND_URL
+const SELENIUM_HOST = process.env.SELENIUM_HOST || ''
+const SELENIUM_PORT = process.env.SELENIUM_PORT || 4445
+const START_PROCESS = (SELENIUM_HOST === '')
 
 module.exports = {
   page_objects_path: './tests/acceptance/pageObjects',
@@ -22,11 +25,12 @@ module.exports = {
         backend_admin_username: BACKEND_ADMIN_USERNAME,
         backend_admin_password: BACKEND_ADMIN_PASSWORD
       },
+      selenium_host: SELENIUM_HOST,
       webdriver: {
-        start_process: true,
+        start_process: START_PROCESS,
         server_path: chromedriver.path,
-        port: 4445,
-        cli_args: ['--port=4445']
+        port: SELENIUM_PORT,
+        cli_args: ['--port=' + SELENIUM_PORT]
       },
       screenshots : {
         enabled : true,


### PR DESCRIPTION
## Description
allow to specify an selenium host when running UI tests locally

## Motivation and Context
useful when running selenium in docker

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...