### PR TITLE
Fixes #1259 - break text in prompt dialog

### DIFF
--- a/apps/files/src/components/ocDialogPrompt.vue
+++ b/apps/files/src/components/ocDialogPrompt.vue
@@ -4,7 +4,7 @@
       <oc-alert v-if="ocError" id="oc-dialog-prompt-alert" noClose="true" variation="danger">
         {{ ocError }}
       </oc-alert>
-      <span v-if="ocContent">{{ ocContent }}</span>
+      <span v-if="ocContent" class="uk-text-break">{{ ocContent }}</span>
         <oc-text-input v-if="ocHasInput"
           :disabled="ocLoading"
           autofocus


### PR DESCRIPTION
fixes #1259 

![Screenshot from 2019-06-06 14-19-25](https://user-images.githubusercontent.com/1005065/59032442-9804bd80-8866-11e9-9ee2-a3d07abc6c2a.png)
