### PR TITLE
Fixes #1232 - use item.type instead of item.extension to determine th…

### DIFF
--- a/apps/files/src/components/FileList.vue
+++ b/apps/files/src/components/FileList.vue
@@ -21,7 +21,7 @@
           <oc-star class="uk-display-block" @click.native="toggleFileFavorite(item)" :shining="item.starred" />
         </oc-table-cell>
         <oc-table-cell class="uk-text-truncate">
-          <oc-file @click.native="item.extension === '' ? navigateTo('files-list', item.path.substr(1)) : openFileActionBar(item)"
+          <oc-file @click.native="item.type === 'folder' ? navigateTo('files-list', item.path.substr(1)) : openFileActionBar(item)"
                    :name="item.basename" :extension="item.extension" class="file-row-name" :icon="fileTypeIcon(item)"
                    :filename="item.name" :key="item.id" />
         </oc-table-cell>


### PR DESCRIPTION
…e type of an item

## Description
File extension is the wrong criteria to determine is it is a file or a folder

## Related Issue
- Fixes #1232

## How Has This Been Tested?
- :hand: 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...