### PR TITLE
Add tests for going back to files page

### DIFF
--- a/tests/acceptance/features/webUIFavorites/favoritesFile.feature
+++ b/tests/acceptance/features/webUIFavorites/favoritesFile.feature
@@ -20,7 +20,7 @@ Feature: Mark file as favorite
     And file "data.zip" should be marked as favorite on the webUI
     When the user browses to the favorites page
     Then there should be 2 files/folders listed on the webUI
-    Then file "data.zip" should be listed on the webUI
+    And file "data.zip" should be listed on the webUI
     And file "data.zip" should be marked as favorite on the webUI
     And file "data.tar.gz" should be listed on the webUI
     And file "data.tar.gz" should be marked as favorite on the webUI
@@ -46,6 +46,17 @@ Feature: Mark file as favorite
     Then the files table should be displayed
     And no notification should be displayed on the webUI
     And there should be no files/folders listed on the webUI
+
+  Scenario: navigate to the favorites page using the menu
+    Given user "user1" has favorited element "data.zip"
+    When the user browses to the favorites page using the webUI
+    Then there should be 1 files/folders listed on the webUI
+    And file "data.zip" should be listed on the webUI
+
+  Scenario: navigate to the favorites page and back to files page using the menu
+    Given the user has browsed to the favorites page using the webUI
+    When the user browses to the files page using the webUI
+    Then there should be 31 files/folders listed on the webUI
 
   @issue-1194
   @skip @yetToImplement

--- a/tests/acceptance/pageObjects/phoenixPage.js
+++ b/tests/acceptance/pageObjects/phoenixPage.js
@@ -30,6 +30,22 @@ module.exports = {
         .click('@coreMenuOpenButton')
         .waitForElementVisible('@coreMenu')
         .waitForAnimationToFinish()
+    },
+    /**
+     * @param {string} page
+     */
+    navigateToUsingMenu: function (page) {
+      const util = require('util')
+      const menuItemSelector = util.format(this.elements.menuItem.selector, page)
+      return this
+        .waitForElementVisible('@menuButton')
+        .click('@menuButton')
+        .useXpath()
+        .waitForElementVisible(menuItemSelector)
+        .click(menuItemSelector)
+        .api.page.FilesPageElement.filesList()
+        .waitForElementPresent({ selector: '@filesListProgressBar', abortOnFailure: false }) // don't fail if we are too late
+        .waitForElementNotPresent('@filesListProgressBar')
     }
   },
   elements: {
@@ -57,6 +73,14 @@ module.exports = {
     },
     coreMenu: {
       selector: '#coreMenu'
+    },
+    menuButton: {
+      selector: '//button[@aria-label="Menu"]',
+      locateStrategy: 'xpath'
+    },
+    menuItem: {
+      selector: '//ul[contains(@class, "oc-main-menu")]/li/a[contains(text(),"%s")]',
+      locateStrategy: 'xpath'
     }
   }
 }

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -22,6 +22,24 @@ Given('the user has browsed to the favorites page', function () {
     .navigateAndWaitTillLoaded()
 })
 
+Given('the user has browsed to the favorites page using the webUI', function () {
+  return client
+    .page.phoenixPage()
+    .navigateToUsingMenu('Favorites')
+})
+
+When('the user browses to the favorites page using the webUI', function () {
+  return client
+    .page.phoenixPage()
+    .navigateToUsingMenu('Favorites')
+})
+
+When('the user browses to the files page using the webUI', function () {
+  return client
+    .page.phoenixPage()
+    .navigateToUsingMenu('All files')
+})
+
 Then('the files table should be displayed',
   () => {
     return client.page.FilesPageElement.filesList()


### PR DESCRIPTION
## Description
Add test for going back to files page after the user has browsed to the favourites page.

## How Has This Been Tested?
🤖

Fixes #1188

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 