### PR TITLE
Add test step to assert the number of files/folders in webUI

### DIFF
--- a/tests/acceptance/features/webUIFavorites/favoritesFile.feature
+++ b/tests/acceptance/features/webUIFavorites/favoritesFile.feature
@@ -18,9 +18,10 @@ Feature: Mark file as favorite
     When the user reloads the current page of the webUI
     Then file "data.zip" should be marked as favorite on the webUI
     When the user browses to the favorites page
-    Then file "data.zip" should be listed on the webUI
-    And file "data.zip" should be marked as favorite on the webUI
-    But file "data.tar.gz" should not be listed on the webUI
+#    Then there should be 2 files/folders listed on the webUI
+    Then there should be 1 files/folders listed on the webUI
+#    Then file "data.zip" should be listed on the webUI
+#    And file "data.zip" should be marked as favorite on the webUI
     #And file "data.tar.gz" should be listed on the webUI
     #And file "data.tar.gz" should be marked as favorite on the webUI
     And file "lorem.txt" should not be listed on the webUI

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -172,11 +172,14 @@ module.exports = {
     },
     /**
      *
-     * @param {function} callback
+     * @returns {Promise.<[]>} Array of files/folders element
      */
-    allFileRows: function (callback) {
-      this.api.elements('css selector', this.elements['fileRows'], function (result) {
-        callback(result)
+    allFileRows: async function () {
+      this.waitForElementNotPresent('@filesListProgressBar')
+      return new Promise((resolve, reject) => {
+        this.api.elements('css selector', this.elements['fileRows'], function (result) {
+          resolve(result)
+        })
       })
     }
   },

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -180,6 +180,11 @@ Then('file/folder {string} should not be marked as favorite on the webUI', funct
   })
 })
 
+Then(/there should be (\d+) files\/folders listed on the webUI/, async function (noOfItems) {
+  const allFileRows = await client.page.FilesPageElement.filesList().allFileRows()
+  return client.assert.equal(allFileRows.value.length, noOfItems)
+})
+
 const assertDeletedElementsAreNotListed = function () {
   for (const element of deletedElementsTable) {
     client.page.FilesPageElement.filesList().assertElementNotListed(element)


### PR DESCRIPTION
## Description
Add test step to assert the number of files/folders displayed on the web UI

Tests were failing the webUIFavories due to issue #1189 because the last item
that should be listed in the favorite page was not being displayed. By using the number of items that should be displayed, we are free from file/folder name dependency that should be displayed in the favorites page.

*Note: callbacks are removed in favor of Promises to improve code readability.*

## How Has This Been Tested?
🤖

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 