### PR TITLE
Added fixed width to alert messages

### DIFF
--- a/src/components/MessageBar.vue
+++ b/src/components/MessageBar.vue
@@ -8,6 +8,7 @@
             :message="item.desc"
             :status="item.status"
             @close="deleteMessage(item)"
+            class="uk-width-large"
     />
     </transition-group>
   </oc-notifications>


### PR DESCRIPTION
## Description
Added `uk-width-large` class to alert messages.

## Motivation and Context
With transition alert messages were getting position absolute which led to their shrinking while disappearing. With fixed width this is prevented.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually
1. Trigger alert message
2. Close the message

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 