### PR TITLE
make clean all apps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 SERVER_HOST=0.0.0.0:8300
 
-apps=files
+apps=files markdown-editor pdf-viewer
 all_apps=$(addprefix app-,$(apps))
 core_bundle=dist/core/core.bundle.js
 

--- a/apps/markdown-editor/Makefile
+++ b/apps/markdown-editor/Makefile
@@ -1,5 +1,5 @@
-apps=apps/files
-bundles=dist/files.bundle.js
+apps=apps/markdown-editor
+bundles=dist/markdown-editor.bundle.js
 
 all: build
 
@@ -9,7 +9,7 @@ build: $(bundles)
 node_modules: package.json yarn.lock
 	yarn install && touch node_modules
 
-$(bundles): webpack.common.js webpack.dev.js node_modules
+$(bundles): webpack.config.js node_modules
 	yarn run build
 
 .PHONY: clean

--- a/apps/pdf-viewer/Makefile
+++ b/apps/pdf-viewer/Makefile
@@ -1,5 +1,5 @@
-apps=apps/files
-bundles=dist/files.bundle.js
+apps=apps/pdf-viewer
+bundles=dist/pdf-viewer.bundle.js
 
 all: build
 


### PR DESCRIPTION
I wanted to build a docker container ... but it kept pulling in hundreds of mb, even after I did a `make clean`. This PR adds missing Makefiles for all apps and as a result correctly deletes the `node_modules` and `dist` folders.