### PR TITLE
Trigger collaborator edit only after change

### DIFF
--- a/apps/files/src/components/Collaborators/Collaborator.vue
+++ b/apps/files/src/components/Collaborators/Collaborator.vue
@@ -18,13 +18,19 @@
     </template>
     <template slot="content">
       <oc-grid gutter="small" class="uk-margin-bottom">
-        <div class="uk-width-1-1">
+        <div class="uk-width-1-1 uk-position-relative">
           <label class="oc-label"><translate>Role</translate></label>
           <oc-button :id="`files-collaborators-role-button-${collaborator.info.id}`" class="uk-width-1-1 files-collaborators-role-button">{{ $_ocCollaborators_selectedRoleName(collaborator) }}</oc-button>
           <p class="uk-text-meta uk-margin-remove">{{ $_ocCollaborators_selectedRoleDescription(collaborator) }}</p>
           <oc-drop :dropId="`files-collaborators-roles-dropdown-${collaborator.info.id}`" closeOnClick :toggle="`#files-collaborators-role-button-${collaborator.info.id}`" mode="click" :options="{ offset: 0, delayHide: 0 }" class="oc-autocomplete-dropdown">
             <ul class="oc-autocomplete-suggestion-list">
-              <li v-for="(role, key) in roles" :key="key" class="oc-autocomplete-suggestion" :class="{ 'oc-autocomplete-suggestion-selected' : (roles[collaborator.role] === role.tag && !selectedNewRole) || selectedNewRole === role }" @click="$_ocCollaborators_changeRole(role, collaborator)">
+              <li
+                v-for="(role, key) in roles"
+                :key="key"
+                class="oc-autocomplete-suggestion"
+                :class="rolesDropItemClass(role)"
+                @click="$_ocCollaborators_changeRole(role); onChange()"
+              >
                 <span class="uk-text-bold">{{ role.name }}</span>
                 <p class="uk-text-meta uk-margin-remove">{{ role.description }}</p>
               </li>
@@ -53,7 +59,7 @@
         </oc-grid>
       </oc-grid>
       <template v-if="editing">
-        <oc-button :disabled="collaboratorSaving" @click="$_ocCollaborators_cancelChanges(collaborator)">
+        <oc-button :disabled="collaboratorSaving" @click="$_ocCollaborators_cancelChanges">
           <translate>Cancel</translate>
         </oc-button>
         <oc-button variation="primary" :disabled="collaboratorSaving" @click="$_ocCollaborators_saveChanges(collaborator)">
@@ -84,6 +90,7 @@ export default {
       canCreate: this.collaborator.customPermissions.create,
       canDelete: this.collaborator.customPermissions.delete,
       selectedNewRole: null,
+      permissionsChanged: false,
       switchKey: Math.floor(Math.random() * 100) // Ensure switch gets back to orginal position after cancel
     }
   },
@@ -93,6 +100,10 @@ export default {
 
     _deleteButtonLabel () {
       return this.$gettext('Delete Share')
+    },
+
+    originalRole () {
+      return this.roles[this.collaborator.role].tag
     }
   },
   methods: {
@@ -122,8 +133,6 @@ export default {
     },
     $_ocCollaborators_changeRole (role) {
       this.selectedNewRole = role
-      this.editing = true
-      this.toggleCollaboratorsEdit(true)
     },
     $_ocCollaborators_selectedRoleName (collaborator) {
       if (!this.selectedNewRole) {
@@ -139,15 +148,32 @@ export default {
 
       return this.selectedNewRole.description
     },
-    $_ocCollaborators_cancelChanges (collaborator) {
+    $_ocCollaborators_cancelChanges () {
       this.selectedNewRole = null
-      this.canShare = collaborator.canShare
-      this.canChange = collaborator.customPermissions.change
-      this.canCreate = collaborator.customPermissions.create
-      this.canDelete = collaborator.customPermissions.delete
+      this.canShare = this.collaborator.canShare
+      this.canChange = this.collaborator.customPermissions.change
+      this.canCreate = this.collaborator.customPermissions.create
+      this.canDelete = this.collaborator.customPermissions.delete
       this.editing = false
       this.switchKey = Math.floor(Math.random() * 100)
       this.toggleCollaboratorsEdit(false)
+    },
+
+    onChange () {
+      if (this.selectedNewRole.tag === this.originalRole && !this.permissionsChanged) {
+        this.editing = false
+        this.toggleCollaboratorsEdit(false)
+        return
+      }
+
+      this.editing = true
+      this.toggleCollaboratorsEdit(true)
+    },
+
+    rolesDropItemClass (role) {
+      if ((this.roles[this.collaborator.role].tag === role.tag && !this.selectedNewRole) || this.selectedNewRole === role) {
+        return 'oc-autocomplete-suggestion-selected'
+      }
     }
   }
 }

--- a/apps/files/src/components/Collaborators/mixins.js
+++ b/apps/files/src/components/Collaborators/mixins.js
@@ -36,6 +36,7 @@ export default {
       return this.$gettext('Group')
     },
     $_ocCollaborators_switchPermission (permission) {
+      this.permissionsChanged = true
       this[permission] = !this[permission]
       this.editing = true
       this.toggleCollaboratorsEdit(true)


### PR DESCRIPTION
## Description
Check if the new selected role is not the same as original role and prevent trigger of edit if it is.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Refs #1186

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually
1. Select same role for collaborator
2. Select different role for collaborator

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 