### PR TITLE
Add some more information about a file in the side bar header

### DIFF
--- a/apps/files/src/components/FileDetails.vue
+++ b/apps/files/src/components/FileDetails.vue
@@ -1,7 +1,17 @@
 <template>
   <oc-app-side-bar :disableAction="false" @close="close()">
-    <template slot="title">
-      <span class="uk-text-lead uk-margin-bottom">{{ getTabName }}</span>
+    <template slot="title" v-if="items.length === 1">
+      <div class="uk-inline">
+        <oc-icon :name="fileTypeIcon(items[0])" size="large" />
+      </div>
+      <div class="uk-inline">
+        <div>
+          {{ getTabName }} <oc-icon name="link" aria-label="Close"/>
+        </div>
+        <div>
+          <oc-star class="uk-inline" :shining="items[0].starred"/> {{ items[0].size | fileSize }}, {{ formDateFromNow(items[0].mdate) }}
+        </div>
+      </div>
     </template>
     <template slot="content">
       <oc-tabs>

--- a/apps/files/src/components/FileDetails.vue
+++ b/apps/files/src/components/FileDetails.vue
@@ -5,8 +5,8 @@
         <oc-icon :name="fileTypeIcon(items[0])" size="large" />
       </div>
       <div class="uk-inline">
-        <div>
-          {{ getTabName }} <oc-icon name="link" aria-label="Close"/>
+        <div class="uk-flex uk-flex-middle">
+          <span class="uk-margin-small-right">{{ getTabName }}</span> <oc-icon name="link" aria-label="Close"/>
         </div>
         <div>
           <oc-star class="uk-inline" :shining="items[0].starred"/> {{ items[0].size | fileSize }}, {{ formDateFromNow(items[0].mdate) }}


### PR DESCRIPTION
## Description
Just like in OC10 some more information about the current selected file is displayed in the header

## Screenshots (if appropriate):
![Screenshot from 2019-04-10 21-56-31](https://user-images.githubusercontent.com/1005065/55909210-b2f6e080-5bdb-11e9-8396-313f792b71fd.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] no tooltip on private link icon
- [ ] no functionality on private link icon
- [ ] no preview of files displayed / no special display of files
- [ ] not working for multiple files - kill multiple files handling ???