### PR TITLE
Fix favoritesPage test failure due to sidebar sliding slow.

### DIFF
--- a/tests/acceptance/pageObjects/phoenixPage.js
+++ b/tests/acceptance/pageObjects/phoenixPage.js
@@ -36,6 +36,7 @@ module.exports = {
         .click('@menuButton')
         .useXpath()
         .waitForElementVisible(menuItemSelector)
+        .waitForAnimationToFinish()
         .click(menuItemSelector)
         .api.page.FilesPageElement.filesList()
         .waitForElementPresent({ selector: '@filesListProgressBar', abortOnFailure: false }) // don't fail if we are too late


### PR DESCRIPTION
Favorites page tests were failing because the test tried to click the sidebar element 
while the sidebar was still sliding.

This PR fixes it to only click on the element after the sliding animation is complete.