### PR TITLE
Adjusted access denied template

### DIFF
--- a/src/pages/accessDenied.vue
+++ b/src/pages/accessDenied.vue
@@ -8,13 +8,15 @@
               <h3 class="oc-login-card-title">
                   <span v-translate>Login Error</span>
               </h3>
-              <h4 v-translate>
+              <h4 v-translate class="uk-margin-remove">
                 You are not allowed to use this application.
               </h4>
           </div>
-          <div class="oc-login-card-footer">
-              <p>{{ helpDeskText }}</p>
-            <a v-if="helpDeskLink !== ''" :href="helpDeskLink">{{ helpDeskLinkText }}</a>
+          <div class="oc-login-card-footer uk-width-large">
+              <p>
+                {{ helpDeskText }}
+                <a v-if="helpDeskLink" :href="helpDeskLink" v-text="helpDeskLinkText" />
+              </p>
           </div>
       </div>
   </div>


### PR DESCRIPTION
## Description
Added fixed width to footer of access denied page and moved link into `p` tag to keep it on same line.

## Motivation and Context
Without fixed width the footer would expand across the screen create one big line of text - bad. Also when the link was outside the `p` tag, it was always on its own line + margin bottom was applied.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually


## Screenshots (if appropriate):
![localhost_8300_(iPad) (1)](https://user-images.githubusercontent.com/25989331/64539491-e1115580-d31e-11e9-9d0e-dfc6366ab47d.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 