### PR TITLE
Fixed download in Firefox

### DIFF
--- a/src/plugins/phoenix.js
+++ b/src/plugins/phoenix.js
@@ -41,8 +41,10 @@ export default {
                       const anchor = document.createElement('a')
                       anchor.href = objectUrl
                       anchor.download = fileName
+                      anchor.style.display = 'none'
+                      document.body.appendChild(anchor)
                       anchor.click()
-
+                      document.body.removeChild(anchor)
                       window.URL.revokeObjectURL(objectUrl)
                     }
                   })


### PR DESCRIPTION
## Description
Inserted download anchor into the body of document and hid it with `display: none`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #1719

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually
1. Download file in Chrome
2. Download file in Firefox

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 