### PR TITLE
Fixed file size in file upload menu

### DIFF
--- a/apps/files/src/components/FileList.vue
+++ b/apps/files/src/components/FileList.vue
@@ -26,7 +26,7 @@
                    :filename="item.name" :key="item.id" />
         </oc-table-cell>
         <oc-table-cell class="uk-text-meta uk-text-nowrap">
-          {{ item.size | fileSize }}
+          {{ item.size | multiplyFileSize | fileSize }}
         </oc-table-cell>
         <oc-table-cell class="uk-text-meta uk-text-nowrap uk-visible@s">
           {{ formDateFromNow(item.mdate) }}

--- a/apps/files/src/mixins.js
+++ b/apps/files/src/mixins.js
@@ -11,9 +11,10 @@ export default {
       if (isNaN(int)) {
         return '?'
       }
-      return filesize(int * 100, {
-        round: 2
-      })
+      return filesize(int)
+    },
+    multiplyFileSize (int) {
+      return int * 100
     }
   },
   data: () => ({


### PR DESCRIPTION
## Description
Moved multiplying of file size into its own filter to preserve it in file list but get rid of it in file upload menu.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #901 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Apply file-upload-menu component when it's merged in master in ods