### PR TITLE
Load favorite page without items

### DIFF
--- a/tests/acceptance/features/webUIFavorites/favoritesFile.feature
+++ b/tests/acceptance/features/webUIFavorites/favoritesFile.feature
@@ -10,23 +10,22 @@ Feature: Mark file as favorite
     And the user has browsed to the files page
 
   @smokeTest
-  @issue-1189
   Scenario: mark files as favorites
     When the user marks file "data.tar.gz" as favorite using the webUI
     And the user marks file "data.zip" as favorite using the webUI
-    Then file "data.zip" should be marked as favorite on the webUI
+    Then file "data.tar.gz" should be marked as favorite on the webUI
+    And file "data.zip" should be marked as favorite on the webUI
     When the user reloads the current page of the webUI
-    Then file "data.zip" should be marked as favorite on the webUI
+    Then file "data.tar.gz" should be marked as favorite on the webUI
+    And file "data.zip" should be marked as favorite on the webUI
     When the user browses to the favorites page
-#    Then there should be 2 files/folders listed on the webUI
-    Then there should be 1 files/folders listed on the webUI
-#    Then file "data.zip" should be listed on the webUI
-#    And file "data.zip" should be marked as favorite on the webUI
-    #And file "data.tar.gz" should be listed on the webUI
-    #And file "data.tar.gz" should be marked as favorite on the webUI
+    Then there should be 2 files/folders listed on the webUI
+    Then file "data.zip" should be listed on the webUI
+    And file "data.zip" should be marked as favorite on the webUI
+    And file "data.tar.gz" should be listed on the webUI
+    And file "data.tar.gz" should be marked as favorite on the webUI
     And file "lorem.txt" should not be listed on the webUI
 
-  @issue-1189
   Scenario: mark folders as favorites
     When the user marks folder "simple-folder" as favorite using the webUI
     And the user marks folder "strängé नेपाली folder" as favorite using the webUI
@@ -38,17 +37,14 @@ Feature: Mark file as favorite
     When the user browses to the favorites page
     Then folder "simple-folder" should be listed on the webUI
     And folder "simple-folder" should be marked as favorite on the webUI
-    But folder "strängé नेपाली folder" should not be listed on the webUI
-    #And folder "strängé नेपाली folder" should be listed on the webUI
-    #And folder "strängé नेपाली folder" should be marked as favorite on the webUI
+    And folder "strängé नेपाली folder" should be listed on the webUI
+    And folder "strängé नेपाली folder" should be marked as favorite on the webUI
     But folder "simple-folder-empty" should not be listed on the webUI
 
-  @issue-1189
   Scenario: navigate to an empty favorites page
     When the user browses to the favorites page
     Then the files table should be displayed
-    And the error message 'Loading folder failed…' should be displayed on the webUI
-    #And no notification should be displayed on the webUI
+    And no notification should be displayed on the webUI
     And there should be no files/folders listed on the webUI
 
   @issue-1194

--- a/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature
+++ b/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature
@@ -9,7 +9,6 @@ Feature: Unmark file/folder as favorite
     And user "user1" has logged in using the webUI
 
   @smokeTest
-  @issue-1189
   Scenario: unmark files as favorite from files page
     Given user "user1" has favorited element "data.zip"
     And user "user1" has favorited element "data.tar.gz"
@@ -21,11 +20,9 @@ Feature: Unmark file/folder as favorite
     And file "lorem.txt" should be marked as favorite on the webUI
     When the user browses to the favorites page
     Then file "data.zip" should not be listed on the webUI
-    But file "data.tar.gz" should not be listed on the webUI
-    #But file "data.tar.gz" should be listed on the webUI
-    But file "lorem.txt" should be listed on the webUI
+    But file "data.tar.gz" should be listed on the webUI
+    And file "lorem.txt" should be listed on the webUI
 
-  @issue-1189
   Scenario: unmark a folder as favorite from files page
     Given user "user1" has favorited element "simple-folder"
     And user "user1" has favorited element "simple-empty-folder"
@@ -37,12 +34,10 @@ Feature: Unmark file/folder as favorite
     And folder "0" should be marked as favorite on the webUI
     When the user browses to the favorites page
     Then folder "simple-folder" should not be listed on the webUI
-    But folder "0" should not be listed on the webUI
-    #But file "0" should be listed on the webUI
-    But folder "simple-empty-folder" should be listed on the webUI
+    But folder "0" should be listed on the webUI
+    And folder "simple-empty-folder" should be listed on the webUI
 
   @smokeTest
-  @issue-1189
   Scenario: unmark a file as favorite from favorite page
     Given user "user1" has favorited element "data.zip"
     And user "user1" has favorited element "data.tar.gz"
@@ -53,15 +48,13 @@ Feature: Unmark file/folder as favorite
     But file "data.zip" should not be marked as favorite on the webUI
     When the user reloads the current page of the webUI
     Then file "data.zip" should not be listed on the webUI
-    And file "data.tar.gz" should not be listed on the webUI
-    #But file "data.tar.gz" should be listed on the webUI
-    But file "lorem.txt" should be listed on the webUI
+    But file "data.tar.gz" should be listed on the webUI
+    And file "lorem.txt" should be listed on the webUI
     When the user browses to the files page
     Then file "data.zip" should not be marked as favorite on the webUI
     But file "data.tar.gz" should be marked as favorite on the webUI
     And file "lorem.txt" should be marked as favorite on the webUI
 
-  @issue-1189
   Scenario: unmark a folder as favorite from favorite page
     Given user "user1" has favorited element "simple-folder"
     And user "user1" has favorited element "simple-empty-folder"
@@ -72,9 +65,8 @@ Feature: Unmark file/folder as favorite
     But folder "simple-folder" should not be marked as favorite on the webUI
     When the user reloads the current page of the webUI
     Then folder "simple-folder" should not be listed on the webUI
-    And folder "0" should not be listed on the webUI
-    #But folder "0" should be listed on the webUI
-    But folder "simple-empty-folder" should be listed on the webUI
+    But folder "0" should be listed on the webUI
+    And folder "simple-empty-folder" should be listed on the webUI
     When the user browses to the files page
     Then folder "simple-folder" should not be marked as favorite on the webUI
     But folder "simple-empty-folder" should be marked as favorite on the webUI


### PR DESCRIPTION
## Description
Set root folder as current folder for favourites page and removed permissions to upload in that page.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #1247
- Fixes #1189

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 