### PR TITLE
Create folder with existing name tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -49,6 +49,7 @@ pipeline:
       - php occ config:list
       - php occ a:e oauth2
       - php occ oauth2:add-client Phoenix Cxfj9F9ZZWQbQZps1E1M0BszMz6OOFq3lxjSuc8Uh4HLEYb9KIfyRMmgY5ibXXrU 930C6aA0U1VhM03IfNiheR2EwSzRi4hRSpcNqIhhbpeSGU6h38xssVfNcGP0sSwQ http://phoenix:8300/#/oidc-callback
+      - php occ config:system:set skeletondirectory --value=/var/www/owncloud/apps/testing/data/webUISkeleton
 
   owncloud-log:
     image: owncloud/ubuntu:16.04

--- a/tests/acceptance/features/webUIFiles/createFolders.feature
+++ b/tests/acceptance/features/webUIFiles/createFolders.feature
@@ -17,10 +17,9 @@ Feature: create folders
     When the user reloads the current page of the webUI
     Then folder "sub-folder" should be listed on the webUI
 
-  @skip
   Scenario: Create a folder with existing name
     When the user creates a folder with the invalid name "simple-folder" using the webUI
-    Then the error message 'The resource you tried to create already exists' should be displayed on the webUI
+    Then the error message 'Creating folder failed ....' should be displayed on the webUI
 
   @skip @yetToImplement
   Scenario: Create a folder in a public share

--- a/tests/acceptance/pageObjects/filesPage.js
+++ b/tests/acceptance/pageObjects/filesPage.js
@@ -13,6 +13,21 @@ module.exports = {
         .waitForElementVisible('@breadcrumb')
         .assert.containsText('@breadcrumb', folder)
     },
+    createFolder: function (name, expectToSucceed = true) {
+      this
+        .waitForElementVisible('@newFileMenuButton', 500000)
+        .click('@newFileMenuButton')
+        .waitForElementVisible('@newFolderButton')
+        .click('@newFolderButton')
+        .waitForElementVisible('@newFolderInput')
+        .setValue('@newFolderInput', name)
+        .click('@newFolderOkButton')
+        .waitForElementNotPresent('@loadingIndicator')
+      if (expectToSucceed) {
+        this.waitForElementNotVisible('@newFolderDialog')
+      }
+      return this
+    },
     waitForFileVisible: function (fileName) {
       var selector = this.getFileRowSelectorByFileName(fileName)
       return this

--- a/tests/acceptance/pageObjects/filesPage.js
+++ b/tests/acceptance/pageObjects/filesPage.js
@@ -60,6 +60,9 @@ module.exports = {
     newFolderButton: {
       selector: '#new-folder-btn'
     },
+    newFolderDialog: {
+      selector: '#new-folder-dialog'
+    },
     newFolderInput: {
       selector: '#new-folder-input'
     },

--- a/tests/acceptance/pageObjects/phoenixPage.js
+++ b/tests/acceptance/pageObjects/phoenixPage.js
@@ -1,0 +1,11 @@
+module.exports = {
+  url: function () {
+    return this.api.launchUrl + '/#/'
+  },
+  elements: {
+    message: {
+      selector: '//*[contains(@class, "uk-notification-message-primary")]/div',
+      locateStrategy: 'xpath'
+    }
+  }
+}

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -22,16 +22,11 @@ Given('the user has browsed to the files page', function () {
 })
 
 When('the user creates a folder with the name {string} using the webUI', function (folderName) {
-  return client.page.filesPage()
-    .waitForElementVisible('@newFileMenuButton', 500000)
-    .click('@newFileMenuButton')
-    .waitForElementVisible('@newFolderButton')
-    .click('@newFolderButton')
-    .waitForElementVisible('@newFolderInput')
-    .setValue('@newFolderInput', folderName)
-    .click('@newFolderOkButton')
-    .waitForElementNotPresent('@loadingIndicator')
-    .waitForElementNotVisible('@newFolderDialog')
+  return client.page.filesPage().createFolder(folderName)
+})
+
+When('the user creates a folder with the invalid name {string} using the webUI', function (folderName) {
+  return client.page.filesPage().createFolder(folderName, false)
 })
 
 When('the user opens folder {string} using the webUI', function (folder) {

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -22,8 +22,7 @@ Given('the user has browsed to the files page', function () {
 })
 
 When('the user creates a folder with the name {string} using the webUI', function (folderName) {
-  const filesPage = client.page.filesPage()
-  filesPage
+  return client.page.filesPage()
     .waitForElementVisible('@newFileMenuButton', 500000)
     .click('@newFileMenuButton')
     .waitForElementVisible('@newFolderButton')
@@ -31,10 +30,8 @@ When('the user creates a folder with the name {string} using the webUI', functio
     .waitForElementVisible('@newFolderInput')
     .setValue('@newFolderInput', folderName)
     .click('@newFolderOkButton')
-
-  client.waitForAjaxCallsToStartAndFinish()
-  return filesPage
     .waitForElementNotPresent('@loadingIndicator')
+    .waitForElementNotVisible('@newFolderDialog')
 })
 
 When('the user opens folder {string} using the webUI', function (folder) {

--- a/tests/acceptance/stepDefinitions/generalContext.js
+++ b/tests/acceptance/stepDefinitions/generalContext.js
@@ -1,0 +1,9 @@
+const { client } = require('nightwatch-api')
+const { Then } = require('cucumber')
+
+Then('the error message {string} should be displayed on the webUI', function (folder) {
+  return client
+    .page.phoenixPage()
+    .waitForElementVisible('@message')
+    .expect.element('@message').text.to.equal(folder)
+})


### PR DESCRIPTION
## Description
1. improve waiting for folder creation should give us 90-100% passing see https://drone.owncloud.com/owncloud/phoenix/2204 https://drone.owncloud.com/owncloud/phoenix/2205
2. move folder creation code to pageObject
3. create a folder with a name that already exists

## Related Issue
part of #844

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...