### PR TITLE
Use oids from git because of latest bugfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "nightwatch-api": "^2.3.0",
     "node-fetch": "^2.6.0",
     "npm-run-all": "^4.1.5",
-    "oidc-client": "^1.8.2",
+    "oidc-client": "https://github.com/IdentityModel/oidc-client-js#35d7c79bf64ed5e89d8a41adf0e4a8a1c3d843c5",
     "owncloud-design-system": "^1.0.0-834",
     "owncloud-sdk": "1.0.0-232",
     "parse-json": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6105,10 +6105,9 @@ obuf@^1.0.0, obuf@^1.1.2:
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
   integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
 
-oidc-client@^1.8.2:
+"oidc-client@https://github.com/IdentityModel/oidc-client-js#35d7c79bf64ed5e89d8a41adf0e4a8a1c3d843c5":
   version "1.8.2"
-  resolved "https://registry.yarnpkg.com/oidc-client/-/oidc-client-1.8.2.tgz#5a73c33858fe0e25489fdc6de31c8ce3075f6e0b"
-  integrity sha512-WwoSY8S6QyNN3qpne88YurjNqjTf6z1Xr0y+OrFVvdnVPYcefkTtXlZ5iOwR2JrmP4vBuq2j8eTjUJyDZFrFNQ==
+  resolved "https://github.com/IdentityModel/oidc-client-js#35d7c79bf64ed5e89d8a41adf0e4a8a1c3d843c5"
   dependencies:
     uuid "^3.3.2"
 


### PR DESCRIPTION
## Description

because of https://github.com/IdentityModel/oidc-client-js/pull/898 we switch temporary to git version of oidc client