### PR TITLE
Prevented creation of home folder in root

### DIFF
--- a/apps/files/src/components/FilesTopBar.vue
+++ b/apps/files/src/components/FilesTopBar.vue
@@ -183,7 +183,8 @@ export default {
       })
     },
     addNewFolder (folderName) {
-      if (folderName !== '') {
+      // TODO: Get rid of home in url of root
+      if (folderName !== '' && (folderName !== 'home' || this.item !== 'home')) {
         this.fileFolderCreationLoading = true
         this.$client.files.createFolder(((this.item === 'home') ? '' : this.item) + '/' + folderName)
           .then(() => {
@@ -201,6 +202,11 @@ export default {
           .finally(() => {
             this.fileFolderCreationLoading = false
           })
+      } else {
+        this.showNotification({
+          title: this.$gettext("Can't create folder called home in root directory ...."),
+          type: 'error'
+        })
       }
     },
     addNewFile (fileName) {


### PR DESCRIPTION
## Description
Added condition to prevent the creation of home folder in root directory. I would call this just a temporary solution since it doesn't fix the bug. I want to remove 'home' from URL of root since I don't think it makes too much sense. (At least if the subfolders then kept the home in URL instead of replacing it). But for this, I'll need a little bit more time because I'm having troubles rendering the content of root folder without item home.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #855 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Get rid of 'home' in URL of root