### PR TITLE
improve test stability

### DIFF
--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -72,7 +72,7 @@ module.exports = {
         javascriptEnabled: true,
         acceptSslCerts: true,
         chromeOptions: {
-          args: ['disable-gpu'],
+          args: ['disable-gpu', 'disable-dev-shm-usage'],
           w3c: false
         }
       }

--- a/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
@@ -9,7 +9,20 @@ module.exports = {
      */
     shareWithUserOrGroup: async function (sharee, shareWithGroup = false) {
       this.enterAutoComplete(sharee)
-        .waitForElementVisible('@sharingAutoCompleteDropDownElements')
+      // We need waitForElementPresent here.
+      // waitForElementVisible would break even with 'abortOnFailure: false' if the element is not present
+        .waitForElementPresent({
+          selector: '@sharingAutoCompleteDropDownElements',
+          abortOnFailure: false
+        }, (result) => {
+          if (result.value === false) {
+            // sharing dropdown was not shown
+            console.log('WARNING: no sharing autocomple dropdown found, retry typing')
+            this.clearValue('@sharingAutoComplete')
+              .enterAutoComplete(sharee)
+              .waitForElementVisible('@sharingAutoCompleteDropDownElements')
+          }
+        })
 
       const webElementIdList = await this.getShareAutocompleteWebElementIdList()
       webElementIdList.forEach((webElementId) => {

--- a/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
@@ -55,6 +55,7 @@ module.exports = {
       return this.initAjaxCounters()
         .waitForElementVisible('@sharingAutoComplete')
         .setValue('@sharingAutoComplete', input)
+        .waitForOutstandingAjaxCalls()
     },
     /**
      *

--- a/tests/acceptance/pageObjects/favoritesPage.js
+++ b/tests/acceptance/pageObjects/favoritesPage.js
@@ -1,5 +1,18 @@
 module.exports = {
   url: function () {
     return this.api.launchUrl + '/#/files/favorites/'
+  },
+  commands: {
+    /**
+     * like build-in navigate() but also waits till for the progressbar to appear and disappear
+     * @returns {*}
+     */
+    navigateAndWaitTillLoaded: function () {
+      this.navigate()
+      return this
+        .page.FilesPageElement.filesList()
+        .waitForElementPresent({ selector: '@filesListProgressBar', abortOnFailure: false }) // don't fail if we are too late
+        .waitForElementNotPresent('@filesListProgressBar')
+    }
   }
 }

--- a/tests/acceptance/pageObjects/filesPage.js
+++ b/tests/acceptance/pageObjects/filesPage.js
@@ -4,6 +4,17 @@ module.exports = {
   },
   commands: {
     /**
+     * like build-in navigate() but also waits till for the progressbar to appear and disappear
+     * @returns {*}
+     */
+    navigateAndWaitTillLoaded: function () {
+      this.navigate()
+      return this
+        .page.FilesPageElement.filesList()
+        .waitForElementPresent({ selector: '@filesListProgressBar', abortOnFailure: false }) // don't fail if we are too late
+        .waitForElementNotPresent('@filesListProgressBar')
+    },
+    /**
      *
      * @param {string} folder
      */

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -7,19 +7,19 @@ When('the user browses to the files page',
   () => {
     return client
       .page.filesPage()
-      .navigate()
+      .navigateAndWaitTillLoaded()
   })
 
 When('the user browses to the favorites page', function () {
   return client
     .page.favoritesPage()
-    .navigate()
+    .navigateAndWaitTillLoaded()
 })
 
 Given('the user has browsed to the favorites page', function () {
   return client
     .page.favoritesPage()
-    .navigate()
+    .navigateAndWaitTillLoaded()
 })
 
 Then('the files table should be displayed',
@@ -31,7 +31,7 @@ Then('the files table should be displayed',
 Given('the user has browsed to the files page', function () {
   return client
     .page.filesPage()
-    .navigate()
+    .navigateAndWaitTillLoaded()
 })
 
 When('the user creates a folder with the name {string} using the webUI', function (folderName) {

--- a/tests/acceptance/stepDefinitions/loginContext.js
+++ b/tests/acceptance/stepDefinitions/loginContext.js
@@ -27,6 +27,19 @@ const loginAsUser = function (userId) {
     .page.ownCloudAuthorizePage()
     .waitForElementVisible('@authorizeButton')
     .click('@authorizeButton')
+    .waitForElementNotPresent({
+      selector: '@authorizeButton',
+      abortOnFailure: false
+    }, (result) => {
+      if (result.value.length > 0) {
+        // click failed
+        console.log('WARNING: looks like I\'m still on auth page. ' +
+                    'I will click the auth button again')
+        client.page.ownCloudAuthorizePage()
+          .click('@authorizeButton')
+          .waitForElementNotPresent('@authorizeButton')
+      }
+    })
 
   // Then the files table should be displayed
   return client


### PR DESCRIPTION
## Description
this should hopefully make the most frequent failures less likely
1. retries when the authentication did not work properly
2. retries when the typing in the share-with input did not trigger the event
3. wait for better indicators when opening files pages
4. wait till ajax calls are finished when sharing
5. disable-dev-shm-usage should help prevent selenium crashes, see https://stackoverflow.com/questions/53902507/unknown-error-session-deleted-because-of-page-crash-from-unknown-error-cannot

## How Has This Been Tested?
- run CI a lot, seems to be better but still not 100% stable

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...