### PR TITLE
Fixed cancel action of overwrite dialog

### DIFF
--- a/apps/files/src/components/FilesAppBar.vue
+++ b/apps/files/src/components/FilesAppBar.vue
@@ -53,7 +53,7 @@
         </oc-drop>
       </div>
     </oc-grid>
-    <oc-dialog-prompt name="overwrite-dialog" :oc-active="overwriteDialogMessage !== null" :oc-has-input="false" ocConfirmId="overwrite-ok" :ocTitle="overwriteDialogTitle" :oc-content="overwriteDialogMessage" @oc-confirm="$_ocUpload_confirmOverwrite(true)" @oc-cancel="$_ocUpload_confirmOverwrite(false)" />
+    <oc-dialog-prompt name="overwrite-dialog" :oc-active="overwriteDialogMessage !== null" :oc-has-input="false" ocCancelId="files-overwrite-cancel" ocConfirmId="files-overwrite-confirm" :ocTitle="overwriteDialogTitle" :oc-content="overwriteDialogMessage" @oc-confirm="$_ocUpload_confirmOverwrite(true)" @oc-cancel="$_ocUpload_confirmOverwrite(false)" />
     <oc-dialog-prompt name="new-folder-dialog" :oc-active="createFolder" v-model="newFolderName" ocInputId="new-folder-input" ocConfirmId="new-folder-ok" :ocLoading="fileFolderCreationLoading" :ocError="newFolderErrorMessage" :ocTitle="_createFolderDialogTitle" @oc-confirm="addNewFolder" @oc-cancel="createFolder = false; newFolderName = ''"></oc-dialog-prompt>
     <oc-dialog-prompt name="new-file-dialog" :oc-active="createFile" v-model="newFileName" :ocLoading="fileFolderCreationLoading" :ocError="newFileErrorMessage" :ocTitle="_createFileDialogTitle" @oc-confirm="addNewFile" @oc-cancel="createFile = false; newFileName = ''"></oc-dialog-prompt>
   </div>

--- a/apps/files/src/components/ocDialogPrompt.vue
+++ b/apps/files/src/components/ocDialogPrompt.vue
@@ -16,7 +16,7 @@
       <oc-loader v-if="ocLoading"></oc-loader>
     </template>
     <template slot="footer">
-        <oc-button :disabled="ocLoading" @click.stop="onCancel">{{ _ocCancelText }}</oc-button>
+        <oc-button :id="ocCancelId" :disabled="ocLoading" @click.stop="onCancel">{{ _ocCancelText }}</oc-button>
         <oc-button :disabled="ocLoading || ocError || inputValue === ''"
                :id="ocConfirmId"
                ref="confirmButton"
@@ -42,6 +42,7 @@ export default {
     ocContent: String,
     ocError: String,
     ocLoading: { type: Boolean, default: false },
+    ocCancelId: String,
     ocConfirmId: String,
     ocConfirmText: {
       type: String,

--- a/apps/files/src/mixins.js
+++ b/apps/files/src/mixins.js
@@ -239,18 +239,24 @@ export default {
     async $_ocUpload_addFileToQue (e) {
       const files = e.target.files
       if (!files.length) return
-      for (const file of files) {
-        const exists = this.checkIfElementExists(file)
+      for (let i = 0; i < files.length; i++) {
+        const exists = this.checkIfElementExists(files[i])
         if (!exists) {
-          this.$_ocUpload(file, file.name)
+          this.$_ocUpload(files[i], files[i].name)
+          if ((i + 1) === files.length) this.$_ocUploadInput_clean()
           continue
         }
 
         const translated = this.$gettext('File %{file} already exists.')
-        this.setOverwriteDialogTitle(this.$gettextInterpolate(translated, { file: file.name }, true))
+        this.setOverwriteDialogTitle(this.$gettextInterpolate(translated, { file: files[i].name }, true))
         this.setOverwriteDialogMessage(this.$gettext('Do you want to overwrite it?'))
         const overwrite = await this.$_ocUpload_confirmOverwrite()
-        if (overwrite) this.$_ocUpload(file, file.name, exists.etag)
+        if (overwrite === true) {
+          this.$_ocUpload(files[i], files[i].name, exists.etag)
+          if ((i + 1) === files.length) this.$_ocUploadInput_clean()
+        } else {
+          if ((i + 1) === files.length) this.$_ocUploadInput_clean()
+        }
         this.setOverwriteDialogMessage(null)
       }
     },
@@ -301,15 +307,20 @@ export default {
           // once all files are uploaded we emit the success event
           Promise.all(uploadPromises).then(() => {
             this.$emit('success', null, rootDir)
+            this.$_ocUploadInput_clean()
           })
         })
       }
     },
     $_ocUpload_confirmOverwrite () {
       return new Promise(resolve => {
-        const confirmButton = document.querySelector('#overwrite-ok')
-        confirmButton.addEventListener('click', (e) => {
-          resolve(e)
+        const confirmButton = document.querySelector('#files-overwrite-confirm')
+        const cancelButton = document.querySelector('#files-overwrite-cancel')
+        confirmButton.addEventListener('click', _ => {
+          resolve(true)
+        })
+        cancelButton.addEventListener('click', _ => {
+          resolve(false)
         })
       })
     },
@@ -324,11 +335,9 @@ export default {
           if (emitSuccess) {
             this.$emit('success', e, file)
           }
-          this.$_ocUploadInput_clean()
         })
         .catch(e => {
           this.$emit('error', e)
-          this.$_ocUploadInput_clean()
         })
     },
     $_ocUpload_onProgress (e, file) {


### PR DESCRIPTION
## Description
Resolve promise as false if the user clicks on cancel button in overwrite dialog and move clean input action into the addToQue methods to ensure it is triggered even if the file is not being uploaded.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually
- test case 1: Upload file that already exists and cancel overwrite
- test case 2: Upload file that already exists confirm overwrite
- test case 3: Upload folder that already exists and cancel overwrite
- test case 4: Upload folder that already exists and confirm overwrite
- test case 5: Upload multiple files and do both cancel and confirm actions

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 