### PR TITLE
Allow to set the oidc log level via config.json

### DIFF
--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -21,7 +21,8 @@ export function initVueAuthenticate (config) {
       accessTokenExpiringNotificationTime: 10,
       automaticSilentRenew: false,
       filterProtocolClaims: true,
-      loadUserInfo: true
+      loadUserInfo: true,
+      logLevel: Log.INFO
     }
     if (config.openIdConnect && config.openIdConnect.authority) {
       Object.assign(openIdConfig, config.openIdConnect)
@@ -55,6 +56,7 @@ export function initVueAuthenticate (config) {
     const mgr = new UserManager(openIdConfig)
 
     Log.logger = console
+    Log.level = openIdConfig.logLevel
 
     mgr.events.addUserLoaded(function (user) {
       console.log('New User Loaded：', arguments)


### PR DESCRIPTION
## Description
The log level of the open id client can now be set via config.json

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...