### PR TITLE
Do not import root config in files app - this bundles not properly tr…

### DIFF
--- a/apps/files/src/components/FilesApp.vue
+++ b/apps/files/src/components/FilesApp.vue
@@ -141,13 +141,7 @@ export default {
       // clear file filter search query when folder changes
       this.fileFilterQuery = ''
 
-      let absolutePath
-
-      if (this.configuration.rootFolder) {
-        absolutePath = this.$route.params.item === '' ? this.configuration.rootFolder : this.route.params.item
-      } else {
-        absolutePath = this.$route.params.item === '' ? this.configuration.rootFolder : this.route.params.item
-      }
+      let absolutePath = this.$route.params.item === '' || this.$route.params.item === undefined ? this.configuration.rootFolder : this.route.params.item
 
       this.loadFolder({
         client: this.$client,

--- a/apps/files/src/components/FilesAppBar.vue
+++ b/apps/files/src/components/FilesAppBar.vue
@@ -186,13 +186,7 @@ export default {
     $_ocFilesFolder_getFolder () {
       this.path = []
 
-      let absolutePath
-
-      if (this.configuration.rootFolder) {
-        absolutePath = this.$route.params.item === '' ? this.configuration.rootFolder : this.route.params.item
-      } else {
-        absolutePath = this.$route.params.item === '' ? this.configuration.rootFolder : this.route.params.item
-      }
+      let absolutePath = this.$route.params.item === '' || this.$route.params.item === undefined ? this.configuration.rootFolder : this.route.params.item
 
       this.loadFolder({
         client: this.$client,

--- a/apps/files/src/default.js
+++ b/apps/files/src/default.js
@@ -7,7 +7,6 @@ import FileSharingSidebar from './components/FileSharingSidebar.vue'
 import translationsJson from '../l10n/translations.json'
 
 const store = require('./store')
-const rootStore = require('./../../../src/store')
 
 const appInfo = {
   name: 'Files',
@@ -40,7 +39,7 @@ const navItems = [
       name: 'files-list',
       path: `/`,
       params: {
-        item: rootStore.Store.getters.configuration.rootFolder
+        item: ''
       }
     }
   },
@@ -68,7 +67,7 @@ const navItems = [
 const routes = [
   {
     path: '',
-    redirect: `/${appInfo.id}/list/${rootStore.Store.getters.configuration.rootFolder}`,
+    redirect: `/${appInfo.id}/list/`,
     components: {
       app: FilesApp
     }

--- a/src/store/config.js
+++ b/src/store/config.js
@@ -50,7 +50,7 @@ const mutations = {
     state.server = config.server
     state.auth = config.auth
     state.openIdConnect = config.openIdConnect
-    state.rootFolder = config.rootFolder
+    state.rootFolder = config.rootFolder === undefined ? '/' : config.rootFolder
     state.state = config.state === undefined ? 'working' : config.state
     if (config.corrupted) state.corrupted = config.corrupted
   },


### PR DESCRIPTION
…anspiled code into the files app and break IE11

## Description
By importing the root store into the files app webpack had to bundle some dependencies from root to the files app - like vue-persist, which needs special handling with respect to transpiling.
The file app had the transpiling options not properly setup.

This PR now removes the import of the root store and as side effect fixed IE11.

We should be more careful in the future to not import any code from outside of an app.

## How Has This Been Tested?
- :hand: with rootFolder set to 'foo'
- :hand: without rootFolder being set

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...