### PR TITLE
Use OAuth/OpenIDConnect redirect uri without fragment

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -77,7 +77,7 @@ pipeline:
       - php occ log:manage --level 0
       - php occ config:list
       - php occ a:e oauth2
-      - php occ oauth2:add-client Phoenix Cxfj9F9ZZWQbQZps1E1M0BszMz6OOFq3lxjSuc8Uh4HLEYb9KIfyRMmgY5ibXXrU 930C6aA0U1VhM03IfNiheR2EwSzRi4hRSpcNqIhhbpeSGU6h38xssVfNcGP0sSwQ http://phoenix:8300/#/oidc-callback
+      - php occ oauth2:add-client Phoenix Cxfj9F9ZZWQbQZps1E1M0BszMz6OOFq3lxjSuc8Uh4HLEYb9KIfyRMmgY5ibXXrU 930C6aA0U1VhM03IfNiheR2EwSzRi4hRSpcNqIhhbpeSGU6h38xssVfNcGP0sSwQ http://phoenix:8300/oidc-callback.html
       - php occ config:system:set skeletondirectory --value=/var/www/owncloud/apps/testing/data/webUISkeleton
     when:
       matrix:
@@ -110,6 +110,7 @@ pipeline:
       - TEST_CONTEXT=${TEST_CONTEXT}
     commands:
       - cd /var/www/owncloud/phoenix
+      - curl http://phoenix:8300/oidc-callback.html
       - yarn run acceptance-tests-drone
     when:
       matrix:

--- a/oidc-callback.html
+++ b/oidc-callback.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="en">
+<script>
+    window.onload = function() {
+        window.location.href = "/#/oidc-callback" + window.location.search;
+    }
+</script>
+</html>

--- a/oidc-silent-redirect.html
+++ b/oidc-silent-redirect.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="en">
+<script>
+    window.onload = function() {
+        window.location.href = "/#/oidc-silent-redirect" + window.location.search;
+    }
+</script>
+</html>

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -11,16 +11,15 @@ export function initVueAuthenticate (config) {
       mgr = new UserManager({
         userStore: store,
         authority: config.url,
-        // with OAuth2 we need to se the metadata manually
         metadataUrl: config.metaDataUrl,
         client_id: config.clientId,
-        redirect_uri: baseUrl + '#/oidc-callback',
+        redirect_uri: baseUrl + 'oidc-callback.html',
         response_type: 'code', // code triggers auth code grant flow
         response_mode: 'query',
         scope: 'openid profile offline_access',
         monitorSession: false,
         post_logout_redirect_uri: baseUrl,
-        silent_redirect_uri: baseUrl + '#/oidc-silent-redirect',
+        silent_redirect_uri: baseUrl + 'oidc-silent-redirect.html',
         accessTokenExpiringNotificationTime: 10,
         automaticSilentRenew: false,
         filterProtocolClaims: true,
@@ -38,7 +37,7 @@ export function initVueAuthenticate (config) {
           userinfo_endpoint: ''
         },
         client_id: config.clientId,
-        redirect_uri: baseUrl + '#/oidc-callback',
+        redirect_uri: baseUrl + 'oidc-callback.html',
         response_type: 'token', // token is implicit flow - to be killed
         // response_type: 'code', // for authentication code flow use 'code
         response_mode: 'query',

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -16,6 +16,12 @@ module.exports = merge(common, {
     }, {
       from: 'manifest.json',
       to: 'manifest.json'
+    }, {
+      from: 'oidc-callback.html',
+      to: 'oidc-callback.html'
+    }, {
+      from: 'oidc-silent-redirect.html',
+      to: 'oidc-silent-redirect.html'
     }])
   ],
   mode: 'production',


### PR DESCRIPTION
## Description
OAuth/OpenIDConnect redirect uris are not allowed to contain fragments.

## Related Issue
- Fixes #573 

## How Has This Been Tested?
- :hand: 
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...