### PR TITLE
Don't yarn watch node_modules

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -22,7 +22,7 @@ module.exports = merge(common, {
     port: 8300,
     disableHostCheck: true,
     watchOptions: {
-      ignored: path.resolve(__dirname, 'tests')
+      ignored: [path.resolve(__dirname, 'tests'), path.resolve(__dirname, 'node_modules')]
     }
   }
 })


### PR DESCRIPTION
Prevents running quickly out of watch descriptors.

In my setup, just running `yarn watch` would tell me that it ran out of descriptors.
Of course I could also decide to increase the system limit, but having a better default prevents the potential distraction of having an extra config step for new setups.