### PR TITLE
Add missing matrix for run build-docker-image only after job

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,7 +14,8 @@ pipeline:
       - docker build -t owncloud/phoenix:${DRONE_COMMIT_SHA}-${DRONE_BUILD_NUMBER} .
     when:
       event: [ push ]
-      AFTER_JOB: true
+      matrix:
+        AFTER_JOB: true
 
   npm-install:
     image: owncloudci/php:${PHP_VERSION=7.1}


### PR DESCRIPTION
## Description
Only run build-docker-image on pull request merge

## Related Issue

## Motivation and Context
Make drone faster

## How Has This Been Tested?
🤖

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 