### PR TITLE
improve sharing autocomplete tests

### DIFF
--- a/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
@@ -33,7 +33,8 @@ Feature: Autocompletion of share-with names
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "us" in the share-with-field
     Then all users and groups that contain the string "us" in their name should be listed in the autocomplete list on the webUI
-    And the users own name should not be listed in the autocomplete list on the webUI
+    And every item listed in the autocomplete list on the webUI should contain "us"
+    But the users own name should not be listed in the autocomplete list on the webUI
 
   @smokeTest
   Scenario: autocompletion of regular existing groups
@@ -42,7 +43,8 @@ Feature: Autocompletion of share-with names
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "fi" in the share-with-field
     Then all users and groups that contain the string "fi" in their name should be listed in the autocomplete list on the webUI
-    And the users own name should not be listed in the autocomplete list on the webUI
+    And every item listed in the autocomplete list on the webUI should contain "fi"
+    But the users own name should not be listed in the autocomplete list on the webUI
 
   @skip @yetToImplement
   Scenario: autocompletion for a pattern that does not match any user or group

--- a/tests/acceptance/helpers/userSettings.js
+++ b/tests/acceptance/helpers/userSettings.js
@@ -67,7 +67,13 @@ module.exports = {
   addUserToCreatedUsersList: function (userId, password, displayname = null, email = null) {
     this.createdUsers[userId] = { password: password, displayname: displayname, email: email }
   },
-
+  /**
+   *
+   * @param {string} userId
+   */
+  deleteUserFromCreatedUsersList: function (userId) {
+    delete this.createdUsers[userId]
+  },
   /**
    *
    * @param {string} groupId

--- a/tests/acceptance/helpers/userSettings.js
+++ b/tests/acceptance/helpers/userSettings.js
@@ -55,6 +55,7 @@ module.exports = {
     }
   },
   createdUsers: {},
+  createdGroups: [],
 
   /**
    *
@@ -67,6 +68,20 @@ module.exports = {
     this.createdUsers[userId] = { password: password, displayname: displayname, email: email }
   },
 
+  /**
+   *
+   * @param {string} groupId
+   */
+  addGroupToCreatedGroupsList: function (groupId) {
+    this.createdGroups.push(groupId)
+  },
+  /**
+   *
+   * @param {string} userId
+   */
+  deleteGroupFromCreatedGroupsList: function (groupId) {
+    this.createdGroups = this.createdGroups.filter(item => item !== groupId)
+  },
   /**
    * gets the password of a previously created user
    * if the user was not created yet, gets the password from the default Users list
@@ -165,5 +180,12 @@ module.exports = {
    */
   getCreatedUsers: function () {
     return this.createdUsers
+  },
+  /**
+   *
+   * @returns {Array}
+   */
+  getCreatedGroups: function () {
+    return this.createdGroups
   }
 }

--- a/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
@@ -117,6 +117,9 @@ module.exports = {
           })
         })
         .then(() => shareList)
+    },
+    getGroupSharePostfix: function () {
+      return groupSharePostfix
     }
   },
   elements: {

--- a/tests/acceptance/stepDefinitions/provisioningContext.js
+++ b/tests/acceptance/stepDefinitions/provisioningContext.js
@@ -68,17 +68,28 @@ function initUser (userId) {
   return fetch(client.globals.backend_url + '/ocs/v2.php/cloud/users/' + userId, { method: 'GET', headers: headers })
 }
 
+/**
+ *
+ * @param {string} groupId
+ * @returns {*|Promise}
+ */
 function createGroup (groupId) {
   const body = new URLSearchParams()
   body.append('groupid', groupId)
-
+  userSettings.addGroupToCreatedGroupsList(groupId)
   const headers = httpHelper.createAuthHeader(client.globals.backend_admin_username)
   return fetch(client.globals.backend_url + '/ocs/v2.php/cloud/groups?format=json', { method: 'POST', body: body, headers: headers })
 }
 
+/**
+ *
+ * @param {string} groupId
+ * @returns {*|Promise}
+ */
 function deleteGroup (groupId) {
   const headers = httpHelper.createAuthHeader(client.globals.backend_admin_username)
-  return fetch(client.globals.backend_url + '/ocs/v2.php/cloud/groups/' + groupId, { method: 'POST', headers: headers })
+  userSettings.deleteGroupFromCreatedGroupsList(groupId)
+  return fetch(client.globals.backend_url + '/ocs/v2.php/cloud/groups/' + groupId, { method: 'DELETE', headers: headers })
 }
 function addToGroup (userId, groupId) {
   const body = new URLSearchParams()
@@ -135,14 +146,14 @@ Given('these users have been created with default attributes:', function (dataTa
 })
 
 Given('group {string} has been created', function (groupId) {
-  return deleteGroup(groupId)
-    .then(() => createGroup(groupId))
+  return deleteGroup(groupId.toString())
+    .then(() => createGroup(groupId.toString()))
 })
 
 Given('these groups have been created:', function (dataTable) {
   return Promise.all(dataTable.rows().map((groupId) => {
-    return deleteGroup(groupId)
-      .then(() => createGroup(groupId))
+    return deleteGroup(groupId.toString())
+      .then(() => createGroup(groupId.toString()))
   }))
 })
 
@@ -154,4 +165,7 @@ After(function () {
   for (var userId in userSettings.getCreatedUsers()) {
     deleteUser(userId)
   }
+  userSettings.getCreatedGroups().forEach(function (groupId) {
+    deleteGroup(groupId)
+  })
 })

--- a/tests/acceptance/stepDefinitions/provisioningContext.js
+++ b/tests/acceptance/stepDefinitions/provisioningContext.js
@@ -60,6 +60,7 @@ function createUser (userId, password = false) {
 
 function deleteUser (userId) {
   const headers = httpHelper.createAuthHeader(client.globals.backend_admin_username)
+  userSettings.deleteUserFromCreatedUsersList(userId)
   return fetch(client.globals.backend_url + '/ocs/v2.php/cloud/users/' + userId, { method: 'DELETE', headers: headers })
 }
 


### PR DESCRIPTION
## Description
1. remember created groups
2. delete groups with `DELETE` not `POST` :see_no_evil: 
3. make the step `Then all users and groups that contain the string {string} in their name should be listed in the autocomplete list on the webUI` check if all users and groups, that are expected to be in the list, are in the list

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #1473

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...