### PR TITLE
Unfavourite files with same names in favourites page

### DIFF
--- a/apps/files/src/store/mutations.js
+++ b/apps/files/src/store/mutations.js
@@ -44,7 +44,7 @@ export default {
   },
   FAVORITE_FILE (state, item) {
     let fileIndex = state.files.findIndex((f) => {
-      return f.name === item.name
+      return f.id === item.id
     })
     state.files[fileIndex].starred = !item.starred
   },


### PR DESCRIPTION
## Description
Find index of file by id and not by name to prevent wrong files to be found in case they have same name.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #1385

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 