### PR TITLE
Added limit for messages and transition

### DIFF
--- a/src/components/MessageBar.vue
+++ b/src/components/MessageBar.vue
@@ -1,13 +1,15 @@
 <template>
   <oc-notifications>
-    <oc-notification-message
-            v-for="(item, index) in activeMessages"
-            :key="index"
+    <transition-group name="oc-alerts-transition" tag="div">
+      <oc-notification-message
+            v-for="item in $_ocMessages_limited"
+            :key="item.id"
             :title="item.title"
             :message="item.desc"
             :status="item.status"
             @close="deleteMessage(item)"
     />
+    </transition-group>
   </oc-notifications>
 </template>
 
@@ -16,10 +18,14 @@ import { mapGetters, mapActions } from 'vuex'
 
 export default {
   methods: {
-    ...mapActions(['showMessage', 'deleteMessage'])
+    ...mapActions(['deleteMessage'])
   },
   computed: {
-    ...mapGetters(['activeMessages'])
+    ...mapGetters(['activeMessages']),
+
+    $_ocMessages_limited () {
+      return this.activeMessages ? this.activeMessages.slice(0, 5) : []
+    }
   }
 }
 </script>


### PR DESCRIPTION
## Description
Added limit to messages to display maximum 5 at once and transition (needs https://github.com/owncloud/owncloud-design-system/pull/419 to work).

## Motivation and Context
Not spamming users whole 🖥 with messages.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 