### PR TITLE
Enable click on search button on mobile

### DIFF
--- a/apps/files/src/components/FilesAppBar.vue
+++ b/apps/files/src/components/FilesAppBar.vue
@@ -40,8 +40,8 @@
             </oc-button>
           </template>
           <oc-button v-if="!publicPage()" class="uk-hidden@m" icon="search" aria-label="search" id="files-open-search-btn" @click="focusMobileSearchInput()"/>
-          <oc-drop toggle="#files-open-search-btn" boundary="#files-app-bar" pos="bottom-right" mode="click" class="uk-margin-remove uk-width-large">
-            <oc-search-bar ref="mobileSearch" @search="onFileSearch" :value="searchTerm" :label="searchLabel" :loading="isLoadingSearch" />
+          <oc-drop toggle="#files-open-search-btn" boundary="#files-app-bar" pos="bottom-right" mode="click" class="uk-margin-remove">
+            <oc-search-bar ref="mobileSearch" @search="onFileSearch" :label="searchLabel" :loading="isLoadingSearch" />
           </oc-drop>
           <oc-button id="oc-filter-list-btn" icon="filter_list" />
           <file-filter-menu />
@@ -451,6 +451,7 @@ export default {
     // TODO: Find a better solution
     $route (to, from) {
       this.actionsKey = Math.floor(Math.random() * 20)
+      this.$refs.mobileSearch.value = null
     }
   }
 }


### PR DESCRIPTION
## Description
Removed value from mobile search bar and reset its value after the route has been changed.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #1770

## Motivation and Context
When the `searchTerm` was used as a value the button would be always disabled since the value wasn't updated when writing a new search term.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: manually
1. Switch to mobile view in dev tools
2. Open search bar
3. Write a search term
4. See button change it's colour to primary
5. Click on the button
6. Try navigating into found folder
7. Open search bar again and see empty value

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 