### PR TITLE
Added scroll to apps and removed stickiness

### DIFF
--- a/apps/files/src/components/FileDetails.vue
+++ b/apps/files/src/components/FileDetails.vue
@@ -1,5 +1,5 @@
 <template>
-  <oc-app-side-bar :disableAction="false" uk-sticky="offset: 120" @close="close()">
+  <oc-app-side-bar :disableAction="false" @close="close()">
     <template slot="title" v-if="items.length === 1">
       <div class="uk-inline">
         <oc-icon :name="fileTypeIcon(items[0])" size="large" />

--- a/apps/files/src/components/FileList.vue
+++ b/apps/files/src/components/FileList.vue
@@ -162,5 +162,4 @@ export default {
     }
   }
 }
-
 </script>

--- a/apps/files/src/components/FilesApp.vue
+++ b/apps/files/src/components/FilesApp.vue
@@ -1,16 +1,14 @@
   <template>
-    <div class="oc-app" id="files-app" @dragover="$_ocApp_dragOver">
-      <oc-grid>
-        <div class="uk-width-expand" :class="{ 'uk-visible@s' : _sidebarOpen }">
-          <oc-loader id="files-list-progress" v-if="loadingFolder"></oc-loader>
-          <file-list @toggle="toggleFileSelect" @FileAction="openFileActionBar" :fileData="activeFiles" @sideBarOpen="openSideBar"/>
-        </div>
-        <div class="uk-width-1-1 uk-width-medium@s uk-width-large@l" v-show="_sidebarOpen">
-          <file-details :items="selectedFiles" :starsEnabled="false" :checkboxEnabled="false" ref="fileDetails" @reload="$_ocFilesFolder_getFolder" @reset="resetFileSelection"/>
-        </div>
-      </oc-grid>
-      <oc-file-actions></oc-file-actions>
-  </div>
+    <oc-grid class="oc-app uk-height-1-1" id="files-app" @dragover="$_ocApp_dragOver">
+      <div class="uk-width-expand uk-height-1-1 uk-overflow-auto" :class="{ 'uk-visible@s' : _sidebarOpen }">
+        <oc-loader id="files-list-progress" v-if="loadingFolder"></oc-loader>
+        <file-list @toggle="toggleFileSelect" @FileAction="openFileActionBar" :fileData="activeFiles" @sideBarOpen="openSideBar"/>
+      </div>
+      <div class="uk-width-1-1 uk-width-medium@s uk-width-large@l" v-show="_sidebarOpen">
+        <file-details :items="selectedFiles" :starsEnabled="false" :checkboxEnabled="false" ref="fileDetails" @reload="$_ocFilesFolder_getFolder" @reset="resetFileSelection"/>
+      </div>
+    <oc-file-actions></oc-file-actions>
+  </oc-grid>
 </template>
 <script>
 import Mixins from '../mixins'

--- a/apps/files/src/components/FilesTopBar.vue
+++ b/apps/files/src/components/FilesTopBar.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
   <file-drop :url='url' :headers="headers" @success="onFileSuccess" @error="onFileError" @progress="onFileProgress" />
-  <oc-topbar variation="secondary" uk-sticky="offset: 60">
+  <oc-topbar variation="secondary">
     <template slot="left">
       <oc-topbar-logo icon="home" @click="navigateTo('files-list', '')"></oc-topbar-logo>
       <oc-breadcrumb id="files-breadcrumb" :items="activeRoute" v-if="!atSearchPage"></oc-breadcrumb>

--- a/src/Phoenix.vue
+++ b/src/Phoenix.vue
@@ -1,17 +1,22 @@
 <template>
-  <div id="Phoenix" :class="{ loginGradient: showGradientBackground}"
-       :style="showImageBackground ? { 'background-image': 'url('+configuration.theme.logo.background+')',
-                 'background-size':'cover'} : {}">
-    <div v-if="!showHeader">
+  <div
+    id="Phoenix"
+    :class="['uk-flex uk-flex-column uk-height-1-1', { loginGradient: showGradientBackground}]"
+    :style="showImageBackground ? { 'background-image': 'url('+configuration.theme.logo.background+')',
+      'background-size':'cover'} : {}"
+  >
+    <template v-if="!showHeader">
       <router-view name="fullscreen"></router-view>
-    </div>
-    <div v-else>
+    </template>
+    <template v-else>
       <notification-bar />
       <top-bar></top-bar>
       <side-menu></side-menu>
       <router-view v-if="this.$route.matched[0].components.appTopbar" class="appTopbar" name="appTopbar"></router-view>
-      <router-view name="appContent"></router-view>
-    </div>
+      <div class="uk-height-1-1 uk-overflow-auto">
+        <router-view name="appContent"></router-view>
+      </div>
+    </template>
   </div>
 </template>
 <script>
@@ -58,3 +63,9 @@ export default {
   }
 }
 </script>
+<style>
+  body {
+    height: 100vh;
+    overflow: hidden;
+  }
+</style>

--- a/src/components/Top-Bar.vue
+++ b/src/components/Top-Bar.vue
@@ -1,5 +1,5 @@
 <template>
-  <oc-navbar tag="header" class="oc-topbar" :sticky="true" :offset="0">
+  <oc-navbar tag="header" class="oc-topbar">
     <oc-navbar-item position="left">
       <button class="oc-topbar-menu-burger" aria-label="Files" @click="toggleSidebar(!isSidebarVisible)">
         <oc-icon name="menu" class="oc-topbar-menu-burger-icon" />


### PR DESCRIPTION
## Description
I removed stickiness from elements and ensured scrolling by adding scroll to apps. To ensure scroll for any app in the future, there is a container in phoenix.vue. That way other developers doesn't have to define it all the time again. But I also defined scroll in files app. That way we also don't need stickiness at sidebar.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/owncloud-design-system/issues/225

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Define scroll at sidebar when too many sharings