### PR TITLE
Prevent scroll of file row actions

### DIFF
--- a/apps/files/src/components/FileList.vue
+++ b/apps/files/src/components/FileList.vue
@@ -34,7 +34,7 @@
               <oc-table-cell class="uk-text-meta uk-text-nowrap" :class="{ 'uk-visible@s' : !_sidebarOpen, 'uk-visible@m'  : _sidebarOpen }">
                 {{ formDateFromNow(item.mdate) }}
               </oc-table-cell>
-              <oc-table-cell :class="{ 'uk-visible@s' : _sidebarOpen }">
+              <oc-table-cell :class="{ 'uk-visible@s' : _sidebarOpen }" class="uk-position-relative">
                 <div class="uk-button-group uk-margin-small-right" :class="{ 'uk-visible@m' : !_sidebarOpen, 'uk-visible@xl' : _sidebarOpen  }">
                   <oc-button v-for="(action, index) in actions" :key="index" @click.stop="action.handler(item, action.handlerData)" :disabled="!action.isEnabled(item)" :icon="action.icon" :ariaLabel="action.ariaLabel" />
                 </div>
@@ -48,15 +48,14 @@
                 <oc-drop
                   v-if="!$_ocDialog_isOpen"
                   :toggle="'#files-file-list-action-button-small-resolution-' + index"
-                  :options="{ 'pos': 'bottom-center' }"
-                  class="uk-width-auto"
+                  :options="{ offset: 0 }"
+                  position="bottom-right"
                 >
                   <ul class="uk-list">
-                    <li v-for="(action, index) in actions" :key="index">
+                    <li v-for="(action, index) in enabledActions(item)" :key="index">
                       <oc-button
                         class="uk-width-1-1"
                         @click.native.stop="action.handler(item, action.handlerData)"
-                        :disabled="!action.isEnabled(item)"
                         :icon="action.icon"
                         :ariaLabel="action.ariaLabel"
                       >
@@ -187,6 +186,10 @@ export default {
         if (pathSplit.length > 2) return `…/${pathSplit[pathSplit.length - 2]}/${item.basename}`
       }
       return item.basename
+    },
+
+    enabledActions (item) {
+      return this.actions.filter(action => action.isEnabled(item))
     }
   },
   computed: {

--- a/apps/files/src/mixins.js
+++ b/apps/files/src/mixins.js
@@ -93,7 +93,7 @@ export default {
       return this.$gettext('Delete File/Folder')
     },
     $_ocDialog_isOpen () {
-      return this.changeFileName
+      return this.changeFileName || this.filesDeleteMessage !== ''
     },
     _sidebarOpen () {
       return this.highlightedFile !== null


### PR DESCRIPTION
## Description
Added relative position to table cell containing actions to prevent them staying at the same position while scrolling.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #1762
- Fixes #1771

## Motivation and Context
Since we use overflow to handle scroll of files list absolute position won't work properly while scrolling. To prevent the element to stay on the screen it's parent needs position relative.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually
1. Open actions drop on mobile resolution
2. Open actions drop on desktop resolution while having sidebar opened
3. Scroll

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 