### PR TITLE
Added getter for token into mixins

### DIFF
--- a/apps/files/src/mixins.js
+++ b/apps/files/src/mixins.js
@@ -23,6 +23,7 @@ export default {
   }),
   computed: {
     ...mapGetters('Files', ['searchTerm', 'inProgress', 'files']),
+    ...mapGetters(['getToken']),
 
     _renameDialogTitle () {
       let translated


### PR DESCRIPTION
## Description
In FilesApp wasn't passed the token thus download failed with unauthorised error. The getter for token is now in mixins so we don't need to pass it with the specific component.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually
- Download file with button in file row
- Download file with link in actions menu

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 