### PR TITLE
Enable sharing sidebar only if sharing is enabled

### DIFF
--- a/apps/files/src/components/FileDetails.vue
+++ b/apps/files/src/components/FileDetails.vue
@@ -22,7 +22,7 @@
     </template>
     <template slot="content">
       <oc-tabs>
-          <oc-tab-item :active="key == activeTab" @click="activeTab = key" v-for="(tab, key) of fileSideBars" :key="tab.name">
+          <oc-tab-item :active="key == activeTab" @click="activeTab = key" v-for="(tab, key) of fileSideBarsEnabled" :key="tab.name">
             {{ tab.component.title($gettext) }}
           </oc-tab-item>
       </oc-tabs>
@@ -64,7 +64,10 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(['getToken', 'fileSideBars']),
+    ...mapGetters(['getToken', 'fileSideBars', 'capabilities']),
+    fileSideBarsEnabled () {
+      return this.fileSideBars.filter(b => b.enabled === undefined || b.enabled(this.capabilities))
+    },
     getTabName () {
       if (this.items.length === 0) {
         return ''
@@ -72,12 +75,11 @@ export default {
       if (this.items.length > 1) {
         return this.$gettext('Multiple Files')
       } else {
-        // return (this.items[0].name.length > 16) ? `${this.items[0].name.substr(0, 10)}...` : this.items[0].name
         return this.items[0].name
       }
     },
     activeTabComponent () {
-      return this.fileSideBars[this.activeTab]
+      return this.fileSideBarsEnabled[this.activeTab]
     }
   }
 }

--- a/apps/files/src/components/FileList.vue
+++ b/apps/files/src/components/FileList.vue
@@ -150,7 +150,7 @@ export default {
   },
   computed: {
     ...mapGetters('Files', ['selectedFiles', 'atSearchPage', 'loadingFolder']),
-    ...mapGetters(['getToken', 'fileSideBars']),
+    ...mapGetters(['getToken', 'fileSideBars', 'capabilities']),
     all () {
       return this.selectedFiles.length === this.fileData.length && this.fileData.length !== 0
     },
@@ -180,6 +180,9 @@ export default {
       ]
       for (let sideBarName in this.fileSideBars) {
         let sideBar = this.fileSideBars[sideBarName]
+        if (sideBar.enabled !== undefined && !sideBar.enabled(this.capabilities)) {
+          continue
+        }
         if (sideBar.quickAccess) {
           actions.push({
             icon: sideBar.quickAccess.icon,

--- a/apps/files/src/default.js
+++ b/apps/files/src/default.js
@@ -22,6 +22,9 @@ const appInfo = {
     }, {
       app: 'files-sharing',
       component: FileSharingSidebar,
+      enabled (capabilities) {
+        return capabilities.files_sharing.api_enabled === '1'
+      },
       quickAccess: {
         icon: 'share',
         ariaLabel: 'Share'
@@ -52,6 +55,9 @@ const navItems = [
   {
     name: 'Deleted files',
     iconMaterial: 'delete',
+    enabled (capabilities) {
+      return capabilities.dav.trashbin === '1.0'
+    },
     route: {
       name: 'files-trashbin',
       path: `/${appInfo.id}/trash-bin`

--- a/src/Phoenix.vue
+++ b/src/Phoenix.vue
@@ -12,7 +12,7 @@
   </div>
 </template>
 <script>
-import { mapGetters, mapState } from 'vuex'
+import { mapGetters, mapState, mapActions } from 'vuex'
 import TopBar from './components/Top-Bar.vue'
 import Menu from './components/Menu.vue'
 import MessageBar from './components/MessageBar.vue'
@@ -24,7 +24,7 @@ export default {
     TopBar
   },
   beforeMount () {
-    this.$store.dispatch('initAuth')
+    this.initAuth()
   },
   computed: {
     ...mapState(['route']),
@@ -32,6 +32,9 @@ export default {
     showHeader () {
       return this.$route.meta.hideHeadbar !== true
     }
+  },
+  methods: {
+    ...mapActions(['initAuth'])
   }
 }
 </script>

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -27,10 +27,17 @@ export default {
   },
   computed: {
     nav () {
-      return this.$root.navItems
+      return this.$root.navItems.filter(item => {
+        if (item.enabled === undefined) {
+          return true
+        }
+        if (this.capabilities === undefined) {
+          return false
+        }
+        return item.enabled(this.capabilities)
+      })
     },
-    ...mapGetters(['isSidebarVisible']),
-    ...mapGetters(['configuration']),
+    ...mapGetters(['isSidebarVisible', 'configuration', 'capabilities']),
     sidebarIsVisible: {
       get () {
         return this.isSidebarVisible
@@ -48,10 +55,6 @@ export default {
   },
   methods: {
     ...mapActions(['toggleSidebar']),
-    notImplemented () {
-      // TODO: tempelgogo's snackbarQueue
-      console.log('snackbar should be here')
-    },
     logout () {
       this.sidebarIsVisible = false
       this.$store.dispatch('logout')


### PR DESCRIPTION
## Description
The sharing side bar is only enabled if sharing is enabled on server side

## Related issue
- Fixes #1155 

## How Has This Been Tested?
- :hand: 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] capabilities are only loaded on login - so changing the setting at runtime will not cause an update of the frontend