### PR TITLE
Fixed name of alerts in store

### DIFF
--- a/src/store/app.js
+++ b/src/store/app.js
@@ -70,8 +70,7 @@ const mutations = {
     state.messages.push(message)
   },
   REMOVE_MESSAGE (state, item) {
-    let index = state.notifications.indexOf(item)
-    state.notifications.splice(index, 1)
+    state.messages.splice(state.messages.indexOf(item), 1)
   },
   LOADING_NOTIFICATIONS (state, loading) {
     state.notifications.loading = loading


### PR DESCRIPTION
## Description
Replaced notifications name in messages in app store to messages.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 