### PR TITLE
Clean search after navigating into a folder

### DIFF
--- a/apps/files/src/components/FilesApp.vue
+++ b/apps/files/src/components/FilesApp.vue
@@ -46,7 +46,7 @@ export default {
     this.getFolder()
   },
   methods: {
-    ...mapActions('Files', ['resetFileSelection', 'addFileSelection', 'removeFileSelection', 'loadFiles', 'markFavorite', 'addFiles', 'updateFileProgress']),
+    ...mapActions('Files', ['resetFileSelection', 'addFileSelection', 'removeFileSelection', 'loadFiles', 'markFavorite', 'addFiles', 'updateFileProgress', 'resetSearch']),
     ...mapActions(['openFile', 'showNotification']),
 
     trace () {
@@ -154,6 +154,9 @@ export default {
         this.loadFiles({ currentFolder, files })
         this.self = files.self
         this.resetFileSelection()
+        if (this.searchTerm !== '') {
+          this.resetSearch()
+        }
       }).catch(error => {
         this.showNotification({
           title: this.$gettext('Loading folder failed…'),
@@ -193,7 +196,7 @@ export default {
 
   computed: {
     ...mapState(['route']),
-    ...mapGetters('Files', ['selectedFiles', 'inProgress', 'activeFiles', 'fileFilter', 'davProperties']),
+    ...mapGetters('Files', ['selectedFiles', 'inProgress', 'activeFiles', 'fileFilter', 'davProperties', 'searchTerm']),
     ...mapGetters(['getToken', 'extensions']),
     activeRoute () {
       return this.getRoutes()

--- a/apps/files/src/components/FilesTopBar.vue
+++ b/apps/files/src/components/FilesTopBar.vue
@@ -7,7 +7,7 @@
     </template>
     <template slot="title">
       <div class="uk-navbar-item">
-        <oc-search-bar @search="onFileSearch" :label="searchLabel" :loading="isLoadingSearch" :button="false"/>
+        <oc-search-bar @search="onFileSearch" :value="searchTerm" :label="searchLabel" :loading="isLoadingSearch" :button="false"/>
       </div>
     </template>
     <template slot="right">

--- a/apps/files/src/mixins.js
+++ b/apps/files/src/mixins.js
@@ -1,7 +1,7 @@
 import filesize from 'filesize'
 import moment from 'moment'
 import fileTypeIconMappings from './fileTypeIconMappings.json'
-import { mapActions } from 'vuex'
+import { mapActions, mapGetters } from 'vuex'
 
 export default {
   filters: {
@@ -20,13 +20,20 @@ export default {
   data: () => ({
     selectedFile: ''
   }),
+  computed: {
+    ...mapGetters('Files', ['searchTerm'])
+  },
   methods: {
+    ...mapActions('Files', ['resetSearch']),
     ...mapActions(['showNotification']),
 
     formDateFromNow (date) {
       return moment(date).locale(this.$language.current).fromNow()
     },
     navigateTo (route, param) {
+      if (this.searchTerm !== '' && this.$route.params.item === param) {
+        this.resetSearch()
+      }
       this.$router.push({
         'name': route,
         'params': {

--- a/apps/files/src/store/actions.js
+++ b/apps/files/src/store/actions.js
@@ -147,5 +147,8 @@ export default {
         reject(error)
       })
     })
+  },
+  resetSearch (context) {
+    context.commit('SET_SEARCH_TERM', '')
   }
 }


### PR DESCRIPTION
## Description
Added clearing of the search after navigating into a folder and after trying to navigate into the active folder.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #979

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Prevent displaying the content of the previous folder before loading the new content
- [ ] Remove close icon from search bar after navigating into a folder (needs to be edited in ods)
- [x] Clean search term when trying to navigate into the same folder