### PR TITLE
fix phoenix build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM node:9.11.1-alpine as build-stage
+FROM node:10.15.3-alpine as build-stage
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git
 


### PR DESCRIPTION
ran into this:
```
Step 1/10 : FROM node:9.11.1-alpine as build-stage
 ---> 9cc7800b3f3c
Step 2/10 : RUN apk update && apk upgrade &&     apk add --no-cache bash git
 ---> Running in 16dd6e8d858e
fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/community/x86_64/APKINDEX.tar.gz
v3.6.5-44-gda55e27396 [http://dl-cdn.alpinelinux.org/alpine/v3.6/main]
v3.6.5-34-gf0ba0b43d5 [http://dl-cdn.alpinelinux.org/alpine/v3.6/community]
OK: 8448 distinct packages available
Upgrading critical system libraries and apk-tools:
(1/1) Upgrading apk-tools (2.7.5-r0 -> 2.7.6-r0)
Executing busybox-1.26.2-r9.trigger
Continuing the upgrade transaction with new apk-tools:
(1/7) Upgrading musl (1.1.16-r14 -> 1.1.16-r15)
(2/7) Upgrading busybox (1.26.2-r9 -> 1.26.2-r11)
Executing busybox-1.26.2-r11.post-upgrade
(3/7) Upgrading libressl2.5-libcrypto (2.5.5-r0 -> 2.5.5-r2)
(4/7) Upgrading libressl2.5-libssl (2.5.5-r0 -> 2.5.5-r2)
(5/7) Installing libressl2.5-libtls (2.5.5-r2)
(6/7) Installing ssl_client (1.26.2-r11)
(7/7) Upgrading musl-utils (1.1.16-r14 -> 1.1.16-r15)
Executing busybox-1.26.2-r11.trigger
OK: 5 MiB in 15 packages
fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/community/x86_64/APKINDEX.tar.gz
(1/11) Installing ncurses-terminfo-base (6.0_p20171125-r1)
(2/11) Installing ncurses-terminfo (6.0_p20171125-r1)
(3/11) Installing ncurses-libs (6.0_p20171125-r1)
(4/11) Installing readline (6.3.008-r5)
(5/11) Installing bash (4.3.48-r1)
Executing bash-4.3.48-r1.post-install
(6/11) Installing ca-certificates (20161130-r3)
(7/11) Installing libssh2 (1.8.2-r0)
(8/11) Installing libcurl (7.61.1-r2)
(9/11) Installing expat (2.2.0-r1)
(10/11) Installing pcre (8.41-r0)
(11/11) Installing git (2.13.7-r2)
Executing busybox-1.26.2-r11.trigger
Executing ca-certificates-20161130-r3.trigger
OK: 35 MiB in 26 packages
Removing intermediate container 16dd6e8d858e
 ---> a4247dba7cca
Step 3/10 : WORKDIR /app
 ---> Running in 351dffbbee2d
Removing intermediate container 351dffbbee2d
 ---> 11c7e792bc3f
Step 4/10 : COPY . .
 ---> 472a680bcd78
Step 5/10 : RUN yarn install
 ---> Running in 7661a1b381b3
yarn install v1.5.1
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@1.2.9: The platform "linux" is incompatible with this module.
info "fsevents@1.2.9" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
$ cd node_modules/cucumber; yarn install
yarn install v1.5.1
[1/5] Validating package.json...
[2/5] Resolving packages...
[3/5] Fetching packages...
info fsevents@1.2.4: The platform "linux" is incompatible with this module.
info "fsevents@1.2.4" is an optional dependency and failed compatibility check. Excluding it from installation.
error get-caller-file@2.0.5: The engine "node" is incompatible with this module. Expected version "6.* || 8.* || >= 10.*".
error An unexpected error occurred: "Found incompatible module".
info If you think this is a bug, please open a bug report with the information provided in "/app/node_modules/cucumber/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
error An unexpected error occurred: "Command failed.
Exit code: 1
Command: sh
Arguments: -c cd node_modules/cucumber; yarn install
Directory: /app
Output:
".
info If you think this is a bug, please open a bug report with the information provided in "/app/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
ERROR: Service 'phoenix' failed to build: The command '/bin/sh -c yarn install' returned a non-zero code: 1
```