### PR TITLE
Fixed display of special characters in delete dialog

### DIFF
--- a/apps/files/src/components/FileList.vue
+++ b/apps/files/src/components/FileList.vue
@@ -96,8 +96,7 @@ export default {
     },
     deleteFile (file) {
       this.fileToBeDeleted = file
-      let translated = this.$gettext('Please confirm the deletion of %{file}')
-      this.deleteConfirmation = this.$gettextInterpolate(translated, { file: file.name })
+      this.deleteConfirmation = this.$gettext(`Please confirm the deletion of ${file.name}`)
     },
     /* shareFile (file) {
       this.deleteConfirmation = this.$gettextInterpolate(translated, { file: file.name })


### PR DESCRIPTION
## Description
Exchanged single quotes with backticks and squashed deleteConfirmation dialogue and translated variable.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #911

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: manually

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/25989331/56604070-6e1e7100-6601-11e9-9fb8-24a5ea9986cb.png)
![image](https://user-images.githubusercontent.com/25989331/56604083-7676ac00-6601-11e9-8ed9-03c563f15665.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 