### PR TITLE
run tests again that were failing because of #1502

### DIFF
--- a/tests/acceptance/features/webUITrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinDelete.feature
@@ -31,7 +31,6 @@ Feature: files and folders can be deleted from the trashbin
     When the user deletes folder "simple-folder" using the webUI
     Then folder "simple-folder" should not be listed on the webUI
 
-  @skip @issue-1502
   Scenario: Select some files and delete from trashbin in a batch
     When the user batch deletes these files using the webUI
       | name          |
@@ -45,7 +44,6 @@ Feature: files and folders can be deleted from the trashbin
     And file "lorem.txt" should not be listed on the webUI
     And file "lorem-big.txt" should not be listed on the webUI
 
-  @skip @issue-1502
   Scenario: Select all except for some files and delete from trashbin in a batch
     When the user marks all files for batch action using the webUI
     And the user unmarks these files for batch action using the webUI


### PR DESCRIPTION
## Description
These tests were failing because of #1502
That issue was fixed in https://github.com/owncloud/core/pull/35879
so let's run them again

## Related Issue
part of  #1502

## Motivation and Context
tests don't like to be ignored https://blog.developer.atlassian.com/open-letter-from-an-ignored-test/

## How Has This Been Tested?
:robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...