### PR TITLE
Shared with others list

### DIFF
--- a/apps/files/src/components/Collaborators/SharedFilesList.vue
+++ b/apps/files/src/components/Collaborators/SharedFilesList.vue
@@ -1,0 +1,64 @@
+<script>
+import { mapGetters, mapActions } from 'vuex'
+import Mixins from '../../mixins'
+
+export default {
+  name: 'SharedFilesList',
+  mixins: [
+    Mixins
+  ],
+  props: {
+    /**
+       * Array of active files
+       */
+    fileData: {
+      type: Array,
+      required: true,
+      default: null
+    }
+  },
+  computed: {
+    ...mapGetters('Files', ['loadingFolder'])
+  },
+  mounted () {
+    this.$_ocSharedFromMe_getFiles()
+  },
+  methods: {
+    ...mapActions('Files', ['loadFolderSharedFromMe', 'setFilterTerm']),
+
+    $_ocSharedFromMe_getFiles () {
+      this.setFilterTerm('')
+      this.loadFolderSharedFromMe({
+        client: this.$client,
+        $gettext: this.$gettext
+      })
+    }
+  }
+}
+</script>
+
+<template>
+  <oc-table middle divider class="oc-filelist" id="shared-with-others-list" v-if="!loadingFolder">
+    <oc-table-group>
+      <oc-table-row>
+        <oc-table-cell type="head" class="uk-text-truncate" v-translate>Name</oc-table-cell>
+        <oc-table-cell shrink type="head" class="uk-text-nowrap" v-translate>Shared with</oc-table-cell>
+        <oc-table-cell shrink type="head" class="uk-text-nowrap" v-translate>Share time</oc-table-cell>
+      </oc-table-row>
+    </oc-table-group>
+    <oc-table-group>
+      <oc-table-row v-for="(item, index) in fileData" :key="index" :class="_rowClasses(item)" @click="selectRow(item, $event)" :id="'file-row-' + item.id">
+        <oc-table-cell class="uk-text-truncate">
+          <oc-file :name="item.basename" :extension="item.extension" class="file-row-name uk-disabled"
+            :filename="item.name" :icon="fileTypeIcon(item)" :key="item.path" />
+        </oc-table-cell>
+        <oc-table-cell class="uk-text-meta uk-text-nowrap">
+          {{ item.sharedWith }} <translate v-if="item.shareType === 1">(group)</translate>
+        </oc-table-cell>
+        <oc-table-cell class="uk-text-meta uk-text-nowrap">
+          {{ formDateFromNow(item.shareTime) }}
+        </oc-table-cell>
+      </oc-table-row>
+    </oc-table-group>
+  </oc-table>
+</template>

--- a/apps/files/src/components/FileDetails.vue
+++ b/apps/files/src/components/FileDetails.vue
@@ -6,13 +6,13 @@
       </div>
       <div class="uk-inline">
         <div class="uk-flex uk-flex-middle">
-          <span class="uk-margin-small-right">{{ highlightedFile.name }}</span>
+          <span class="uk-margin-small-right uk-text-bold">{{ highlightedFile.name }}</span>
           <oc-icon name="link" v-clipboard="() => highlightedFile.privateLink"
                    v-if="highlightedFile.privateLink"
                    v-clipboard:success="clipboardSuccessHandler"
           />
         </div>
-        <div>
+        <div v-if="$route.name !== 'files-shared-with-others'">
           <oc-star v-if="!publicPage()" class="uk-inline" :shining="highlightedFile.starred"/> {{ highlightedFile.size | fileSize }}, {{ formDateFromNow(highlightedFile.mdate) }}
         </div>
       </div>

--- a/apps/files/src/components/FilesApp.vue
+++ b/apps/files/src/components/FilesApp.vue
@@ -5,11 +5,14 @@
         <div class="uk-width-expand uk-overflow-auto uk-height-1-1" @dragover="$_ocApp_dragOver" :class="{ 'uk-visible@m' : _sidebarOpen }" id="files-list-container">
           <oc-loader id="files-list-progress" v-if="loadingFolder"></oc-loader>
           <trashbin v-if="$route.name === 'files-trashbin'" :fileData="activeFiles" />
+          <SharedFilesList v-else-if="$route.name === 'files-shared-with-others'" @toggle="toggleFileSelect" :fileData="activeFiles" />
           <file-list v-else @toggle="toggleFileSelect" @FileAction="openFileActionBar" :fileData="activeFiles" @sideBarOpen="openSideBar" />
         </div>
-        <div class="uk-width-1-1 uk-width-1-2@m uk-width-1-3@xl uk-height-1-1" v-if="_sidebarOpen && $route.name !== 'files-trashbin'">
-          <file-details ref="fileDetails" @reset="setHighlightedFile(null)"/>
-        </div>
+        <file-details
+          v-if="_sidebarOpen && $route.name !== 'files-trashbin'"
+          ref="fileDetails" class="uk-width-1-1 uk-width-1-2@m uk-width-1-3@xl uk-height-1-1"
+          @reset="setHighlightedFile(null)"
+        />
     </oc-grid>
     <oc-file-actions />
   </div>
@@ -20,6 +23,7 @@ import FileDetails from './FileDetails.vue'
 import FilesAppBar from './FilesAppBar.vue'
 import FileList from './FileList.vue'
 import Trashbin from './Trashbin.vue'
+import SharedFilesList from './Collaborators/SharedFilesList.vue'
 import { mapActions, mapGetters } from 'vuex'
 
 export default {
@@ -30,7 +34,8 @@ export default {
     FileDetails,
     FileList,
     FilesAppBar,
-    Trashbin
+    Trashbin,
+    SharedFilesList
   },
   data () {
     return {
@@ -119,6 +124,11 @@ export default {
 
     _sidebarOpen () {
       return this.highlightedFile !== null
+    }
+  },
+  watch: {
+    $route () {
+      this.setHighlightedFile(null)
     }
   }
 }

--- a/apps/files/src/default.js
+++ b/apps/files/src/default.js
@@ -56,6 +56,14 @@ const navItems = [
     }
   },
   {
+    name: 'Shared with others',
+    iconMaterial: 'share',
+    route: {
+      name: 'files-shared-with-others',
+      path: `/${appInfo.id}/shared-with-others`
+    }
+  },
+  {
     name: 'Deleted files',
     iconMaterial: 'delete',
     enabled (capabilities) {
@@ -91,6 +99,16 @@ const routes = [
       app: FilesApp
     },
     name: 'files-favorites',
+    meta: {
+      hideFilelistActions: true
+    }
+  },
+  {
+    path: '/shared-with-others',
+    components: {
+      app: FilesApp
+    },
+    name: 'files-shared-with-others',
     meta: {
       hideFilelistActions: true
     }

--- a/apps/files/src/mixins.js
+++ b/apps/files/src/mixins.js
@@ -19,11 +19,15 @@ export default {
     }
   },
   data: () => ({
-    selectedFile: ''
+    selectedFile: '',
+    changeFileName: false,
+    fileToBeDeleted: '',
+    newName: '',
+    originalName: null
   }),
   computed: {
-    ...mapGetters('Files', ['searchTerm', 'inProgress', 'files']),
-    ...mapGetters(['getToken']),
+    ...mapGetters('Files', ['searchTerm', 'inProgress', 'files', 'selectedFiles', 'highlightedFile', 'activeFiles']),
+    ...mapGetters(['getToken', 'capabilities', 'fileSideBars']),
 
     _renameDialogTitle () {
       let translated
@@ -36,10 +40,69 @@ export default {
         translated = this.$gettext('Rename file %{name}')
       }
       return this.$gettextInterpolate(translated, { name: this.selectedFile.name }, true)
+    },
+
+    // Files lists
+    selectedAll () {
+      return this.selectedFiles.length === this.fileData.length && this.fileData.length !== 0
+    },
+    actions () {
+      const actions = [
+        { icon: 'edit',
+          handler: this.changeName,
+          ariaLabel: this.$gettext('Rename'),
+          isEnabled: function (item) {
+            return item.canRename()
+          } },
+        { icon: 'file_download',
+          handler: this.downloadFile,
+          ariaLabel: this.$gettext('Download'),
+          isEnabled: function (item) {
+            return item.canDownload()
+          } },
+        { icon: 'delete',
+          ariaLabel: this.$gettext('Delete'),
+          handler: this.deleteFile,
+          isEnabled: function (item) {
+            return item.canBeDeleted()
+          } }
+      ]
+      for (const sideBar of this.fileSideBars) {
+        if (sideBar.enabled !== undefined && !sideBar.enabled(this.capabilities)) {
+          continue
+        }
+        if (sideBar.quickAccess) {
+          actions.push({
+            icon: sideBar.quickAccess.icon,
+            ariaLabel: sideBar.quickAccess.ariaLabel,
+            handler: this.openSideBar,
+            handlerData: sideBar.app,
+            isEnabled: function (item) {
+              return true
+            }
+          })
+        }
+      }
+
+      return actions
+    },
+    changeFileErrorMessage () {
+      return this.checkNewName(this.newName)
+    },
+    _deleteDialogTitle () {
+      return this.$gettext('Delete File/Folder')
+    },
+    $_ocDialog_isOpen () {
+      return this.changeFileName
+    },
+    _sidebarOpen () {
+      return this.highlightedFile !== null
     }
   },
   methods: {
-    ...mapActions('Files', ['resetSearch', 'addFileToProgress', 'setOverwriteDialogTitle', 'setOverwriteDialogMessage']),
+    ...mapActions('Files', ['resetSearch', 'addFileToProgress', 'resetFileSelection', 'addFileSelection',
+      'removeFileSelection', 'setOverwriteDialogTitle', 'setOverwriteDialogMessage', 'deleteFiles', 'renameFile',
+      'setHighlightedFile', 'setFilesDeleteMessage']),
     ...mapActions(['showMessage']),
 
     formDateFromNow (date) {
@@ -290,6 +353,91 @@ export default {
       if (input) {
         input.value = ''
       }
+    },
+
+    // Files lists
+    toggleAll () {
+      if (this.selectedFiles.length && this.selectedFiles.length === this.fileData.length) {
+        this.resetFileSelection()
+      } else {
+        const selectedFiles = this.fileData.slice()
+        for (const item of selectedFiles) {
+          if (!this.selectedFiles.includes(item)) {
+            this.addFileSelection(item)
+          }
+        }
+      }
+    },
+    openFileActionBar (file) {
+      this.$emit('FileAction', file)
+    },
+    checkNewName (name) {
+      if (/[/]/.test(name)) return this.$gettext('The name cannot contain "/"')
+
+      if (name === '.') return this.$gettext('The name cannot be equal to "."')
+
+      if (name === '..') return this.$gettext('The name cannot be equal to ".."')
+
+      if (/\s+$/.test(name)) return this.$gettext('The name cannot end with whitespace')
+
+      const exists = this.activeFiles.find((n) => {
+        if (n['name'] === name && this.originalName !== name) {
+          return n
+        }
+      })
+
+      if (exists) {
+        const translated = this.$gettext('The name "%{name}" is already taken')
+        return this.$gettextInterpolate(translated, { name: name }, true)
+      }
+      return null
+    },
+    deleteFile (file) {
+      this.fileToBeDeleted = file
+      const translated = this.$gettext('Please confirm the deletion of %{ fileName }')
+      this.setFilesDeleteMessage(this.$gettextInterpolate(translated, { fileName: file.name }, true))
+    },
+    openSideBar (file, sideBarName) {
+      this.$emit('sideBarOpen', file, sideBarName)
+    },
+    reallyDeleteFiles () {
+      const files = this.fileToBeDeleted ? [this.fileToBeDeleted] : this.selectedFiles
+      this.deleteFiles({
+        client: this.$client,
+        files: files,
+        publicPage: this.publicPage()
+      }).then(() => {
+        this.fileToBeDeleted = ''
+        this.setFilesDeleteMessage('')
+      })
+    },
+    _rowClasses (item) {
+      if (this.highlightedFile && item.id === this.highlightedFile.id) {
+        return 'file-row uk-active'
+      }
+      return 'file-row'
+    },
+    selectRow (item, event) {
+      if (event.target.tagName !== 'TD') {
+        return
+      }
+      event.stopPropagation()
+      this.setHighlightedFile(item)
+    },
+    navigateTo (param) {
+      if (this.searchTerm !== '' && this.$route.params.item === param) {
+        this.resetSearch()
+      }
+      let route = 'files-list'
+      if (this.publicPage()) {
+        route = 'public-files'
+      }
+      this.$router.push({
+        name: route,
+        params: {
+          item: param
+        }
+      })
     }
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Created `SharedFilesList` component. Moved most of file list related functionality into mixins so we can reuse it in different lists. At the moment this list doesn't contain any actions thus checkboxes and star were removed as well and file name got class `uk-disabled` to prevent any hover/focus on it and to allow selecting of the row by clicking on it.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Refs #1186 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually
1. Share file with other user
2. Share file that has been shared with me with can share permission with some other user

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/25989331/62855889-ae5e4800-bcf3-11e9-880d-e61ef1f3ac54.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 