### PR TITLE
use tr as fileRow instead of the link

### DIFF
--- a/tests/acceptance/pageObjects/filesPage.js
+++ b/tests/acceptance/pageObjects/filesPage.js
@@ -7,7 +7,7 @@ module.exports = {
       this.waitForFileVisible(folder)
       this.useXpath()
         .moveToElement(this.getFileRowSelectorByFileName(folder), 0, 0)
-        .click(this.getFileRowSelectorByFileName(folder))
+        .click(this.getFileLinkSelectorByFileName(folder))
         .useCss()
       return this.waitForElementNotPresent('@filesListProgressBar')
         .waitForElementVisible('@breadcrumb')
@@ -27,6 +27,11 @@ module.exports = {
         element.selector = element.selector.replace(/"/g, "'")
       }
       return util.format(element.selector, fileName)
+    },
+    getFileLinkSelectorByFileName: function (fileName) {
+      return this
+        .getFileRowSelectorByFileName(fileName) +
+          this.elements['fileLinkInFileRow'].selector
     },
     showHiddenFiles: function () {
       return this
@@ -68,7 +73,10 @@ module.exports = {
       selector: '#files-breadcrumb li:nth-of-type(1)'
     },
     fileRowByName: {
-      selector: '//a[contains(@class, "file-row-name")][@filename="%s"]'
+      selector: '//a[contains(@class, "file-row-name")][@filename="%s"]/../..'
+    },
+    fileLinkInFileRow: {
+      selector: '//a[contains(@class, "file-row-name")]'
     },
     filterListButton: {
       selector: '#filter-list-btn'


### PR DESCRIPTION
## Description
find the complete `tr` element as fileRow and not only the link to the file

## Motivation and Context
the link is not the row, we want to find the complete row to be able to get to the buttons of that particular files e.g. the delete button

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...