### PR TITLE
Set disableHostCheck: true to allow any host in requests - helps to t…

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -20,8 +20,9 @@ module.exports = merge(common, {
     compress: true,
     host: '0.0.0.0',
     port: 8300,
+    disableHostCheck: true,
     watchOptions: {
-      ignored: path.resolve(__dirname, 'tests'),
+      ignored: path.resolve(__dirname, 'tests')
     }
   }
 })


### PR DESCRIPTION
…est the same setup from different locations (localhost, from docker via the host ip, from a VM/different machine with the hostname)

## Description
It is rather boring to restart yarn watch with a different server host name just because one is using a different client. 
Two different use cases I have at the same time:
- phoenix shall be accessible via the hostname for local testing as well as from a VM or another device
- phoenix shall be accessible via the docker host ip in case of acceptance testing with selenium in a docker

changing the host always requires restarting of yarn watch and changing the oauth client redirect url in owncloud

With disableHostCheck: true the dev server is accessible via any hostname. 

## Motivation and Context
Easier dev

## How Has This Been Tested?
- :hand: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...