### PR TITLE
Fix usage of interpolated strings in gettext

### DIFF
--- a/apps/files/src/components/FileList.vue
+++ b/apps/files/src/components/FileList.vue
@@ -96,7 +96,8 @@ export default {
     },
     deleteFile (file) {
       this.fileToBeDeleted = file
-      this.deleteConfirmation = this.$gettext(`Please confirm the deletion of ${file.name}`)
+      let translated = this.$gettext('Please confirm the deletion of %{ fileName }')
+      this.deleteConfirmation = this.$gettextInterpolate(translated, { fileName: file.name }, true)
     },
     /* shareFile (file) {
       this.deleteConfirmation = this.$gettextInterpolate(translated, { file: file.name })

--- a/apps/files/src/mixins.js
+++ b/apps/files/src/mixins.js
@@ -58,8 +58,10 @@ export default {
         this.newName = item.name
       } else {
         if (item.includes('/')) {
+          let translated = this.$gettext('Renaming of %{ fileName} failed. The file name cannot contain a "/"')
+
           this.showNotification({
-            title: this.$gettext(`Renaming of ${this.selectedFile.name} failed. The file name cannot contain a "/"`),
+            title: this.$gettextInterpolate(translated, { fileName: this.selectedFile.name }, true),
             status: 'danger'
           })
           return
@@ -125,7 +127,7 @@ export default {
           this.$_ocUpload(file)
         } else {
           this.showNotification({
-            title: this.$gettextInterpolate('Upload for %{file} failed - File already exists', { file: file.name }),
+            title: this.$gettextInterpolate('Upload for %{file} failed - File already exists', { file: file.name }, true),
             status: 'danger'
           })
         }


### PR DESCRIPTION
## Description
Translating interpolated strings has to be done this way: https://github.com/Polyconseil/vue-gettext#interpolation-support-1

## How Has This Been Tested?
- :hand: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...