### PR TITLE
delete unneeded steps for trashbin tests

### DIFF
--- a/tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature
@@ -23,7 +23,6 @@ Feature: files and folders exist in the trashbin after being deleted
     And as "user1" folder "strängé नेपाली folder" should exist in trash
     And as "user1" file "strängé filename (duplicate #2 &).txt" should exist in trash
     And the deleted elements should be listed on the webUI
-    And file "lorem.txt" should be listed in the folder "simple-folder" on the webUI
 
   Scenario: Delete a file with problematic characters and check it is in the trashbin
     Given the user has renamed the following files
@@ -59,7 +58,6 @@ Feature: files and folders exist in the trashbin after being deleted
     And as "user1" folder "simple-folder" should exist in trash
     And as "user1" the file with original path "simple-folder/lorem.txt" should exist in trash
     And the deleted elements should be listed on the webUI
-    And file "lorem.txt" should be listed in the folder "simple-folder" on the webUI
 
   Scenario: Delete an empty folder and check it is in the trashbin
     Given the user has created folder "my-empty-folder"


### PR DESCRIPTION
## Description
currently its impossible to navigate into a subfolder in trashbin see https://github.com/owncloud/phoenix/issues/1725#issuecomment-519390558
so no need to try to test it

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...