### PR TITLE
Moved load folder methods into related components

### DIFF
--- a/apps/files/src/components/FileFilterMenu.vue
+++ b/apps/files/src/components/FileFilterMenu.vue
@@ -11,7 +11,7 @@
         <label for="oc-filter-search" class="uk-text-meta" v-translate>
           Name Filter
         </label>
-        <oc-search-bar id="oc-filter-search" small :type-ahead="true" @search="setFilterTerm" :button="false" />
+        <oc-search-bar id="oc-filter-search" small :type-ahead="true" @search="setFilterTerm" :value="filterTerm" :button="false" />
       </li>
     </ul>
  </oc-drop>
@@ -31,15 +31,7 @@ export default {
     }
   },
   methods: {
-    ...mapActions('Files', ['setFileFilter', 'setFilterTerm']),
-    focusFilenameFilter () {
-      this.$refs.filenameFilter.$el.querySelector('input').focus()
-      // nested vuetify VList animation will block native autofocus, so we use this workaround...
-      setTimeout(() => {
-        // ...to set focus after the element is rendered visible
-        this.$refs.filenameFilter.$el.querySelector('input').focus()
-      }, 50)
-    }
+    ...mapActions('Files', ['setFileFilter', 'setFilterTerm'])
   },
   computed: {
     ...mapGetters('Files', ['fileFilter', 'filterTerm'])

--- a/apps/files/src/components/FileList.vue
+++ b/apps/files/src/components/FileList.vue
@@ -77,7 +77,7 @@
 </template>
 <script>
 import OcDialogPrompt from './ocDialogPrompt.vue'
-import { mapGetters, mapActions } from 'vuex'
+import { mapGetters, mapActions, mapState } from 'vuex'
 
 import Mixins from '../mixins'
 
@@ -95,11 +95,31 @@ export default {
     fileToBeDeleted: '',
     newName: ''
   }),
+  mounted () {
+    this.$_ocFilesFolder_getFolder()
+  },
   methods: {
-    ...mapActions('Files', ['markFavorite', 'resetFileSelection', 'addFileSelection', 'removeFileSelection',
+    ...mapActions('Files', ['loadFolder', 'setFilterTerm', 'markFavorite', 'resetFileSelection', 'addFileSelection', 'removeFileSelection',
       'deleteFiles', 'renameFile', 'setFilesDeleteMessage', 'setHighlightedFile']),
     ...mapActions(['openFile']),
 
+    $_ocFilesFolder_getFolder () {
+      this.setFilterTerm('')
+      let absolutePath
+
+      if (this.configuration.rootFolder) {
+        absolutePath = !this.item ? this.configuration.rootFolder : this.item
+      } else {
+        absolutePath = !this.item ? this.configuration.rootFolder : this.item
+      }
+
+      this.loadFolder({
+        client: this.$client,
+        absolutePath: absolutePath,
+        $gettext: this.$gettext,
+        routeName: this.$route.name
+      })
+    },
     toggleAll () {
       if (this.selectedFiles.length && this.selectedFiles.length === this.fileData.length) {
         this.resetFileSelection()
@@ -164,8 +184,10 @@ export default {
     }
   },
   computed: {
+    ...mapState(['route']),
     ...mapGetters('Files', ['selectedFiles', 'atSearchPage', 'loadingFolder', 'filesDeleteMessage', 'highlightedFile']),
-    ...mapGetters(['getToken', 'fileSideBars', 'capabilities']),
+    ...mapGetters(['getToken', 'fileSideBars', 'capabilities', 'configuration']),
+
     all () {
       return this.selectedFiles.length === this.fileData.length && this.fileData.length !== 0
     },
@@ -224,6 +246,14 @@ export default {
     },
     $_ocDialog_isOpen () {
       return this.changeFileName
+    },
+    item () {
+      return this.$route.params.item
+    }
+  },
+  watch: {
+    item () {
+      this.$_ocFilesFolder_getFolder()
     }
   }
 }

--- a/apps/files/src/components/FilesApp.vue
+++ b/apps/files/src/components/FilesApp.vue
@@ -5,13 +5,13 @@
         <div class="uk-width-expand uk-overflow-auto uk-height-1-1" @dragover="$_ocApp_dragOver" :class="{ 'uk-visible@m' : _sidebarOpen }">
           <oc-loader id="files-list-progress" v-if="loadingFolder"></oc-loader>
           <trashbin v-if="$route.name === 'files-trashbin'" :fileData="activeFiles" />
-          <file-list v-else @toggle="toggleFileSelect" @FileAction="openFileActionBar" :fileData="activeFiles" @sideBarOpen="openSideBar"/>
+          <file-list v-else @toggle="toggleFileSelect" @FileAction="openFileActionBar" :fileData="activeFiles" @sideBarOpen="openSideBar" />
         </div>
         <div class="uk-width-1-1 uk-width-1-2@m uk-width-1-3@xl uk-height-1-1" v-if="_sidebarOpen && $route.name !== 'files-trashbin'">
-          <file-details ref="fileDetails" @reload="$_ocFilesFolder_getFolder" @reset="setHighlightedFile(null)"/>
+          <file-details ref="fileDetails" @reset="setHighlightedFile(null)"/>
         </div>
-      <oc-file-actions></oc-file-actions>
     </oc-grid>
+    <oc-file-actions />
   </div>
 </template>
 <script>
@@ -20,7 +20,7 @@ import FileDetails from './FileDetails.vue'
 import FilesAppBar from './FilesAppBar.vue'
 import FileList from './FileList.vue'
 import Trashbin from './Trashbin.vue'
-import { mapActions, mapGetters, mapState } from 'vuex'
+import { mapActions, mapGetters } from 'vuex'
 
 export default {
   mixins: [
@@ -40,22 +40,12 @@ export default {
       upload: false,
       fileName: '',
       selected: [],
-      fileFilterQuery: '',
       breadcrumbs: [],
       self: {}
     }
   },
-  mounted () {
-    if (this.$route.name === 'files-trashbin') {
-      this.$_ocTrashbin_getFiles()
-    } else {
-      this.$_ocFilesFolder_getFolder()
-    }
-  },
   methods: {
-    ...mapActions('Files', ['resetFileSelection', 'addFileSelection', 'removeFileSelection', 'loadFiles',
-      'markFavorite', 'addFiles', 'updateFileProgress', 'resetSearch', 'dragOver', 'loadFolder', 'loadTrashbin',
-      'setHighlightedFile']),
+    ...mapActions('Files', ['resetFileSelection', 'addFileSelection', 'removeFileSelection', 'dragOver', 'setHighlightedFile', 'toggleFileSelect']),
     ...mapActions(['openFile', 'showMessage']),
 
     trace () {
@@ -114,59 +104,18 @@ export default {
       })
     },
 
-    focusFilenameFilter () {
-      this.$refs.filenameFilter.$el.querySelector('input').focus()
-      // nested vuetify VList animation will block native autofocus, so we use this workaround...
-      setTimeout(() => {
-        // ...to set focus after the element is rendered visible
-        this.$refs.filenameFilter.$el.querySelector('input').focus()
-      }, 50)
-    },
-    $_ocFilesFolder_getFolder () {
-      // clear file filter search query when folder changes
-      this.fileFilterQuery = ''
-
-      let absolutePath = this.$route.params.item === '' || this.$route.params.item === undefined ? this.configuration.rootFolder : this.route.params.item
-
-      this.loadFolder({
-        client: this.$client,
-        absolutePath: absolutePath,
-        $gettext: this.$gettext,
-        routeName: this.$route.name
-      })
-    },
-    $_ocTrashbin_getFiles () {
-      this.fileFilterQuery = ''
-
-      this.loadTrashbin({
-        client: this.$client,
-        $gettext: this.$gettext
-      })
-    },
     $_ocApp_dragOver () {
       this.dragOver(true)
-    }
-  },
-
-  watch: {
-    item () {
-      if (this.$route.name === 'files-trashbin') return
-      this.$_ocFilesFolder_getFolder()
     },
-    $route (to, from) {
-      if (to.name === 'files-trashbin') this.$_ocTrashbin_getFiles()
+
+    $_ocAppSideBar_onReload () {
+      this.$refs.filesList.$_ocFilesFolder_getFolder()
     }
   },
 
   computed: {
-    ...mapState(['route']),
-    ...mapGetters('Files', ['selectedFiles', 'inProgress', 'activeFiles', 'fileFilter', 'davProperties', 'searchTerm',
-      'dropzone', 'loadingFolder', 'highlightedFile']),
-    ...mapGetters(['getToken', 'extensions', 'configuration']),
-
-    item () {
-      return this.$route.params.item
-    },
+    ...mapGetters('Files', ['selectedFiles', 'activeFiles', 'dropzone', 'loadingFolder', 'highlightedFile']),
+    ...mapGetters(['extensions']),
 
     _sidebarOpen () {
       return this.highlightedFile !== null

--- a/apps/files/src/components/Trashbin.vue
+++ b/apps/files/src/components/Trashbin.vue
@@ -58,6 +58,10 @@ export default {
     Mixins
   ],
 
+  mounted () {
+    this.$_ocTrashbin_getFiles()
+  },
+
   computed: {
     ...mapGetters('Files', ['loadingFolder', 'selectedFiles', 'trashbinDeleteMessage']),
 
@@ -80,9 +84,16 @@ export default {
   },
 
   methods: {
-    ...mapActions('Files', ['loadTrashbin', 'addFileSelection', 'removeFileSelection', 'resetFileSelection', 'setTrashbinDeleteMessage', 'removeFilesFromTrashbin']),
+    ...mapActions('Files', ['loadTrashbin', 'addFileSelection', 'removeFileSelection', 'resetFileSelection', 'setTrashbinDeleteMessage', 'removeFilesFromTrashbin', 'setFilterTerm']),
     ...mapActions(['showMessage']),
 
+    $_ocTrashbin_getFiles () {
+      this.setFilterTerm('')
+      this.loadTrashbin({
+        client: this.$client,
+        $gettext: this.$gettext
+      })
+    },
     $_ocTrashbin_deleteFile (item) {
       this.resetFileSelection()
       this.addFileSelection(item)

--- a/tests/acceptance/pageObjects/phoenixPage.js
+++ b/tests/acceptance/pageObjects/phoenixPage.js
@@ -73,7 +73,7 @@ module.exports = {
       locateStrategy: 'xpath'
     },
     searchInputFieldLowResolution: {
-      selector: '(//input[contains(@class, "oc-search-input")])[3]',
+      selector: '(//input[contains(@class, "oc-search-input")])[2]',
       locateStrategy: 'xpath'
     },
     searchLoadingIndicator: {


### PR DESCRIPTION
## Description
Moved load folder and load trashbin methods to its related components to prevent issues caused by its placement in FilesApp and to get rid of conditions to decide which should be used.

## Related issues
- Fixes #1410 

## Motivation and Context
Less bugs, cleaner code.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [x] Fix dropdowns
- [ ] Fix width of search on smaller screens (damn uk-width gives it max-width 😞 )