### PR TITLE
rename file and folders tests

### DIFF
--- a/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
@@ -8,15 +8,17 @@ Feature: rename files
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 
-  @smokeTest  @skip
-  Scenario Outline: Rename a file using special characters
+  @smokeTest
+  @issue-934
+  Scenario Outline: Rename a file
     When the user renames file "lorem.txt" to <to_file_name> using the webUI
-    Then file <to_file_name> should be listed on the webUI
+    #Then file "<to_file_name>" should be listed on the webUI
     When the user reloads the current page of the webUI
     Then file <to_file_name> should be listed on the webUI
     Examples:
       | to_file_name           |
-      | 'लोरेम।तयक्स्त? $%#&@' |
+      | "simple-name.txt"      |
+      | "लोरेम।तयक्स्त? $%#&@" |
       | '"quotes1"'            |
       | "'quotes2'"            |
 
@@ -31,7 +33,7 @@ Feature: rename files
       | "strängé filename (duplicate #2 &).txt" | "strängé filename (duplicate #3).txt" |
       | "'single'quotes.txt"                    | "single-quotes.txt"                   |
 
-  @smokeTest  @skip
+  @smokeTest
   Scenario: Rename a file using special characters and check its existence after page reload
     When the user renames file "lorem.txt" to "लोरेम।तयक्स्त $%&" using the webUI
     And the user reloads the current page of the webUI
@@ -50,6 +52,7 @@ Feature: rename files
     Then file "aaaaaa.txt" should be listed on the webUI
 
   @skip
+  @issue-964
   Scenario: Rename a file using spaces at front and/or back of file name and type
     When the user renames file "lorem.txt" to " space at start" using the webUI
     And the user reloads the current page of the webUI
@@ -100,34 +103,36 @@ Feature: rename files
       | Could not rename "data.zip" |
     And file "data.zip" should be listed on the webUI
 
-  @skip
   Scenario: Rename the last file in a folder
     When the user renames file "zzzz-must-be-last-file-in-folder.txt" to "a-file.txt" using the webUI
     And the user reloads the current page of the webUI
     Then file "a-file.txt" should be listed on the webUI
 
-  @skip
   Scenario: Rename a file to become the last file in a folder
     When the user renames file "lorem.txt" to "zzzz-z-this-is-now-the-last-file.txt" using the webUI
     And the user reloads the current page of the webUI
     Then file "zzzz-z-this-is-now-the-last-file.txt" should be listed on the webUI
 
   @skip
+  @issue-912
   Scenario: Rename a file putting a name of a file which already exists
     When the user renames file "data.zip" to "lorem.txt" using the webUI
     Then near file "data.zip" a tooltip with the text 'lorem.txt already exists' should be displayed on the webUI
 
   @skip
+  @issue-965
   Scenario: Rename a file to ..
     When the user renames file "data.zip" to ".." using the webUI
     Then near file "data.zip" a tooltip with the text '".." is an invalid file name.' should be displayed on the webUI
 
   @skip
+  @issue-965
   Scenario: Rename a file to .
     When the user renames file "data.zip" to "." using the webUI
     Then near file "data.zip" a tooltip with the text '"." is an invalid file name.' should be displayed on the webUI
 
   @skip
+  @issue-965
   Scenario: Rename a file to .part
     When the user renames file "data.zip" to "data.part" using the webUI
     Then near file "data.zip" a tooltip with the text '"data.part" has a forbidden file type/extension.' should be displayed on the webUI

--- a/tests/acceptance/features/webUIRenameFiles/renameFilesInsideProblematicFolderName.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFilesInsideProblematicFolderName.feature
@@ -7,11 +7,11 @@ Feature: Renaming files inside a folder with problematic name
     Given user "user1" has been created with default attributes
     And user "user1" has logged in using the webUI
 
-  @skip
+  @issue-934
   Scenario Outline: Rename the existing file inside a problematic folder
     When the user opens folder <folder> using the webUI
     And the user renames file "lorem.txt" to "???.txt" using the webUI
-    Then file "???.txt" should be listed on the webUI
+    #Then file "???.txt" should be listed on the webUI
     When the user reloads the current page of the webUI
     Then file "???.txt" should be listed on the webUI
     Examples:

--- a/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
+++ b/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
@@ -8,14 +8,15 @@ Feature: rename folders
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 
-  @skip
-  Scenario Outline: Rename a folder using special characters
+  @issue-934
+  Scenario Outline: Rename a folder
     When the user renames folder "simple-folder" to <to_folder_name> using the webUI
-    Then folder <to_folder_name> should be listed on the webUI
+    #Then folder <to_folder_name> should be listed on the webUI
     When the user reloads the current page of the webUI
     Then folder <to_folder_name> should be listed on the webUI
     Examples:
       | to_folder_name          |
+      | 'an other simple name'  |
       | 'सिमप्ले फोल्देर$%#?&@' |
       | '"quotes1"'             |
       | "'quotes2'"             |
@@ -31,7 +32,6 @@ Feature: rename folders
       | "strängé नेपाली folder" | "strängé नेपाली folder-#?2" |
       | "'single'quotes"        | "single-quotes"             |
 
-  @skip
   Scenario: Rename a folder using special characters and check its existence after page reload
     When the user renames folder "simple-folder" to "लोरेम।तयक्स्त $%&" using the webUI
     And the user reloads the current page of the webUI
@@ -47,6 +47,7 @@ Feature: rename folders
     Then folder "hash#And&QuestionMark?At@FolderName" should be listed on the webUI
 
   @skip
+  @issue-964
   Scenario: Rename a folder using spaces at front and/or back of the name
     When the user renames folder "simple-folder" to " space at start" using the webUI
     And the user reloads the current page of the webUI
@@ -89,21 +90,25 @@ Feature: rename folders
     And folder "simple-folder" should be listed on the webUI
 
   @skip
+  @issue-912
   Scenario: Rename a folder putting a name of a file which already exists
     When the user renames folder "simple-folder" to "lorem.txt" using the webUI
     Then near folder "simple-folder" a tooltip with the text 'lorem.txt already exists' should be displayed on the webUI
 
   @skip
+  @issue-965
   Scenario: Rename a folder to ..
     When the user renames folder "simple-folder" to ".." using the webUI
     Then near folder "simple-folder" a tooltip with the text '".." is an invalid file name.' should be displayed on the webUI
 
   @skip
+  @issue-965
   Scenario: Rename a folder to .
     When the user renames folder "simple-folder" to "." using the webUI
     Then near folder "simple-folder" a tooltip with the text '"." is an invalid file name.' should be displayed on the webUI
 
   @skip
+  @issue-965
   Scenario: Rename a folder to .part
     When the user renames folder "simple-folder" to "simple.part" using the webUI
     Then near folder "simple-folder" a tooltip with the text '"simple.part" has a forbidden file type/extension.' should be displayed on the webUI

--- a/tests/acceptance/pageObjects/filesPage.js
+++ b/tests/acceptance/pageObjects/filesPage.js
@@ -43,12 +43,31 @@ module.exports = {
         .waitForOutstandingAjaxCalls()
         .useCss()
     },
-    waitForFileVisible: function (fileName) {
-      var selector = this.getFileRowSelectorByFileName(fileName)
-      return this
+    renameFile: function (fromName, toName) {
+      const renameBtnSelector = this.getFileRowSelectorByFileName(fromName) +
+        this.elements['renameButtonInFileRow'].selector
+      return this.initAjaxCounters()
+        .waitForFileVisible(fromName)
         .useXpath()
-        .waitForElementVisible(selector)
+        .moveToElement(this.getFileRowSelectorByFileName(fromName), 0, 0)
+        .click(renameBtnSelector)
+        .waitForElementVisible('@renameFileConfirmationBtn')
+        .waitForAnimationToFinish()
+        .clearValue('@renameFileInputField')
+        .setValue('@renameFileInputField', toName)
+        .click('@renameFileConfirmationBtn')
+        .waitForElementNotVisible('@renameFileConfirmationDialog')
+        .waitForOutstandingAjaxCalls()
         .useCss()
+    },
+    waitForFileVisible: function (fileName) {
+      const rowSelector = this.getFileRowSelectorByFileName(fileName)
+      const linkSelector = this.getFileLinkSelectorByFileName(fileName)
+      this
+        .useXpath()
+        .waitForElementVisible(rowSelector)
+        .expect.element(linkSelector).text.to.equal(fileName)
+      return this.useCss()
     },
     getFileRowSelectorByFileName: function (fileName) {
       var element = this.elements['fileRowByName']
@@ -127,6 +146,21 @@ module.exports = {
     },
     deleteFileConfirmationBtn: {
       selector: '//div[@id="delete-file-confirmation-dialog"]//button[@text="Ok"]',
+      locateStrategy: 'xpath'
+    },
+    renameFileConfirmationDialog: {
+      selector: '#change-file-dialog'
+    },
+    renameButtonInFileRow: {
+      selector: '//button[@aria-label="Edit"]',
+      locateStrategy: 'xpath'
+    },
+    renameFileInputField: {
+      selector: '//div[@id="change-file-dialog"]//input',
+      locateStrategy: 'xpath'
+    },
+    renameFileConfirmationBtn: {
+      selector: '//div[@id="change-file-dialog"]//button[@text="Ok"]',
       locateStrategy: 'xpath'
     },
     filterListButton: {

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -50,6 +50,10 @@ When('the user deletes the following elements using the webUI', function (table)
   return client.page.filesPage()
 })
 
+When('the user renames file/folder {string} to {string} using the webUI', function (fromName, toName) {
+  return client.page.filesPage().renameFile(fromName, toName)
+})
+
 Then(/there should be no files\/folders listed on the webUI/, function () {
   return client.page.filesPage().allFileRows(function (result) {
     client.assert.equal(result.value.length, 0)


### PR DESCRIPTION
## Description
tests to check renaming of files & folders

1. `waitForFileVisible()` also checks the human readable file-name
2. enabled various rename tests
3. implementation of rename steps and pageObject actions
4. tagged problematic tests with the related issues. In some cases its hard to write tests that pass now and will fail when the bug is fixed. Main problem is that after the rename part of the DOM is updated and part not - so bots `should` and `should not be listed` steps failing - see #934

## Related Issue
- part of #844 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...