### PR TITLE
run UI tests in chrome 75

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -211,7 +211,7 @@ services:
         NEED_SERVER: true
 
   selenium:
-    image: selenium/standalone-chrome-debug:3.141.59-oxygen
+    image: selenium/standalone-chrome-debug:latest
     pull: true
     when:
       matrix:

--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -32,6 +32,7 @@ module.exports = {
         start_process: START_PROCESS,
         server_path: chromedriver.path,
         port: SELENIUM_PORT,
+        use_legacy_jsonwire: false,
         cli_args: ['--port=' + SELENIUM_PORT]
       },
       screenshots: {
@@ -44,7 +45,8 @@ module.exports = {
         javascriptEnabled: true,
         acceptSslCerts: true,
         chromeOptions: {
-          args: ['disable-gpu']
+          args: ['disable-gpu'],
+          w3c: false
         }
       }
     },
@@ -57,7 +59,8 @@ module.exports = {
       },
       selenium_host: 'selenium',
       webdriver: {
-        start_process: false
+        start_process: false,
+        use_legacy_jsonwire: false
       },
       screenshots : {
         enabled : true,
@@ -69,7 +72,8 @@ module.exports = {
         javascriptEnabled: true,
         acceptSslCerts: true,
         chromeOptions: {
-          args: ['disable-gpu']
+          args: ['disable-gpu'],
+          w3c: false
         }
       }
     }

--- a/tests/acceptance/stepDefinitions/loginContext.js
+++ b/tests/acceptance/stepDefinitions/loginContext.js
@@ -25,7 +25,7 @@ const loginAsUser = function (userId) {
   // When the user authorizes access to phoenix
   client
     .page.ownCloudAuthorizePage()
-    .waitForElementPresent('@authorizeButton')
+    .waitForElementVisible('@authorizeButton')
     .click('@authorizeButton')
 
   // Then the files table should be displayed


### PR DESCRIPTION
## Description
run UI tests again with the current version of Chrome

tests were switched to chrome 74 in https://github.com/owncloud/phoenix/pull/1260
nightwatch made a workaround of the current issue in chrome and now it works again with disabled W3C protocol and nightwatch 1.1.12 https://github.com/nightwatchjs/nightwatch/releases/tag/v1.1.12

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...