### PR TITLE
Define active tab by name instead of key

### DIFF
--- a/apps/files/src/components/FileDetails.vue
+++ b/apps/files/src/components/FileDetails.vue
@@ -19,8 +19,8 @@
     </template>
     <template slot="content">
       <oc-tabs>
-          <oc-tab-item :active="key == activeTab" @click="activeTab = key" v-for="(tab, key) of fileSideBarsEnabled" :key="tab.name">
-            {{ tab.component.title($gettext) }}
+          <oc-tab-item :active="tab.app == activeTab" @click="activeTab = tab.app" v-for="tab of fileSideBarsEnabled" :key="tab.name">
+            {{ tab.component.title($gettext) }} {{ tab.name }}
           </oc-tab-item>
       </oc-tabs>
       <component v-if="fileSideBars.length > 0 && activeTabComponent" v-bind:is="activeTabComponent.component" @reload="$emit('reload')"></component>
@@ -35,10 +35,10 @@ import { mapActions, mapGetters } from 'vuex'
 export default {
   mixins: [Mixins],
   name: 'FileDetails',
-  data: function () {
+  data () {
     return {
       /** String name of the tab that is activated */
-      activeTab: 0
+      activeTab: null
     }
   },
   methods: {
@@ -62,9 +62,24 @@ export default {
     fileSideBarsEnabled () {
       return this.fileSideBars.filter(b => b.enabled === undefined || b.enabled(this.capabilities, this.highlightedFile))
     },
+    defaultTab () {
+      if (this.fileSideBarsEnabled.length < 1) return null
+
+      return this.fileSideBarsEnabled[0].app
+    },
     activeTabComponent () {
-      return this.fileSideBarsEnabled[this.activeTab]
+      return this.fileSideBarsEnabled.find(sidebar => sidebar.app === this.activeTab)
     }
+  },
+  watch: {
+    // Switch back to default tab after selecting different file
+    highlightedFile () {
+      this.activeTab = this.defaultTab
+    }
+  },
+  mounted () {
+    // Ensure default tab is not undefined
+    this.activeTab = this.defaultTab
   }
 }
 </script>

--- a/apps/files/src/components/FileList.vue
+++ b/apps/files/src/components/FileList.vue
@@ -277,8 +277,7 @@ export default {
             return item.canBeDeleted()
           } }
       ]
-      for (const sideBarName in this.fileSideBars) {
-        const sideBar = this.fileSideBars[sideBarName]
+      for (const sideBar of this.fileSideBars) {
         if (sideBar.enabled !== undefined && !sideBar.enabled(this.capabilities)) {
           continue
         }
@@ -287,7 +286,7 @@ export default {
             icon: sideBar.quickAccess.icon,
             ariaLabel: sideBar.quickAccess.ariaLabel,
             handler: this.openSideBar,
-            handlerData: sideBarName,
+            handlerData: sideBar.app,
             isEnabled: function (item) {
               return true
             }


### PR DESCRIPTION
## Description
Use name of the tab to define which one is selected instead of key to prevent wrong tab being selected if other tab is disabled but the key is not changed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually
1. Open sidebar by clicking on file row
2. Open sidebar by clicking on folder row
3. Open sidebar by clicking on collaborators action

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 