### PR TITLE
test the files side-bar when clicking the file row

### DIFF
--- a/apps/files/src/components/FileInfoVersions.vue
+++ b/apps/files/src/components/FileInfoVersions.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div id="oc-file-versions-sidebar">
         <oc-table middle divider>
             <oc-table-group>
                 <oc-table-row v-for="(item, index) in versions" :key="index" class="file-row">

--- a/tests/acceptance/features/webUIFiles/fileDetails.feature
+++ b/tests/acceptance/features/webUIFiles/fileDetails.feature
@@ -11,35 +11,47 @@ Feature: User can open the details panel for any file or folder
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 
-  @skip @yetToImplement
-  @comments-app-required @files_versions-app-required
-  Scenario: View different areas of the details panel in files page
-    When the user opens the file action menu of file "lorem.txt" in the webUI
-    And the user clicks the details file action in the webUI
-    Then the details dialog should be visible in the webUI
-    And the thumbnail should be visible in the details panel
-    When the user switches to "sharing" tab in details panel using the webUI
-    Then the "sharing" details panel should be visible
-    When the user switches to "comments" tab in details panel using the webUI
-    Then the "comments" details panel should be visible
-    When the user switches to "versions" tab in details panel using the webUI
-    Then the "versions" details panel should be visible
+  @yetToImplement
+  @files_versions-app-required
+  Scenario: View different areas of the app-sidebar for a file in files page
+    When the user picks the row of file "lorem.txt" in the webUI
+    Then the app-sidebar should be visible
+    # And the thumbnail should be visible in the app-sidebar
+    And the "versions" details panel should be visible
+    When the user switches to "collaborators" tab in details panel using the webUI
+    Then the "collaborators" details panel should be visible
 
-  @skip @yetToImplement
-  @comments-app-required @files_versions-app-required
-  Scenario: View different areas of the details panel in favorites page
-    When the user marks file "lorem.txt" as favorite using the webUI
-    And the user browses to the favorites page
-    And the user opens the file action menu of file "lorem.txt" in the webUI
-    And the user clicks the details file action in the webUI
-    Then the details dialog should be visible in the webUI
-    And the thumbnail should be visible in the details panel
-    When the user switches to "sharing" tab in details panel using the webUI
-    Then the "sharing" details panel should be visible
-    When the user switches to "comments" tab in details panel using the webUI
-    Then the "comments" details panel should be visible
-    When the user switches to "versions" tab in details panel using the webUI
-    Then the "versions" details panel should be visible
+  @yetToImplement
+  @files_versions-app-required
+  Scenario: View different areas of the app-sidebar for a folder in files page
+    When the user picks the row of folder "simple-folder" in the webUI
+    Then the app-sidebar should be visible
+    # And the thumbnail should be visible in the app-sidebar
+    And the "collaborators" details panel should be visible
+    And no "versions" tab should be available in the details panel
+
+  @yetToImplement
+  @files_versions-app-required
+  Scenario: View different areas of the app-sidebar for a file in favorites page
+    Given user "user1" has favorited element "lorem.txt"
+    And the user has browsed to the favorites page
+    When the user picks the row of file "lorem.txt" in the webUI
+    Then the app-sidebar should be visible
+    # And the thumbnail should be visible in the app-sidebar
+    And the "versions" details panel should be visible
+    When the user switches to "collaborators" tab in details panel using the webUI
+    Then the "collaborators" details panel should be visible
+
+  @yetToImplement
+  @files_versions-app-required
+  Scenario: View different areas of the app-sidebar for a folder in favorites page
+    Given user "user1" has favorited element "simple-folder"
+    And the user has browsed to the favorites page
+    When the user picks the row of folder "simple-folder" in the webUI
+    Then the app-sidebar should be visible
+    # And the thumbnail should be visible in the app-sidebar
+    And the "collaborators" details panel should be visible
+    And no "versions" tab should be available in the details panel
 
   @skip @yetToImplement
   @comments-app-required @public_link_share-feature-required

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -165,6 +165,18 @@ module.exports = {
         .useCss()
     },
     /**
+     * @param {string} item the file/folder to click
+     */
+    clickRow: function (item) {
+      return this.initAjaxCounters()
+        .waitForFileVisible(item)
+        .useXpath()
+        .click(this.getFileRowSelectorByFileName(item))
+        .waitForOutstandingAjaxCalls()
+        .useCss()
+    },
+
+    /**
      * Toggle enable or disable file/folder select checkbox
      *
      * @param {string} enableOrDisable

--- a/tests/acceptance/pageObjects/filesPage.js
+++ b/tests/acceptance/pageObjects/filesPage.js
@@ -1,3 +1,5 @@
+const util = require('util')
+
 module.exports = {
   url: function () {
     return this.api.launchUrl + ''
@@ -105,6 +107,44 @@ module.exports = {
         .click('@deleteFileConfirmationBtn')
         .waitForElementNotVisible('@deleteFileConfirmationDialog')
         .waitForAnimationToFinish()
+    },
+    /**
+     * return the complete xpath of the link to the specified tab in the side-bad
+     * @param tab
+     * @returns {string}
+     */
+    getXpathOfLinkToTabInSidePanel: function (tab) {
+      return this.elements['sideBar'].selector +
+        util.format(this.elements['tabOfSideBar'].selector, tab)
+    },
+    selectTabInSidePanel: function (tab) {
+      return this
+        .useXpath()
+        .waitForElementVisible('@sideBar')
+        .click(this.getXpathOfLinkToTabInSidePanel(tab))
+        .useCss()
+    },
+    isSidebarVisible: function (callback) {
+      return this
+        .useXpath()
+        .isVisible('@sideBar', (result) => {
+          callback(result.value)
+        })
+        .useCss()
+    },
+    isPanelVisible: function (panelName, callback) {
+      let selector = ''
+      if (panelName === 'collaborators') {
+        selector = this.page.FilesPageElement.sharingDialog().elements['sharingAutoComplete']
+      } else if (panelName === 'versions') {
+        selector = this.elements['versionsPanel']
+      } else {
+        throw new Error(`invalid panel`)
+      }
+      return this
+        .isVisible(selector, (result) => {
+          callback(result.value)
+        })
     }
   },
   elements: {
@@ -168,6 +208,21 @@ module.exports = {
     },
     deleteFileConfirmationDialog: {
       selector: '#delete-file-confirmation-dialog'
+    },
+    versionsPanel: {
+      selector: '#oc-file-versions-sidebar'
+    },
+    sideBar: {
+      selector: '//div[@class="sidebar-container"]',
+      locateStrategy: 'xpath'
+    },
+    /**
+     * path from inside the side-bar
+     */
+    tabOfSideBar: {
+      // the translate bit is to make it case-insensitive
+      selector: '//a[contains(translate(.,\'ABCDEFGHJIKLMNOPQRSTUVWXYZ\',\'abcdefghjiklmnopqrstuvwxyz\'),\'%s\')]',
+      locateStrategy: 'xpath'
     }
   }
 }

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -219,6 +219,14 @@ When('the user batch restores the marked files using the webUI', function () {
   return client.page.FilesPageElement.filesList().restoreSelected()
 })
 
+When('the user picks the row of file/folder {string} in the webUI', function (item) {
+  return client.page.FilesPageElement.filesList().clickRow(item)
+})
+
+When('the user switches to {string} tab in details panel using the webUI', function (tab) {
+  return client.page.filesPage().selectTabInSidePanel(tab)
+})
+
 Then('the folder should be empty on the webUI', async function () {
   const allFileRows = await client.page.FilesPageElement.filesList().allFileRows()
   return client.assert.equal(allFileRows.value.length, 0)
@@ -261,6 +269,25 @@ Then('the folder should be empty on the webUI after a page reload', async functi
   await client.refresh()
   const allFileRows = await client.page.FilesPageElement.filesList().allFileRows()
   return client.assert.equal(allFileRows.value.length, 0)
+})
+
+Then('the app-sidebar should be visible', function () {
+  return client.page.filesPage().isSidebarVisible((value) => {
+    assert.strictEqual(value, true, `side-bar should be visible, but is not`)
+  })
+})
+
+Then('the {string} details panel should be visible', function (panel) {
+  return client.page.filesPage().isPanelVisible(panel, (value) => {
+    assert.strictEqual(value, true, `'${panel}-panel' should be visible, but is not`)
+  })
+})
+
+Then('no {string} tab should be available in the details panel', function (tab) {
+  const tabSelector = client.page.filesPage().getXpathOfLinkToTabInSidePanel()
+  return client.page.filesPage()
+    .useXpath()
+    .waitForElementNotPresent(tabSelector)
 })
 
 const assertElementsAreListed = function (elements) {


### PR DESCRIPTION
## Description
Tests to make sure the side-panel opens correctly when clicking just the file row and not the action button

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...