### PR TITLE
Added actions for small resolution

### DIFF
--- a/apps/files/src/components/FileList.vue
+++ b/apps/files/src/components/FileList.vue
@@ -35,7 +35,22 @@
           <div class="uk-button-group uk-margin-small-right" :class="{ 'uk-visible@m' : !_sidebarOpen, 'uk-visible@xl' : _sidebarOpen  }">
             <oc-button v-for="(action, index) in actions" :key="index" @click.native="action.handler(item, action.handlerData)" :disabled="!action.isEnabled(item)" :icon="action.icon" :ariaLabel="action.ariaLabel" />
           </div>
-          <oc-button icon="menu" :class="{ 'uk-hidden@m' : !_sidebarOpen, 'uk-visible@s uk-hidden@xl' : _sidebarOpen }"></oc-button>
+          <oc-button
+            :id="'files-file-list-action-button-small-resolution-' + index"
+            icon="menu"
+            :class="{ 'uk-hidden@m' : !_sidebarOpen, 'uk-visible@s uk-hidden@xl' : _sidebarOpen }"
+          />
+          <oc-drop
+            :toggle="'#files-file-list-action-button-small-resolution-' + index"
+            :options="{ 'pos': 'bottom-center' }"
+            class="uk-width-auto"
+          >
+            <ul class="uk-list">
+              <li v-for="(action, index) in actions" :key="index">
+                <oc-button  @click.native="action.handler(item, action.handlerData)" :disabled="!action.isEnabled(item)" :icon="action.icon" :ariaLabel="action.ariaLabel" />
+              </li>
+            </ul>
+          </oc-drop>
         </oc-table-cell>
       </oc-table-row>
     </oc-table-group>


### PR DESCRIPTION
## Description
Added oc-drop with actions for smaller resolution.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #1237 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/25989331/59051988-60aa0700-888e-11e9-82d7-4996bc79f7e7.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 