### PR TITLE
Display error message for folder upload on ie11 and prevent upload

### DIFF
--- a/apps/files/src/components/FilesAppBar.vue
+++ b/apps/files/src/components/FilesAppBar.vue
@@ -26,7 +26,7 @@
             <oc-drop toggle="#new-file-menu-btn" mode="click">
               <oc-nav>
                 <file-upload :url='url' :headers="headers" @success="onFileSuccess" @error="onFileError" @progress="onFileProgress"></file-upload>
-                <folder-upload :rootPath='item' :url='url' :headers="headers" @success="onFileSuccess" @error="onFileError" @progress="onFileProgress"></folder-upload>
+                <folder-upload v-if="!isIE11()" :rootPath='item' :url='url' :headers="headers" @success="onFileSuccess" @error="onFileError" @progress="onFileProgress"></folder-upload>
                 <oc-nav-item @click="createFolder = true" id="new-folder-btn" icon="create_new_folder"><translate>Create new folder…</translate></oc-nav-item>
                 <oc-nav-item @click="createFile = true" id="new-file-btn" icon="save"><translate>Create new file…</translate></oc-nav-item>
               </oc-nav>

--- a/apps/files/src/mixins.js
+++ b/apps/files/src/mixins.js
@@ -264,6 +264,15 @@ export default {
       }
     },
     $_ocUpload_addDirectoryToQue (e) {
+      if (this.isIE11()) {
+        this.showMessage({
+          title: this.$gettext('Upload failed'),
+          desc: this.$gettext('Upload of a folder is not supported in Internet Explorer.'),
+          status: 'danger'
+        })
+        return
+      }
+
       const files = e.target.files || e.dataTransfer.files
       if (!files.length) return
 

--- a/src/plugins/phoenix.js
+++ b/src/plugins/phoenix.js
@@ -85,8 +85,15 @@ export default {
           })
 
           request.send()
-        }
+        },
 
+        /**
+         * Checks whether the browser is Internet Explorer 11
+         * @return {boolean} true if the browser is Internet Expoler 11
+         */
+        isIE11 () {
+          return !!window.MSInputMethodContext && !!document.documentMode
+        }
       }
     })
   }


### PR DESCRIPTION
## Description
Hide folder upload option in "+ New" dropdown and display error message for drag and drop in case user tries to upload folder in IE11

## Motivation and Context
Folder upload is not supported in IE11 🤢 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually
1. Try to upload folder with drag and drop in IE11
2. Open "+ New" drop and look for "upload folder" option

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/25989331/64080294-8f4f4680-ccf2-11e9-95e5-1fa98d7f768c.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 