### PR TITLE
Autofocus in oc-dialog

### DIFF
--- a/apps/files/src/components/ocDialogPrompt.vue
+++ b/apps/files/src/components/ocDialogPrompt.vue
@@ -19,6 +19,8 @@
         <oc-button :disabled="ocLoading" @click="onCancel">{{ _ocCancelText }}</oc-button>
         <oc-button :disabled="ocLoading || ocError || inputValue === ''"
                :id="ocConfirmId"
+               ref="confirmButton"
+               :autofocus="!ocHasInput"
                @click="onConfirm">{{ _ocConfirmText }}</oc-button>
     </template>
   </oc-dialog>
@@ -62,9 +64,14 @@ export default {
     },
     ocActive (isActive) {
       this.inputValue = this.value
+
       this.$nextTick().then(() => {
-        if (isActive && this.ocHasInput) {
-          this.$refs.input.focus()
+        if (isActive) {
+          if (this.ocHasInput) {
+            this.$refs.input.$el.focus()
+            return
+          }
+          this.$refs.confirmButton.$el.focus()
         }
       })
     }


### PR DESCRIPTION
## Description
Added focus on confirm button in dialog if there is no input available.

## Motivation and Context
User can now confirm dialog by hitting enter.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 