### PR TITLE
Search collaborators also by id

### DIFF
--- a/apps/files/src/components/FileSharingSidebar.vue
+++ b/apps/files/src/components/FileSharingSidebar.vue
@@ -206,7 +206,8 @@ export default {
         })
     },
     filterRecipients (item, queryText) {
-      return item.label.toLocaleLowerCase().indexOf(queryText.toLocaleLowerCase()) > -1
+      return item.label.toLocaleLowerCase().indexOf(queryText.toLocaleLowerCase()) > -1 ||
+        item.value.shareWith.toLocaleLowerCase().indexOf(queryText.toLocaleLowerCase()) > -1
     },
     $_ocCollaborators_recipientType (recipient) {
       if (recipient.value.shareType === 1) {

--- a/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
@@ -32,7 +32,7 @@ Feature: Autocompletion of share-with names
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "us" in the share-with-field
-    And the user shows all share-autocomplete results using the webUI
+    And the user displays all share-autocomplete results using the webUI
     Then all users and groups that contain the string "us" in their name should be listed in the autocomplete list on the webUI
     But only users and groups that contain the string "us" in their name or displayname should be listed in the autocomplete list on the webUI
     And the users own name should not be listed in the autocomplete list on the webUI
@@ -43,7 +43,7 @@ Feature: Autocompletion of share-with names
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "fi" in the share-with-field
-    And the user shows all share-autocomplete results using the webUI
+    And the user displays all share-autocomplete results using the webUI
     Then all users and groups that contain the string "fi" in their name should be listed in the autocomplete list on the webUI
     But only users and groups that contain the string "fi" in their name or displayname should be listed in the autocomplete list on the webUI
     And the users own name should not be listed in the autocomplete list on the webUI

--- a/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
@@ -16,6 +16,7 @@ Feature: Autocompletion of share-with names
       | username  | password  | displayname     | email          |
       | two       | %regular% | User Two        | u2@oc.com.np   |
       | u444      | %regular% | Four            | u3@oc.com.np   |
+      | five      | %regular% | User Group      | five@oc.com.np |
       | usersmith | %regular% | John Finn Smith | js@oc.com.np   |
     And these groups have been created:
       | groupname     |
@@ -25,27 +26,27 @@ Feature: Autocompletion of share-with names
       | users-finance |
       | other         |
 
-  @smokeTest @issue-1532
+  @smokeTest
   Scenario: autocompletion of regular existing users
     Given user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "us" in the share-with-field
-#    Then all users and groups that contain the string "us" in their name should be listed in the autocomplete list on the webUI
-    Then user "John Finn Smith" should not be listed in the autocomplete list on the webUI
-    And every item listed in the autocomplete list on the webUI should contain "us"
-    But the users own name should not be listed in the autocomplete list on the webUI
+    And the user shows all share-autocomplete results using the webUI
+    Then all users and groups that contain the string "us" in their name should be listed in the autocomplete list on the webUI
+    But only users and groups that contain the string "us" in their name or displayname should be listed in the autocomplete list on the webUI
+    And the users own name should not be listed in the autocomplete list on the webUI
 
-  @smokeTest @issue-1532
+  @smokeTest
   Scenario: autocompletion of regular existing groups
     Given user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "fi" in the share-with-field
-#    Then all users and groups that contain the string "fi" in their name should be listed in the autocomplete list on the webUI
-    Then user "User Group" should not be listed in the autocomplete list on the webUI
-    And every item listed in the autocomplete list on the webUI should contain "fi"
-    But the users own name should not be listed in the autocomplete list on the webUI
+    And the user shows all share-autocomplete results using the webUI
+    Then all users and groups that contain the string "fi" in their name should be listed in the autocomplete list on the webUI
+    But only users and groups that contain the string "fi" in their name or displayname should be listed in the autocomplete list on the webUI
+    And the users own name should not be listed in the autocomplete list on the webUI
 
   @skip @yetToImplement
   Scenario: autocompletion for a pattern that does not match any user or group

--- a/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
@@ -16,7 +16,6 @@ Feature: Autocompletion of share-with names
       | username  | password  | displayname     | email          |
       | two       | %regular% | User Two        | u2@oc.com.np   |
       | u444      | %regular% | Four            | u3@oc.com.np   |
-      | five      | %regular% | User Group      | five@oc.com.np |
       | usersmith | %regular% | John Finn Smith | js@oc.com.np   |
     And these groups have been created:
       | groupname     |

--- a/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
@@ -143,6 +143,11 @@ module.exports = {
         })
         .then(() => shareList)
     },
+    showAllAutoCompleteResults: function () {
+      return this.waitForElementVisible('@sharingAutoCompleteShowAllResultsButton')
+        .click('@sharingAutoCompleteShowAllResultsButton')
+        .waitForElementNotPresent('@sharingAutoCompleteShowAllResultsButton')
+    },
     /**
      *
      * @returns {string}
@@ -167,6 +172,9 @@ module.exports = {
     },
     sharingAutoCompleteDropDownElements: {
       selector: '#oc-sharing-autocomplete .oc-autocomplete-suggestion'
+    },
+    sharingAutoCompleteShowAllResultsButton: {
+      selector: '.oc-autocomplete-suggestion-overflow'
     },
     sidebarCloseBtn: {
       selector: '//div[@class="sidebar-container"]//div[@class="action"]//button',

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -87,7 +87,7 @@ When('the user types {string} in the share-with-field', function (input) {
   return client.page.FilesPageElement.sharingDialog().enterAutoComplete(input)
 })
 
-When('the user shows all share-autocomplete results using the webUI', function () {
+When('the user displays all share-autocomplete results using the webUI', function () {
   return client.page.FilesPageElement.sharingDialog().showAllAutoCompleteResults()
 })
 


### PR DESCRIPTION
## Description
Filter results of collaborators search by id as well and not only by label.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #1532

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually
- test case 1: Create a user (e. g. with username: "owncloud1" and display name "user1")
- test case 2: Write into collaborators autocomplete "owncloud1"
- test case 3: Write into collaborators autocomplete "user1"

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/25989331/61702423-0f6fad00-ad40-11e9-8975-f05b3a86986f.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 