### PR TITLE
No need to createObjectURL if the request failed

### DIFF
--- a/src/components/Avatar.vue
+++ b/src/components/Avatar.vue
@@ -38,16 +38,19 @@ export default {
       headers.append('Authorization', 'Bearer ' + this.getToken)
       fetch(url, { headers })
         .then(response => {
-          if (response.status === 404) {
-            this.avatarSource = ''
-            this.loading = false
-          } else {
+          if (response.ok) {
             return response.blob()
           }
+          throw new Error('Network response was not ok.')
         })
-        .then(blobby => {
+        .then(blob => {
           this.loading = false
-          this.avatarSource = window.URL.createObjectURL(blobby)
+          this.avatarSource = window.URL.createObjectURL(blob)
+        })
+        .catch(error => {
+          this.avatarSource = ''
+          this.loading = false
+          console.log('There has been a problem with your fetch operation: ', error.message)
         })
     }
   },


### PR DESCRIPTION
Fixes this issue:
![Screenshot from 2019-04-15 16-26-13](https://user-images.githubusercontent.com/1005065/56140471-498c1e80-5f9b-11e9-8066-c2708b102fe1.png)
