### PR TITLE
descriptions for browse-directly-to-tab feature

### DIFF
--- a/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
+++ b/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
@@ -1,0 +1,43 @@
+@webUI @insulated @enablePreviews
+Feature: browse directly to details tab
+  As a user
+  I want to be able to browse directly to display the details about a file
+  So that I can see the details immediately without needing to click in the UI
+
+  Background:
+    Given user "user1" has been created with default attributes
+    And user "user1" has logged in using the webUI
+
+  @smokeTest
+  @skip @yetToImplement
+  Scenario Outline: Browse directly to the sharing details of a file
+    When the user browses directly to display the "sharing" details of file "lorem.txt" in folder "<folder>"
+    Then the thumbnail should be visible in the details panel
+    And the "sharing" details panel should be visible
+    And the share-with field should be visible in the details panel
+    Examples:
+      | folder        |
+      | /             |
+      | simple-folder |
+
+  @comments-app-required
+  @skip @yetToImplement
+  Scenario Outline: Browse directly to the comments details of a file
+    When the user browses directly to display the "comments" details of file "lorem.txt" in folder "<folder>"
+    Then the thumbnail should be visible in the details panel
+    And the "comments" details panel should be visible
+    Examples:
+      | folder        |
+      | /             |
+      | simple-folder |
+
+  @files_versions-app-required
+  @skip @yetToImplement
+  Scenario Outline: Browse directly to the versions details of a file
+    When the user browses directly to display the "versions" details of file "lorem.txt" in folder "<folder>"
+    Then the thumbnail should be visible in the details panel
+    And the "versions" details panel should be visible
+    Examples:
+      | folder        |
+      | /             |
+      | simple-folder |


### PR DESCRIPTION
## Description
feature files for the browse-directly-to-tab feature
Is that actually something that should be implemented in phoenix?

## Related Issue
part of #844 

## Motivation and Context
features were copied from core and are currently skipped here, as the feature is not implemented in phoenix yet and also the test steps need to be implemented in nightwatch.js

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...