### PR TITLE
Make name errors consistent

### DIFF
--- a/apps/files/src/components/ocDialogPrompt.vue
+++ b/apps/files/src/components/ocDialogPrompt.vue
@@ -17,7 +17,7 @@
     </template>
     <template slot="footer">
         <oc-button :id="ocCancelId" :disabled="ocLoading" @click.stop="onCancel">{{ _ocCancelText }}</oc-button>
-        <oc-button :disabled="ocLoading || ocError || inputValue === ''"
+        <oc-button :disabled="ocLoading || ocError !== null || inputValue === ''"
                :id="ocConfirmId"
                ref="confirmButton"
                :autofocus="!ocHasInput"
@@ -40,7 +40,10 @@ export default {
     ocInputMaxlength: [String, Number],
     ocInputPlaceholder: [String, Number],
     ocContent: String,
-    ocError: String,
+    ocError: {
+      type: String,
+      default: null
+    },
     ocLoading: { type: Boolean, default: false },
     ocCancelId: String,
     ocConfirmId: String,

--- a/apps/files/src/mixins.js
+++ b/apps/files/src/mixins.js
@@ -56,65 +56,18 @@ export default {
     changeName (item) {
       this.changeFileName = !this.changeFileName
       if (typeof item === 'object') {
+        this.originalName = item.name
         this.selectedFile = item
         this.newName = item.name
         item = this.newName
         return
       }
       if (this.selectedFile.name === item) {
-        return
-      }
-
-      const translatedTitle = this.$gettext('Renaming of %{fileName} failed')
-
-      if (item.includes('/')) {
-        this.showMessage({
-          title: this.$gettextInterpolate(translatedTitle, { fileName: this.selectedFile.name }, true),
-          desc: this.$gettext('The file name cannot contain a "/"'),
-          status: 'danger'
-        })
-        return
-      }
-
-      if (item === '.') {
-        this.showMessage({
-          title: this.$gettextInterpolate(translatedTitle, { fileName: this.selectedFile.name }, true),
-          desc: this.$gettext('File name cannot be equal to "."'),
-          status: 'danger'
-        })
-        return
-      }
-
-      if (item === '..') {
-        this.showMessage({
-          title: this.$gettextInterpolate(translatedTitle, { fileName: this.selectedFile.name }, true),
-          desc: this.$gettext('File name cannot be equal to ".."'),
-          status: 'danger'
-        })
-        return
-      }
-
-      if (/\s+$/.test(item)) {
-        this.showMessage({
-          title: this.$gettextInterpolate(translatedTitle, { fileName: this.selectedFile.name }, true),
-          desc: this.$gettext('File name cannot end with whitespace'),
-          status: 'danger'
-        })
-        return
-      }
-
-      const exists = this.files.find((n) => {
-        if (n['name'] === item) {
-          return n
-        }
-      })
-      if (exists) {
-        const translatedDesc = this.$gettext('File or folder with name "%{fileName}" already exists.')
-        this.showMessage({
-          title: this.$gettextInterpolate(translatedTitle, { fileName: this.selectedFile.name }, true),
-          desc: this.$gettextInterpolate(translatedDesc, { fileName: item }, true),
-          status: 'danger'
-        })
+        // The name has to be resetted a little while later to prevent
+        // showing the error druing the fade out animation of dialog
+        setTimeout(_ => {
+          this.originalName = null
+        }, 1000)
         return
       }
 
@@ -122,7 +75,9 @@ export default {
         client: this.$client,
         file: this.selectedFile,
         newValue: item
-      })
+      }).then(setTimeout(_ => {
+        this.originalName = null
+      }, 1000))
     },
 
     downloadFile (file) {

--- a/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
@@ -105,7 +105,7 @@ Feature: rename files
 
   Scenario Outline: Rename a file/folder using forward slash in its name
     When the user renames file "<from_file_name>" to an invalid name "<to_file_name>" using the webUI
-    Then the error message 'Name cannot contain "/"' should be displayed on the webUI dialog prompt
+    Then the error message 'The name cannot contain "/"' should be displayed on the webUI dialog prompt
     And file "<from_file_name>" should be listed on the webUI
     Examples:
       | from_file_name | to_file_name                      |
@@ -124,27 +124,19 @@ Feature: rename files
     Then file "zzzz-z-this-is-now-the-last-file.txt" should be listed on the webUI
 
   Scenario: Rename a file putting a name of a file which already exists
-    When the user renames file "data.zip" to "lorem.txt" using the webUI
-    Then the error message 'Renaming of data.zip failed' should be displayed on the webUI
+    When the user renames file "data.zip" to an invalid name "lorem.txt" using the webUI
+    Then the error message 'The name "lorem.txt" is already taken' should be displayed on the webUI dialog prompt
     And file 'data.zip' should be listed on the webUI
-    When the user closes the message
-    Then no message should be displayed on the webUI
 
-  @issue-965
   Scenario: Rename a file to ..
-    When the user renames file "data.zip" to ".." using the webUI
-    Then the error message 'Renaming of data.zip failed' should be displayed on the webUI
+    When the user renames file "data.zip" to an invalid name ".." using the webUI
+    Then the error message 'The name cannot be equal to ".."' should be displayed on the webUI dialog prompt
     And file 'data.zip' should be listed on the webUI
-    When the user closes the message
-    Then no message should be displayed on the webUI
-    
-  @issue-965
+
   Scenario: Rename a file to .
-    When the user renames file "data.zip" to "." using the webUI
-    Then the error message 'Renaming of data.zip failed' should be displayed on the webUI
+    When the user renames file "data.zip" to an invalid name "." using the webUI
+    Then the error message 'The name cannot be equal to "."' should be displayed on the webUI dialog prompt
     And file 'data.zip' should be listed on the webUI
-    When the user closes the message
-    Then no message should be displayed on the webUI
 
   @skip
   @issue-965

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -315,7 +315,7 @@ module.exports = {
       selector: '#change-file-dialog'
     },
     renameButtonInFileRow: {
-      selector: '//button[@aria-label="Edit"]',
+      selector: '//button[@aria-label="Rename"]',
       locateStrategy: 'xpath'
     },
     renameFileInputField: {


### PR DESCRIPTION
## Description
Use the same error handling in rename feature as is in create folder/file.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #1450

## Motivation and Context
Consistent error handling behaviour

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/25989331/61590886-35217880-abbf-11e9-91d5-b917e8c00dbf.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 