### PR TITLE
Show additional info

### DIFF
--- a/apps/files/src/components/Collaborators/AutocompleteItem.vue
+++ b/apps/files/src/components/Collaborators/AutocompleteItem.vue
@@ -10,7 +10,8 @@
     </template>
     <div>
       <div class="uk-text-bold files-collaborators-autocomplete-username">{{ item.label }}</div>
-      <span class="uk-text-meta">{{ $_ocCollaborators_collaboratorType(item.value.shareType) }}</span>
+      <div v-if="item.value.shareWithAdditionalInfo">{{ item.value.shareWithAdditionalInfo }}</div>
+      <div class="uk-text-meta">{{ $_ocCollaborators_collaboratorType(item.value.shareType) }}</div>
     </div>
   </div>
 </template>

--- a/apps/files/src/components/Collaborators/Collaborator.vue
+++ b/apps/files/src/components/Collaborators/Collaborator.vue
@@ -5,8 +5,13 @@
       <div class="files-collaborators-collaborator-information uk-flex uk-flex-wrap uk-flex-middle">
         <oc-avatar :src="collaborator.avatar" class="uk-margin-small-right" />
         <div class="uk-flex uk-flex-column uk-flex-center">
-          <div class="oc-text"><span class="files-collaborators-collaborator-name uk-text-bold">{{ collaborator.displayName }}</span><span v-if="collaborator.additionalInfo" class="uk-text-meta"> ({{ collaborator.additionalInfo }})</span></div>
-          <div class="oc-text">{{ roles[collaborator.role].name }}<template v-if="collaborator.expires"> | <translate :translate-params="{expires: formDateFromNow(collaborator.expires)}">Expires: %{expires}</translate></template></div>
+          <div class="oc-text">
+            <span class="files-collaborators-collaborator-name uk-text-bold">{{ collaborator.displayName }}</span>
+            <span v-if="parseInt(collaborator.info.share_type, 10) === 0 && collaborator.info.share_with_additional_info.length > 0" class="uk-text-meta">
+              ({{ collaborator.info.share_with_additional_info }})
+            </span>
+          </div>
+          <span class="oc-text">{{ roles[collaborator.role].name }}<template v-if="collaborator.expires"> | <translate :translate-params="{expires: formDateFromNow(collaborator.expires)}">Expires: %{expires}</translate></template></span>
           <span class="uk-text-meta">{{ $_ocCollaborators_collaboratorType(collaborator.info.share_type) }}</span>
         </div>
       </div>


### PR DESCRIPTION
## Description
In case admins sets additional info to be displayed, show it next to the display name in collaborators for both autocomplete and list.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Refs #1186 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/25989331/62132362-39dfde00-b2dd-11e9-806a-66afe2d1ad00.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 