### PR TITLE
acceptance-test/implement default user creation

### DIFF
--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -13,8 +13,8 @@ Feature: Sharing files and folders with internal users
   @smokeTest
   Scenario: share a file & folder with another internal user
     Given user "user2" has logged in using the webUI
-    When the user shares folder "simple-folder" with user "user1" using the webUI
-    And the user shares file "testimage.jpg" with user "user1" using the webUI
+    When the user shares folder "simple-folder" with user "User One" using the webUI
+    And the user shares file "testimage.jpg" with user "User One" using the webUI
     And the user re-logs in as "user1" using the webUI
     Then folder "simple-folder (2)" should be listed on the webUI
 #    And folder "simple-folder (2)" should be marked as shared by "User Two" on the webUI

--- a/tests/acceptance/helpers/httpHelper.js
+++ b/tests/acceptance/helpers/httpHelper.js
@@ -1,5 +1,4 @@
-const { client } = require('nightwatch-api')
-let password = ''
+const userSettings = require('../helpers/userSettings')
 
 /**
  *
@@ -8,11 +7,7 @@ let password = ''
  * @returns {string}
  */
 exports.createAuthHeader = function (userId) {
-  if (userId === client.globals.backend_admin_username) {
-    password = client.globals.backend_admin_password
-  } else {
-    password = userId
-  }
+  const password = userSettings.getActualPassword(userId)
   return {
     'Authorization': 'Basic ' +
       Buffer.from(userId + ':' + password).toString('base64')

--- a/tests/acceptance/helpers/userSettings.js
+++ b/tests/acceptance/helpers/userSettings.js
@@ -1,0 +1,105 @@
+const adminUsername = process.env.ADMIN_USERNAME || 'admin'
+const adminPassword = process.env.ADMIN_PASSWORD || 'admin'
+const regularUserPassword = process.env.REGULAR_USER_PASSWORD || '123456'
+const alt1UserPassword = process.env.ALT1_USER_PASSWORD || '1234'
+const alt2UserPassword = process.env.ALT2_USER_PASSWORD || 'AaBb2Cc3Dd4'
+const alt3UserPassword = process.env.ALT3_USER_PASSWORD || 'aVeryLongPassword42TheMeaningOfLife'
+const alt4UserPassword = process.env.ALT4_USER_PASSWORD || 'ThisIsThe4thAlternatePwd'
+
+module.exports = {
+  // list of default users
+  defaultUsers: {
+    admin: {
+      displayname: adminUsername,
+      password: adminPassword
+    },
+    regularuser: {
+      displayname: 'Regular User',
+      password: regularUserPassword,
+      email: 'regularuser@example.org'
+    },
+    user0: {
+      displayname: 'Regular User',
+      password: regularUserPassword,
+      email: 'user0@example.org'
+    },
+    user1: {
+      displayname: 'User One',
+      password: alt1UserPassword,
+      email: 'user1@example.org'
+    },
+    user2: {
+      displayname: 'User Two',
+      password: alt2UserPassword,
+      email: 'user2@example.org'
+    },
+    user3: {
+      displayname: 'User Three',
+      password: alt3UserPassword,
+      email: 'user3@example.org'
+    },
+    user4: {
+      displayname: 'User Four',
+      password: alt4UserPassword,
+      email: 'user4@example.org'
+    },
+    usergrp: {
+      displayname: 'User Grp',
+      password: regularUserPassword,
+      email: 'usergrp@example.org'
+    },
+    sharee1: {
+      displayname: 'Sharee One',
+      password: regularUserPassword,
+      email: 'sharee1@example.org'
+    }
+  },
+  /**
+   *
+   * @param {string} userId
+   * @returns {string}
+   */
+  getPasswordForUser: function (userId) {
+    if (userId in this.defaultUsers) {
+      return this.defaultUsers[userId].password
+    } else {
+      return this.defaultUsers.regularuser.password
+    }
+  },
+  /**
+   *
+   * @param {string} userId
+   * @returns {null|string}
+   */
+  getDisplayNameForUser: function (userId) {
+    if (userId in this.defaultUsers) {
+      return this.defaultUsers[userId].displayname
+    } else {
+      return null
+    }
+  },
+  /**
+   *
+   * @param {string} userId
+   * @returns {null|string}
+   */
+  getEmailAddressForUser: function (userId) {
+    if (userId in this.defaultUsers) {
+      return this.defaultUsers[userId].email
+    } else {
+      return null
+    }
+  },
+  /**
+   *
+   * @param {string} userId
+   * @returns {string}
+   */
+  getActualPassword: function (userId) {
+    if (userId in this.defaultUsers) {
+      return this.defaultUsers[userId].password
+    } else {
+      return userId
+    }
+  }
+}

--- a/tests/acceptance/stepDefinitions/loginContext.js
+++ b/tests/acceptance/stepDefinitions/loginContext.js
@@ -1,5 +1,6 @@
 const { client, createSession, closeSession, startWebDriver, stopWebDriver } = require('nightwatch-api')
 const { Given, Then, When } = require('cucumber')
+const userSettings = require('../helpers/userSettings')
 
 const loginAsUser = function (userId) {
   const loginPage = client.page.loginPage()
@@ -12,12 +13,13 @@ const loginAsUser = function (userId) {
     .waitForElementVisible('@authenticateButton')
     .click('@authenticateButton')
 
+  const password = userSettings.getActualPassword(userId)
   // Then the user logs in with username {string} and password {string} using the webUi
   const ocLoginPage = client.page.ownCloudLoginPage()
   ocLoginPage
     .waitForElementVisible('@usernameInput')
     .setValue('@usernameInput', userId)
-    .setValue('@passwordInput', userId)
+    .setValue('@passwordInput', password)
     .click('@loginSubmitButton')
 
   // When the user authorizes access to phoenix
@@ -31,7 +33,8 @@ const loginAsUser = function (userId) {
     .page.filesPage()
     .waitForElementVisible('@filesTable')
     .then(() => {
-      client.globals.currentUserName = userId
+      const displayname = userSettings.getDisplayNameForUser()
+      client.globals.currentUserName = displayname
     })
 }
 


### PR DESCRIPTION
## Description
Add methods to implement default user creation.

## Related Issue
#844

## Motivation and Context
Create users with some pre-defined settings like, `password`, `displayname` and `email`

## How Has This Been Tested?
🤖

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 