### PR TITLE
Disable caching for all Phoenix deliverables

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,12 +1,13 @@
 
 # BEGIN Caching
-<ifModule mod_headers.c>
-    <filesMatch "\\.(ico|jpg|jpeg|png|gif|ttf|otf|woff|woff2|eot|svg)$">
-    Header set Cache-Control "max-age=1, private, must-revalidate"
-    </filesMatch>
-    <filesMatch "\\.(css|js|json|html)$">
-    Header set Cache-Control "max-age=1, private, must-revalidate"
-    </filesMatch>
-</ifModule>
+<filesMatch "\.(html|js|css|json|svg|jpeg)$">
+  FileETag None
+  <ifModule mod_headers.c>
+     Header unset ETag
+     Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
+     Header set Pragma "no-cache"
+     Header set Expires "Wed, 11 Jan 1984 05:00:00 GMT"
+  </ifModule>
+</filesMatch>
 # END Caching
 


### PR DESCRIPTION
##  Description
New caching setting ensure that all assets are not cached at all.
Pro: always get latest frontend deliverables
Con: more server load

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...