### PR TITLE
Bugfix/collapse screenshots on GitHub

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -133,10 +133,13 @@ pipeline:
   build-github-comment:
     image: owncloud/ubuntu:16.04
     pull: true
+    environment:
+      - TEST_CONTEXT=${TEST_CONTEXT}
     commands:
       - cd /var/www/owncloud/phoenix/tests/reports/screenshots/
-      - echo "Find screenshots at https://minio.owncloud.com/phoenix/screenshots/${DRONE_BUILD_NUMBER}/" >> comments.file
+      - 'echo "<details><summary>:boom: Acceptance tests <strong>${TEST_CONTEXT}</strong> failed. Please find the screenshots inside ...</summary><p>\n\n" >> comments.file'
       - for f in *.png; do echo '!'"[$f](https://minio.owncloud.com/phoenix/screenshots/${DRONE_BUILD_NUMBER}/$f)" >> comments.file; done
+      - echo "\n</p></details>" >> comments.file
       - more comments.file
     when:
       status: [ failure ]


### PR DESCRIPTION
## Description
Hide the screenshots taken from failing acceptance tests by default.
This way we are not polluting the PR that much,
In addition the failing acceptance test is now part of the comment as well

## How Has This Been Tested?
- :robot: 

## Screenshots (if appropriate):
![Screenshot from 2019-05-08 16-34-59](https://user-images.githubusercontent.com/1005065/57383685-8076de00-71af-11e9-8338-d718ded40a2c.png)
![Screenshot from 2019-05-08 16-35-16](https://user-images.githubusercontent.com/1005065/57383692-853b9200-71af-11e9-8f05-903d4150aad2.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...