### PR TITLE
Focus search input when clicking search drop on mobile views

### DIFF
--- a/apps/files/src/components/FilesAppBar.vue
+++ b/apps/files/src/components/FilesAppBar.vue
@@ -39,9 +39,9 @@
               <translate>Delete selected</translate>
             </oc-button>
           </template>
-          <oc-button v-if="!publicPage()" class="uk-hidden@m" icon="search" aria-label="search" id="files-open-search-btn" />
+          <oc-button v-if="!publicPage()" class="uk-hidden@m" icon="search" aria-label="search" id="files-open-search-btn" @click="focusMobileSearchInput()"/>
           <oc-drop toggle="#files-open-search-btn" boundary="#files-app-bar" pos="bottom-right" mode="click" class="uk-margin-remove uk-width-large">
-            <oc-search-bar @search="onFileSearch" :value="searchTerm" :label="searchLabel" :loading="isLoadingSearch" />
+            <oc-search-bar ref="mobileSearch" @search="onFileSearch" :value="searchTerm" :label="searchLabel" :loading="isLoadingSearch" />
           </oc-drop>
           <oc-button id="oc-filter-list-btn" icon="filter_list" />
           <file-filter-menu />
@@ -228,12 +228,13 @@ export default {
           this.isLoadingSearch = false
         })
     },
-    focusFilenameFilter () {
-      this.$refs.filenameFilter.$el.querySelector('input').focus()
+    focusMobileSearchInput () {
+      this.$refs.mobileSearch.$el.querySelector('input').focus()
       // nested vuetify VList animation will block native autofocus, so we use this workaround...
+
       setTimeout(() => {
         // ...to set focus after the element is rendered visible
-        this.$refs.filenameFilter.$el.querySelector('input').focus()
+        this.$refs.mobileSearch.$el.querySelector('input').focus()
       }, 50)
     },
     $_ocFilesFolder_getFolder () {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Created focus helper method

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #1648 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Accessability bugfix

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- checkout the mobile files app view
- click on search
- the search drop opens and the input should be focused automatically

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...