### PR TITLE
remember created users

### DIFF
--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -238,7 +238,6 @@ Feature: Sharing files and folders with internal users
   Scenario: user shares the file/folder with another internal user and delete the share with user
     Given user "user1" has logged in using the webUI
     And user "user1" has shared file "lorem.txt" with user "user2"
-    And user "user1" has shared file "lorem.txt" with user "user3"
     When the user opens the share dialog for file "lorem.txt"
     Then "User Two" should be listed in the shared with list
     And as "user2" file "lorem (2).txt" should exist

--- a/tests/acceptance/helpers/httpHelper.js
+++ b/tests/acceptance/helpers/httpHelper.js
@@ -7,7 +7,7 @@ const userSettings = require('../helpers/userSettings')
  * @returns {string}
  */
 exports.createAuthHeader = function (userId) {
-  const password = userSettings.getActualPassword(userId)
+  const password = userSettings.getPasswordForUser(userId)
   return {
     'Authorization': 'Basic ' +
       Buffer.from(userId + ':' + password).toString('base64')

--- a/tests/acceptance/helpers/userSettings.js
+++ b/tests/acceptance/helpers/userSettings.js
@@ -158,5 +158,12 @@ module.exports = {
     } else {
       return null
     }
+  },
+  /**
+   *
+   * @returns {module.exports.createdUsers|{}}
+   */
+  getCreatedUsers: function () {
+    return this.createdUsers
   }
 }

--- a/tests/acceptance/helpers/userSettings.js
+++ b/tests/acceptance/helpers/userSettings.js
@@ -54,24 +54,68 @@ module.exports = {
       email: 'sharee1@example.org'
     }
   },
+  createdUsers: {},
+
   /**
+   *
+   * @param {string} userId
+   * @param {string} password
+   * @param {string} displayname
+   * @param {string} email
+   */
+  addUserToCreatedUsersList: function (userId, password, displayname = null, email = null) {
+    this.createdUsers[userId] = { password: password, displayname: displayname, email: email }
+  },
+
+  /**
+   * gets the password of a previously created user
+   * if the user was not created yet, gets the password from the default Users list
+   * if the user is not in that list either, returns the userId as password
    *
    * @param {string} userId
    * @returns {string}
    */
   getPasswordForUser: function (userId) {
-    if (userId in this.defaultUsers) {
+    if (userId in this.createdUsers) {
+      return this.createdUsers[userId].password
+    } else if (userId in this.defaultUsers) {
       return this.defaultUsers[userId].password
     } else {
-      return this.defaultUsers.regularuser.password
+      // user was not created yet and is not in the default users list, let the userId be the password
+      return userId
     }
   },
   /**
+   * gets the display name of a previously created user
+   * if the user was not created yet, gets the display name from the default Users list
+   * if the user is not in that list either, returns the userId as display name
+   *
+   * @param {string} userId
+   * @returns {string}
+   */
+  getDisplayNameForUser: function (userId) {
+    let user = {}
+    if (userId in this.createdUsers) {
+      user = this.createdUsers[userId]
+    } else if (userId in this.defaultUsers) {
+      user = this.defaultUsers[userId]
+    } else {
+      return userId
+    }
+    if ('displayname' in user && user.displayname !== null) {
+      return user.displayname
+    } else {
+      return userId
+    }
+  },
+  /**
+   * gets the display name of the specified user from the default users list
+   * returns null if the user is not in that list
    *
    * @param {string} userId
    * @returns {null|string}
    */
-  getDisplayNameForUser: function (userId) {
+  getDisplayNameOfDefaultUser: function (userId) {
     if (userId in this.defaultUsers) {
       return this.defaultUsers[userId].displayname
     } else {
@@ -79,27 +123,40 @@ module.exports = {
     }
   },
   /**
+   * gets the email address of a previously created user
+   * if the user was not created yet, gets the email address from the default Users list
+   * if the user is not in that list either, returns null
    *
    * @param {string} userId
    * @returns {null|string}
    */
   getEmailAddressForUser: function (userId) {
-    if (userId in this.defaultUsers) {
-      return this.defaultUsers[userId].email
+    let user = {}
+    if (userId in this.createdUsers) {
+      user = this.createdUsers[userId]
+    } else if (userId in this.defaultUsers) {
+      user = this.defaultUsers[userId]
+    } else {
+      return null
+    }
+    if ('email' in user && user.email !== null) {
+      return user.email
     } else {
       return null
     }
   },
   /**
+   * gets the email address of the specified user from the default users list
+   * returns null if the user is not in that list
    *
    * @param {string} userId
-   * @returns {string}
+   * @returns {null|string}
    */
-  getActualPassword: function (userId) {
+  getEmailAddressOfDefaultUser: function (userId) {
     if (userId in this.defaultUsers) {
-      return this.defaultUsers[userId].password
+      return this.defaultUsers[userId].email
     } else {
-      return userId
+      return null
     }
   }
 }

--- a/tests/acceptance/stepDefinitions/loginContext.js
+++ b/tests/acceptance/stepDefinitions/loginContext.js
@@ -46,7 +46,6 @@ const loginAsUser = function (userId) {
     .page.FilesPageElement.filesList()
     .waitForElementVisible('@filesTable')
     .then(() => {
-      client.globals.currentUserName = userSettings.getDisplayNameForUser(userId)
       client.globals.currentUser = userId
     })
 }

--- a/tests/acceptance/stepDefinitions/loginContext.js
+++ b/tests/acceptance/stepDefinitions/loginContext.js
@@ -13,7 +13,7 @@ const loginAsUser = function (userId) {
     .waitForElementVisible('@authenticateButton')
     .click('@authenticateButton')
 
-  const password = userSettings.getActualPassword(userId)
+  const password = userSettings.getPasswordForUser(userId)
   // Then the user logs in with username {string} and password {string} using the webUi
   const ocLoginPage = client.page.ownCloudLoginPage()
   ocLoginPage
@@ -46,7 +46,7 @@ const loginAsUser = function (userId) {
     .page.FilesPageElement.filesList()
     .waitForElementVisible('@filesTable')
     .then(() => {
-      client.globals.currentUserName = userSettings.getDisplayNameForUser()
+      client.globals.currentUserName = userSettings.getDisplayNameForUser(userId)
       client.globals.currentUser = userId
     })
 }

--- a/tests/acceptance/stepDefinitions/provisioningContext.js
+++ b/tests/acceptance/stepDefinitions/provisioningContext.js
@@ -1,5 +1,5 @@
 const { client } = require('nightwatch-api')
-const { Given } = require('cucumber')
+const { Given, After } = require('cucumber')
 const fetch = require('node-fetch')
 require('url-search-params-polyfill')
 const httpHelper = require('../helpers/httpHelper')
@@ -146,4 +146,10 @@ Given('these groups have been created:', function (dataTable) {
 
 Given('user {string} has been added to group {string}', function (userId, groupId) {
   return addToGroup(userId, groupId)
+})
+
+After(function () {
+  for (var userId in userSettings.getCreatedUsers()) {
+    deleteUser(userId)
+  }
 })

--- a/tests/acceptance/stepDefinitions/provisioningContext.js
+++ b/tests/acceptance/stepDefinitions/provisioningContext.js
@@ -10,9 +10,9 @@ function createDefaultUser (userId) {
   return new Promise((resolve, reject) => {
     createUser(userId, password)
       .then(() => {
-        const displayname = userSettings.getDisplayNameForUser(userId)
-        const email = userSettings.getEmailAddressForUser(userId)
-
+        const displayname = userSettings.getDisplayNameOfDefaultUser(userId)
+        const email = userSettings.getEmailAddressOfDefaultUser(userId)
+        userSettings.addUserToCreatedUsersList(userId, password, displayname, email)
         const body = new URLSearchParams()
         body.append('key', 'display')
         body.append('value', displayname)
@@ -47,10 +47,11 @@ function createDefaultUser (userId) {
 
 function createUser (userId, password = false) {
   const body = new URLSearchParams()
-  const userPassword = password || userId
+  const userPassword = password || userSettings.getPasswordForUser(userId)
   body.append('userid', userId)
   body.append('password', userPassword)
 
+  userSettings.addUserToCreatedUsersList(userId, userPassword)
   const headers = httpHelper.createAuthHeader(client.globals.backend_admin_username)
   return fetch(client.globals.backend_url + '/ocs/v2.php/cloud/users?format=json', { method: 'POST', body: body, headers: headers })
 }

--- a/tests/acceptance/stepDefinitions/provisioningContext.js
+++ b/tests/acceptance/stepDefinitions/provisioningContext.js
@@ -12,6 +12,8 @@ function createDefaultUser (userId) {
       .then(() => {
         const displayname = userSettings.getDisplayNameOfDefaultUser(userId)
         const email = userSettings.getEmailAddressOfDefaultUser(userId)
+
+        // update displayname and email in the created users list
         userSettings.addUserToCreatedUsersList(userId, password, displayname, email)
         const body = new URLSearchParams()
         body.append('key', 'display')

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -5,6 +5,7 @@ const assert = require('assert')
 const { URLSearchParams } = require('url')
 require('url-search-params-polyfill')
 const httpHelper = require('../helpers/httpHelper')
+const userSettings = require('../helpers/userSettings')
 
 /**
  *
@@ -99,15 +100,14 @@ Then('all users and groups that contain the string {string} in their name should
 })
 
 Then('the users own name should not be listed in the autocomplete list on the webUI', function () {
-  // TODO: where to get the current user from
-  const currentUserName = client.globals.currentUserName
+  const currentUserDisplayName = userSettings.getDisplayNameForUser(client.globals.currentUser)
   return client.page.FilesPageElement.sharingDialog().getShareAutocompleteItemsList()
     .then(itemsList => {
       itemsList.forEach(item => {
         assert.notStrictEqual(
           item,
-          currentUserName,
-          `Users own name: ${currentUserName} was not expected to be listed in the autocomplete list but was`
+          currentUserDisplayName,
+          `Users own name: ${currentUserDisplayName} was not expected to be listed in the autocomplete list but was`
         )
       })
     })


### PR DESCRIPTION
## Description
1. remember users that have been created during the test run in a separate table. When information about users that are expected to exist are required use the data from that new table.
    When general information about a specific user is required, but the user is not created yet, fall back to the information from the general users table
2.  delete users that have been created during a test-run after the test
3. delete a test step that refereed to an non-existing user. This test used to pass because the user was created in some other scenario, but now users get deleted after every scenario, so the test could not share with that user. But that step is also not needed for that particular test
4. retrieve the display name of the current user on the go without using unnecessary global variables

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #1471
- Fixes #1472 

## Motivation and Context
improve testing, get rid of :snake: :oil_drum: 

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...