### PR TITLE
Fix loading of file versions

### DIFF
--- a/apps/files/src/components/FilesApp.vue
+++ b/apps/files/src/components/FilesApp.vue
@@ -4,7 +4,7 @@
         <oc-loader id="files-list-progress" v-if="loadingFolder"></oc-loader>
         <file-list @toggle="toggleFileSelect" @FileAction="openFileActionBar" :fileData="activeFiles" @sideBarOpen="openSideBar"/>
       </div>
-      <div class="uk-width-1-1 uk-width-2-3@s uk-width-1-2@m uk-width-2-5@xl" v-show="_sidebarOpen">
+      <div class="uk-width-1-1 uk-width-2-3@s uk-width-1-2@m uk-width-2-5@xl" v-if="_sidebarOpen">
         <file-details :items="selectedFiles" :starsEnabled="false" :checkboxEnabled="false" ref="fileDetails" @reload="$_ocFilesFolder_getFolder" @reset="resetFileSelection"/>
       </div>
     <oc-file-actions></oc-file-actions>


### PR DESCRIPTION
## Description
Changed the `v-show` to `v-if` in right sidebar. If the sidebar was loaded on page load, the versions were loaded even without selected files which kept throwing errors and blocked call for the function `getFileVersions()` in case a new file was selected.

## Motivation and Context
Functioning file versions and no errors 🙂 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually
- test case 1: Select file without any previous version
- test case 2: Select file with previous version

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 