### PR TITLE
Add setup about tech preview APIs in server core

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Pushing a new design and frontend concept to ownCloud
 '<phoenix-env>',
 ]
 ```
+- when developing against unstable APIs (technical preview), these need to be enabled in the server core:
+```
+dav.enable.tech_preview => true,
+```
 
 ## Create config.json
 - For reference look into config.json.sample (example with oauth2)


### PR DESCRIPTION
## Description
Add entry in README to mention the switch that enables unstable APIs from server core.

## Related Issue
- Ref: https://github.com/owncloud/core/issues/36118 and https://github.com/owncloud/core/pull/36124

## Motivation and Context
Some APIs in core are still in development and not stable for production use.
The DAV Trashbin API and public DAV endpoint for public links are currently unstable, so for Phoenix to use them we must enable them in the setup.

## How Has This Been Tested?
Doc-only change

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

