### PR TITLE
Build requires the git folder to determine the commit hash

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
-.git
 node_modules
 apps/*/node_modules


### PR DESCRIPTION
## Description
Since #1454 we require the git folder to determine the commit hash

## Motivation and Context
Due to build errors the demo system was not updated since then

## How Has This Been Tested?
- docker build .

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...