### PR TITLE
Revert "Hide versions tab for folders"

### DIFF
--- a/apps/files/src/components/FileDetails.vue
+++ b/apps/files/src/components/FileDetails.vue
@@ -60,7 +60,7 @@ export default {
     ...mapGetters(['getToken', 'fileSideBars', 'capabilities']),
     ...mapGetters('Files', ['highlightedFile']),
     fileSideBarsEnabled () {
-      return this.fileSideBars.filter(b => b.enabled === undefined || b.enabled(this.capabilities, this.highlightedFile))
+      return this.fileSideBars.filter(b => b.enabled === undefined || b.enabled(this.capabilities))
     },
     activeTabComponent () {
       return this.fileSideBarsEnabled[this.activeTab]

--- a/apps/files/src/default.js
+++ b/apps/files/src/default.js
@@ -20,8 +20,8 @@ const appInfo = {
     {
       app: 'files-version',
       component: FileInfoVersions,
-      enabled (capabilities, highlightedFile) {
-        return !!capabilities.core && highlightedFile && highlightedFile.type !== 'folder'
+      enabled (capabilities) {
+        return !!capabilities.core
       }
     }, {
       app: 'files-sharing',


### PR DESCRIPTION
## Description
This reverts commit d22248d5bbeb3d94b1c1d2c4833990eac783957c.

reverting  #1764

## Motivation and Context
the fix did break sharing folders by using the share button and was merged with failing CI

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...