### PR TITLE
do not run all tests locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Pushing a new design and frontend concept to ownCloud
 - optionally provide custom credentials: `export OC_USER=admin && export OC_PASS=admin`
 - build, configure and run phoenix
 - install the Chrome browser
-- run `yarn run acceptance-tests`
+- run `yarn run acceptance-tests <feature-files-to-test>`
 
 ## Update dependencies
 - Run `yarn update-all` to update core and app dependencies

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint-fix": "eslint src apps/*/src tests build --ext vue --ext js --color --fix",
     "accessibility-tests": "node node_modules/axe-cli/axe-cli --exit --disable page-has-heading-one,meta-viewport",
     "accessibility-tests-drone": "node node_modules/axe-cli/axe-cli --exit --disable page-has-heading-one,meta-viewport",
-    "acceptance-tests": "cucumber-js --require-module @babel/register --require-module @babel/polyfill --require tests/acceptance/setup-local.js --require tests/acceptance/stepDefinitions --format node_modules/cucumber-pretty tests/acceptance/features -t 'not @skip'",
+    "acceptance-tests": "cucumber-js --require-module @babel/register --require-module @babel/polyfill --require tests/acceptance/setup-local.js --require tests/acceptance/stepDefinitions --format node_modules/cucumber-pretty -t 'not @skip'",
     "acceptance-tests-drone": "cucumber-js --require-module @babel/register --require-module @babel/polyfill --require tests/acceptance/setup-drone.js --require tests/acceptance/stepDefinitions --format node_modules/cucumber-pretty tests/acceptance/features -t 'not @skip'"
   },
   "author": "Felix Heidecke",


### PR DESCRIPTION
## Description
only run those tests locally that are requested

## Motivation and Context
as the test suite grows it is not practical to run all tests when developing
so we want to be able to specify what tests to run

e.g. a single test `yarn run acceptance-tests tests/acceptance/features/webUIFiles/createFolders.feature:20`
all tests of a file `yarn run acceptance-tests tests/acceptance/features/webUIFiles/createFolders.feature`
all tests of a suite `yarn run acceptance-tests tests/acceptance/features/webUIFiles/`
all available tests `yarn run acceptance-tests tests/acceptance/features`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...