### PR TITLE
add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+node_modules
+apps/*/node_modules


### PR DESCRIPTION
I may want to build a docker container while having built phoenix locally. Adding this .dockerignore file prevents docker from copying all the node_modules folders. 