### PR TITLE
Don't watch test files for full page reload

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -19,6 +19,9 @@ module.exports = merge(common, {
     https: false,
     compress: true,
     host: '0.0.0.0',
-    port: 8300
+    port: 8300,
+    watchOptions: {
+      ignored: path.resolve(__dirname, 'tests'),
+    }
   }
 })


### PR DESCRIPTION
## Description
Ignore tests folder on webpack-dev-server watch so that the full page reload doesn't occur for test file changes.

## Motivation and Context
Don't reload web app on test file changes.

## How Has This Been Tested?
:hand: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
