### PR TITLE
Add empty folder message

### DIFF
--- a/apps/files/src/components/Collaborators/SharedFilesList.vue
+++ b/apps/files/src/components/Collaborators/SharedFilesList.vue
@@ -63,6 +63,10 @@ export default {
       })
     },
 
+    $_ocEmptyFolderText () {
+      return this.$gettext('No shared files')
+    },
+
     shareStatus (status) {
       if (status === 0) return
 
@@ -84,44 +88,49 @@ export default {
 </script>
 
 <template>
-  <oc-table middle divider class="oc-filelist" id="shared-with-list" v-if="!loadingFolder">
-    <oc-table-group>
-      <oc-table-row>
-        <oc-table-cell type="head" class="uk-text-truncate" v-translate>Name</oc-table-cell>
-        <oc-table-cell shrink type="head" class="uk-text-nowrap" v-text="sharedCellTitle" />
-        <oc-table-cell
-          v-if="$route.name === 'files-shared-with-me'"
-          shrink
-          type="head"
-          class="uk-text-nowrap"
-          v-translate
-        >
-          Status
-        </oc-table-cell>
-        <oc-table-cell shrink type="head" class="uk-text-nowrap" v-translate>Share time</oc-table-cell>
-      </oc-table-row>
-    </oc-table-group>
-    <oc-table-group>
-      <oc-table-row v-for="(item, index) in fileData" :key="index" :class="_rowClasses(item)" @click="selectRow(item, $event)" :id="'file-row-' + item.id">
-        <oc-table-cell class="uk-text-truncate">
-          <oc-file :name="item.basename" :extension="item.extension" class="file-row-name uk-disabled"
-            :filename="item.name" :icon="fileTypeIcon(item)" :key="item.path" />
-        </oc-table-cell>
-        <oc-table-cell class="uk-text-meta uk-text-nowrap">
-          <div v-if="$route.name === 'files-shared-with-others'" key="shared-with-cell">
-            {{ item.sharedWith }} <translate v-if="item.shareType === 1">(group)</translate>
-          </div>
-          <div v-else key="shared-from-cell">
-            {{ item.shareOwnerDisplayname }}
-          </div>
-        </oc-table-cell>
-        <oc-table-cell v-if="$route.name === 'files-shared-with-me'" class="uk-text-nowrap uk-text-right" :key="item.id + item.status">
-          <a v-if="item.status === 1 || item.status === 2" class="uk-text-meta" @click="pendingShareAction(item, 'POST')" v-translate>Accept</a>
-          <a v-if="item.status === 1" class="uk-text-meta uk-margin-left" @click="pendingShareAction(item, 'DELETE')" v-translate>Decline</a>
-          <span class="uk-text-small uk-margin-left" v-text="shareStatus(item.status)" />
-        </oc-table-cell>
-        <oc-table-cell class="uk-text-meta uk-text-nowrap" v-text="formDateFromNow(item.shareTime)" />
-      </oc-table-row>
-    </oc-table-group>
-  </oc-table>
+  <div>
+    <oc-table middle divider class="oc-filelist" id="shared-with-list" v-if="!loadingFolder && !!fileData.length">
+      <oc-table-group>
+        <oc-table-row>
+          <oc-table-cell type="head" class="uk-text-truncate" v-translate>Name</oc-table-cell>
+          <oc-table-cell shrink type="head" class="uk-text-nowrap" v-text="sharedCellTitle" />
+          <oc-table-cell
+            v-if="$route.name === 'files-shared-with-me'"
+            shrink
+            type="head"
+            class="uk-text-nowrap"
+            v-translate
+          >
+            Status
+          </oc-table-cell>
+          <oc-table-cell shrink type="head" class="uk-text-nowrap" v-translate>Share time</oc-table-cell>
+        </oc-table-row>
+      </oc-table-group>
+      <oc-table-group>
+        <oc-table-row v-for="(item, index) in fileData" :key="index" :class="_rowClasses(item)" @click="selectRow(item, $event)" :id="'file-row-' + item.id">
+          <oc-table-cell class="uk-text-truncate">
+            <oc-file :name="item.basename" :extension="item.extension" class="file-row-name uk-disabled"
+              :filename="item.name" :icon="fileTypeIcon(item)" :key="item.path" />
+          </oc-table-cell>
+          <oc-table-cell class="uk-text-meta uk-text-nowrap">
+            <div v-if="$route.name === 'files-shared-with-others'" key="shared-with-cell">
+              {{ item.sharedWith }} <translate v-if="item.shareType === 1">(group)</translate>
+            </div>
+            <div v-else key="shared-from-cell">
+              {{ item.shareOwnerDisplayname }}
+            </div>
+          </oc-table-cell>
+          <oc-table-cell v-if="$route.name === 'files-shared-with-me'" class="uk-text-nowrap uk-text-right" :key="item.id + item.status">
+            <a v-if="item.status === 1 || item.status === 2" class="uk-text-meta" @click="pendingShareAction(item, 'POST')" v-translate>Accept</a>
+            <a v-if="item.status === 1" class="uk-text-meta uk-margin-left" @click="pendingShareAction(item, 'DELETE')" v-translate>Decline</a>
+            <span class="uk-text-small uk-margin-left" v-text="shareStatus(item.status)" />
+          </oc-table-cell>
+          <oc-table-cell class="uk-text-meta uk-text-nowrap" v-text="formDateFromNow(item.shareTime)" />
+        </oc-table-row>
+      </oc-table-group>
+    </oc-table>
+    <oc-grid gutter="large" class="uk-width-1-1 uk-padding-small" v-if="!loadingFolder && !fileData.length">
+      <div>{{ $_ocEmptyFolderText() }}</div>
+    </oc-grid>
+  </div>
 </template>

--- a/apps/files/src/components/FileList.vue
+++ b/apps/files/src/components/FileList.vue
@@ -2,7 +2,7 @@
   <div class="uk-height-1-1">
     <div class="uk-flex uk-flex-column uk-height-1-1">
       <div id="files-list-container" class="uk-overflow-auto uk-flex-auto">
-        <oc-table middle divider class="oc-filelist uk-margin-remove-bottom" id="files-list" v-show="!loadingFolder">
+        <oc-table middle divider class="oc-filelist uk-margin-remove-bottom" id="files-list" v-show="!loadingFolder && !!fileData.length">
           <thead>
             <oc-table-row>
               <oc-table-cell shrink type="head">
@@ -76,6 +76,9 @@
             </oc-table-row>
           </oc-table-group>
         </oc-table>
+        <oc-grid gutter="large" class="uk-width-1-1 uk-padding-small" v-if="!loadingFolder && !fileData.length">
+          <div>{{ $_ocEmptyFolderText() }}</div>
+        </oc-grid>
       </div>
       <oc-grid gutter="large" class="uk-width-1-1 uk-padding-small" v-if="!loadingFolder">
         <div v-if="activeFilesCount.folders > 0 || activeFilesCount.files > 0" class="uk-text-nowrap uk-text-meta">
@@ -193,6 +196,13 @@ export default {
         if (pathSplit.length > 2) return `…/${pathSplit[pathSplit.length - 2]}/${item.basename}`
       }
       return item.basename
+    },
+
+    $_ocEmptyFolderText () {
+      if (this.$route.name === 'files-favorites') {
+        return this.$gettext('No favorites defined')
+      }
+      return this.$gettext('This folder is empty')
     },
 
     enabledActions (item) {

--- a/apps/files/src/components/Trashbin.vue
+++ b/apps/files/src/components/Trashbin.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <oc-table middle divider class="oc-filelist" id="files-list" v-show="!loadingFolder">
+    <oc-table middle divider class="oc-filelist" id="files-list" v-show="!loadingFolder && !!fileData.length">
       <oc-table-group>
         <oc-table-row>
           <oc-table-cell shrink type="head">
@@ -34,6 +34,9 @@
         </oc-table-row>
       </oc-table-group>
     </oc-table>
+    <oc-grid gutter="large" class="uk-width-1-1 uk-padding-small" v-if="!loadingFolder && !fileData.length">
+      <div>{{ $_ocEmptyFolderText() }}</div>
+    </oc-grid>
     <oc-dialog-prompt name="delete-file-confirmation-dialog" :oc-active="trashbinDeleteMessage !== ''"
                       :oc-content="trashbinDeleteMessage" :oc-has-input="false" :ocTitle="_deleteDialogTitle"
                       ocConfirmId="oc-dialog-delete-confirm" @oc-confirm="$_ocTrashbin_clearTrashbinConfirmation"
@@ -206,6 +209,10 @@ export default {
         if (pathSplit.length > 2) return `…/${pathSplit[pathSplit.length - 2]}/${item.basename}`
       }
       return item.basename
+    },
+
+    $_ocEmptyFolderText () {
+      return this.$gettext('The trash bin is empty')
     }
   }
 }


### PR DESCRIPTION
## Description
Whenever a folder is empty, a message is now shown instead of an empty table.

## Related Issue
Fixes https://github.com/owncloud/phoenix/issues/1910

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manual test

## Screenshots (if appropriate):
<img width="960" alt="image" src="https://user-images.githubusercontent.com/277525/64353571-43f0ad00-cffe-11e9-8a6c-5ca2e0336dbd.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] improve design
- [ ] acceptance test
