### PR TITLE
Change title of rename dialog

### DIFF
--- a/apps/files/src/components/FileList.vue
+++ b/apps/files/src/components/FileList.vue
@@ -247,9 +247,6 @@ export default {
 
       return actions
     },
-    _renameDialogTitle () {
-      return this.$gettext('Rename File/Folder')
-    },
     _deleteDialogTitle () {
       return this.$gettext('Delete File/Folder')
     },

--- a/apps/files/src/mixins.js
+++ b/apps/files/src/mixins.js
@@ -22,7 +22,18 @@ export default {
     selectedFile: ''
   }),
   computed: {
-    ...mapGetters('Files', ['searchTerm', 'inProgress', 'files'])
+    ...mapGetters('Files', ['searchTerm', 'inProgress', 'files']),
+
+    _renameDialogTitle () {
+      let translated
+
+      if (this.selectedFile.type === 'folder') {
+        translated = this.$gettext('Rename folder %{name}')
+      } else {
+        translated = this.$gettext('Rename file %{name}')
+      }
+      return this.$gettextInterpolate(translated, { name: this.selectedFile.name }, true)
+    }
   },
   methods: {
     ...mapActions('Files', ['resetSearch', 'addFileToProgress', 'setOverwriteDialogTitle', 'setOverwriteDialogMessage']),


### PR DESCRIPTION
## Motivation and Context
User can now see what file is he renaming and if it is a folder or file.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually
- test case 1: Open rename dialog for file
- test case 2: Open rename dialog for folder

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/25989331/61591035-43709400-abc1-11e9-9d28-2901f51a1a3c.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 