### PR TITLE
gradually hide fileList elements as width shrinks

### DIFF
--- a/apps/files/src/components/FileList.vue
+++ b/apps/files/src/components/FileList.vue
@@ -7,9 +7,9 @@
         </oc-table-cell>
         <oc-table-cell shrink />
         <oc-table-cell type="head" class="uk-text-truncate" v-translate>Name</oc-table-cell>
-        <oc-table-cell shrink type="head" class="uk-visible@s"><translate>Size</translate></oc-table-cell>
-        <oc-table-cell shrink type="head" class="uk-text-nowrap uk-visible@s" v-translate>Modification Time</oc-table-cell>
-        <oc-table-cell shrink type="head" v-translate>Actions</oc-table-cell>
+        <oc-table-cell shrink type="head" :class="{ 'uk-visible@s' : !_sidebarOpen, 'uk-visible@m'  : _sidebarOpen }"><translate>Size</translate></oc-table-cell>
+        <oc-table-cell shrink type="head" :class="{ 'uk-visible@s' : !_sidebarOpen, 'uk-visible@m'  : _sidebarOpen }" class="uk-text-nowrap" v-translate>Modification Time</oc-table-cell>
+        <oc-table-cell shrink type="head" :class="{ 'uk-visible@s' : _sidebarOpen }" v-translate>Actions</oc-table-cell>
       </oc-table-row>
     </oc-table-group>
     <oc-table-group>
@@ -25,17 +25,17 @@
                    :name="item.basename" :extension="item.extension" class="file-row-name" :icon="fileTypeIcon(item)"
                    :filename="item.name" :key="item.id" />
         </oc-table-cell>
-        <oc-table-cell class="uk-text-meta uk-text-nowrap uk-visible@s">
+        <oc-table-cell class="uk-text-meta uk-text-nowrap" :class="{ 'uk-visible@s' : !_sidebarOpen, 'uk-visible@m'  : _sidebarOpen }">
           {{ item.size | fileSize }}
         </oc-table-cell>
-        <oc-table-cell class="uk-text-meta uk-text-nowrap uk-visible@s">
+        <oc-table-cell class="uk-text-meta uk-text-nowrap" :class="{ 'uk-visible@s' : !_sidebarOpen, 'uk-visible@m'  : _sidebarOpen }">
           {{ formDateFromNow(item.mdate) }}
         </oc-table-cell>
-        <oc-table-cell>
-          <div class="uk-button-group uk-margin-small-right uk-visible@m">
+        <oc-table-cell :class="{ 'uk-visible@s' : _sidebarOpen }">
+          <div class="uk-button-group uk-margin-small-right" :class="{ 'uk-visible@m' : !_sidebarOpen, 'uk-visible@xl' : _sidebarOpen  }">
             <oc-button v-for="(action, index) in actions" :key="index" @click.native="action.handler(item, action.handlerData)" :disabled="!action.isEnabled(item)" :icon="action.icon" :ariaLabel="action.ariaLabel" />
           </div>
-          <oc-button class="uk-hidden@m" icon="menu"></oc-button>
+          <oc-button icon="menu" :class="{ 'uk-hidden@m' : !_sidebarOpen, 'uk-visible@s uk-hidden@xl' : _sidebarOpen }"></oc-button>
         </oc-table-cell>
       </oc-table-row>
     </oc-table-group>
@@ -158,8 +158,8 @@ export default {
     _deleteDialogTitle () {
       return this.$gettext('Delete File/Folder')
     },
-    _compactView () {
-      return this.selectedFiles.length > 0 && window.outerWidth <= 768
+    _sidebarOpen () {
+      return this.selectedFiles.length > 0
     }
   }
 }

--- a/apps/files/src/components/FileList.vue
+++ b/apps/files/src/components/FileList.vue
@@ -7,7 +7,7 @@
         </oc-table-cell>
         <oc-table-cell shrink />
         <oc-table-cell type="head" class="uk-text-truncate" v-translate>Name</oc-table-cell>
-        <oc-table-cell shrink type="head"><translate>Size</translate></oc-table-cell>
+        <oc-table-cell shrink type="head" class="uk-visible@s"><translate>Size</translate></oc-table-cell>
         <oc-table-cell shrink type="head" class="uk-text-nowrap uk-visible@s" v-translate>Modification Time</oc-table-cell>
         <oc-table-cell shrink type="head" v-translate>Actions</oc-table-cell>
       </oc-table-row>
@@ -20,21 +20,22 @@
         <oc-table-cell class="uk-padding-remove">
           <oc-star class="uk-display-block" @click.native="toggleFileFavorite(item)" :shining="item.starred" />
         </oc-table-cell>
-        <oc-table-cell>
+        <oc-table-cell class="uk-text-truncate">
           <oc-file @click.native="item.extension === '' ? navigateTo('files-list', item.path.substr(1)) : openFileActionBar(item)"
                    :name="item.basename" :extension="item.extension" class="file-row-name" :icon="fileTypeIcon(item)"
                    :filename="item.name" :key="item.id" />
         </oc-table-cell>
-        <oc-table-cell class="uk-text-meta uk-text-nowrap">
+        <oc-table-cell class="uk-text-meta uk-text-nowrap uk-visible@s">
           {{ item.size | fileSize }}
         </oc-table-cell>
         <oc-table-cell class="uk-text-meta uk-text-nowrap uk-visible@s">
           {{ formDateFromNow(item.mdate) }}
         </oc-table-cell>
         <oc-table-cell>
-          <div class="uk-button-group uk-margin-small-right">
+          <div class="uk-button-group uk-margin-small-right uk-visible@m">
             <oc-button v-for="(action, index) in actions" :key="index" @click.native="action.handler(item, action.handlerData)" :disabled="!action.isEnabled(item)" :icon="action.icon" :ariaLabel="action.ariaLabel" />
           </div>
+          <oc-button class="uk-hidden@m" icon="menu"></oc-button>
         </oc-table-cell>
       </oc-table-row>
     </oc-table-group>
@@ -156,6 +157,9 @@ export default {
     },
     _deleteDialogTitle () {
       return this.$gettext('Delete File/Folder')
+    },
+    _compactView () {
+      return this.selectedFiles.length > 0 && window.outerWidth <= 768
     }
   }
 }

--- a/apps/files/src/components/FilesApp.vue
+++ b/apps/files/src/components/FilesApp.vue
@@ -2,11 +2,11 @@
     <div class="oc-app" id="files-app" @dragover="$_ocApp_dragOver">
       <oc-grid>
         <div class="uk-width-expand" :class="{ 'uk-visible@s' : _sidebarOpen }">
-          <oc-loader id="files-list-progress" v-if="loading"></oc-loader>
+          <oc-loader id="files-list-progress" v-if="loadingFolder"></oc-loader>
           <file-list @toggle="toggleFileSelect" @FileAction="openFileActionBar" :fileData="activeFiles" @sideBarOpen="openSideBar"/>
         </div>
         <div class="uk-width-1-1 uk-width-medium@s uk-width-large@l" v-show="_sidebarOpen">
-          <file-details :items="selectedFiles" :starsEnabled="false" :checkboxEnabled="false" ref="fileDetails" @reload="getFolder" @reset="resetFileSelection"/>
+          <file-details :items="selectedFiles" :starsEnabled="false" :checkboxEnabled="false" ref="fileDetails" @reload="$_ocFilesFolder_getFolder" @reset="resetFileSelection"/>
         </div>
       </oc-grid>
       <oc-file-actions></oc-file-actions>

--- a/apps/files/src/components/FilesApp.vue
+++ b/apps/files/src/components/FilesApp.vue
@@ -1,14 +1,14 @@
   <template>
     <div class="oc-app" id="files-app" @dragover="$_ocApp_dragOver">
-      <oc-app-layout :rightHidden="selectedFiles.length === 0">
-        <template slot="center">
+      <oc-grid>
+        <div class="uk-width-expand">
           <oc-loader id="files-list-progress" v-if="loadingFolder"></oc-loader>
           <file-list @toggle="toggleFileSelect" @FileAction="openFileActionBar" :fileData="activeFiles" @sideBarOpen="openSideBar"/>
-        </template>
-        <template slot="right">
+        </div>
+        <div class="uk-width-medium uk-width-large@l" v-show="selectedFiles.length !== 0">
           <file-details :items="selectedFiles" :starsEnabled="false" :checkboxEnabled="false" ref="fileDetails" @reload="$_ocFilesFolder_getFolder" @reset="resetFileSelection"/>
-        </template>
-      </oc-app-layout>
+        </div>
+      </oc-grid>
       <oc-file-actions></oc-file-actions>
   </div>
 </template>

--- a/apps/files/src/components/FilesApp.vue
+++ b/apps/files/src/components/FilesApp.vue
@@ -1,12 +1,12 @@
   <template>
     <div class="oc-app" id="files-app" @dragover="$_ocApp_dragOver">
       <oc-grid>
-        <div class="uk-width-expand">
-          <oc-loader id="files-list-progress" v-if="loadingFolder"></oc-loader>
+        <div class="uk-width-expand" :class="{ 'uk-visible@s' : _sidebarOpen }">
+          <oc-loader id="files-list-progress" v-if="loading"></oc-loader>
           <file-list @toggle="toggleFileSelect" @FileAction="openFileActionBar" :fileData="activeFiles" @sideBarOpen="openSideBar"/>
         </div>
-        <div class="uk-width-medium uk-width-large@l" v-show="selectedFiles.length !== 0">
-          <file-details :items="selectedFiles" :starsEnabled="false" :checkboxEnabled="false" ref="fileDetails" @reload="$_ocFilesFolder_getFolder" @reset="resetFileSelection"/>
+        <div class="uk-width-1-1 uk-width-medium@s uk-width-large@l" v-show="_sidebarOpen">
+          <file-details :items="selectedFiles" :starsEnabled="false" :checkboxEnabled="false" ref="fileDetails" @reload="getFolder" @reset="resetFileSelection"/>
         </div>
       </oc-grid>
       <oc-file-actions></oc-file-actions>
@@ -162,6 +162,10 @@ export default {
 
     iAmActive () {
       return this.$route.name === 'files-list'
+    },
+
+    _sidebarOpen () {
+      return this.selectedFiles.length > 0
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -83,13 +83,5 @@
     "webpack-copy-plugin": "^0.0.4",
     "webpack-dev-server": "^3.3.1",
     "webpack-merge": "^4.2.1"
-  },
-  "dependencies": {
-    "babel-eslint": "^10.0.1",
-    "eslint-loader": "^2.1.2",
-    "oidc-client": "^1.7.1",
-    "owncloud-sdk": "1.0.0-92",
-    "url-search-params-polyfill": "^6.0.0",
-    "owncloud-design-system": "^1.0.0-605"
   }
 }

--- a/package.json
+++ b/package.json
@@ -83,5 +83,13 @@
     "webpack-copy-plugin": "^0.0.4",
     "webpack-dev-server": "^3.3.1",
     "webpack-merge": "^4.2.1"
+  },
+  "dependencies": {
+    "babel-eslint": "^10.0.1",
+    "eslint-loader": "^2.1.2",
+    "oidc-client": "^1.7.1",
+    "owncloud-sdk": "1.0.0-92",
+    "url-search-params-polyfill": "^6.0.0",
+    "owncloud-design-system": "^1.0.0-605"
   }
 }


### PR DESCRIPTION
The effort to make the filesApp responsive.

TODO:

- [x] correct behavior when the sidebar is closed
- [x] correct behavior when the sidebar is open
- [ ] use the correct icon (dots) for the collapsed actions-button

### Tablet

![files_app_tablet_landscape](https://user-images.githubusercontent.com/12717530/57379857-00994580-71a8-11e9-8d2f-7fbde71b599a.png)

![FireShot Capture 011 - ownCloud Phoenix - localhost](https://user-images.githubusercontent.com/12717530/57530930-9cf25200-7338-11e9-9680-ea69258314bb.png)


### Tablet (portrait)

![files_app_tablet_portrait](https://user-images.githubusercontent.com/12717530/57379839-f70fdd80-71a7-11e9-96e1-ee635fedca49.png)

![FireShot Capture 012 - ownCloud Phoenix - localhost](https://user-images.githubusercontent.com/12717530/57530950-a8de1400-7338-11e9-97f0-cbd38d2aa584.png)


### Mobile

![files_app_mobile](https://user-images.githubusercontent.com/12717530/57379811-eb241b80-71a7-11e9-9ef0-4b6c943d40b8.png)

![FireShot Capture 014 - ownCloud Phoenix - localhost](https://user-images.githubusercontent.com/12717530/57530962-b0052200-7338-11e9-82cd-7687b55520c8.png)

**Landscape**

![FireShot Capture 013 - ownCloud Phoenix - localhost](https://user-images.githubusercontent.com/12717530/57530973-b98e8a00-7338-11e9-9cd0-717aab5ec38e.png)
