### PR TITLE
Properly set token in download request

### DIFF
--- a/apps/media-viewer/src/Mediaviewer.vue
+++ b/apps/media-viewer/src/Mediaviewer.vue
@@ -170,6 +170,8 @@ export default {
 
   computed: {
     ...mapGetters('Files', ['activeFiles']),
+    ...mapGetters(['getToken']),
+
     mediaFiles () {
       return this.activeFiles.filter(file => {
         return file.extension.toLowerCase().match(/(png|jpg|jpeg|gif)/)


### PR DESCRIPTION

## Description
Download via the media viewer is now properly working. Before getToken was undefined ...

## How Has This Been Tested?
- open image in mediaviewer
- click download icon
- see the download happen

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...