### PR TITLE
Don't show items in autocomplete if they already exist

### DIFF
--- a/apps/files/src/components/FileSharingSidebar.vue
+++ b/apps/files/src/components/FileSharingSidebar.vue
@@ -219,8 +219,13 @@ export default {
             const selected = this.selectedCollaborators.find(selectedCollaborator => {
               return collaborator.value.shareWith === selectedCollaborator.value.shareWith
             })
-            if (selected) {
-              return collaborator.value.shareWith !== selected.value.shareWith
+
+            const exists = this.shares.find(existingCollaborator => {
+              return collaborator.value.shareWith === existingCollaborator.name
+            })
+
+            if (selected || exists) {
+              return false
             }
 
             return true


### PR DESCRIPTION
## Description
If the share already exists for users/groups don't show them as a result in autocomplete.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Refs #1186

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 