### PR TITLE
Notifications now fully visible on small screens

### DIFF
--- a/src/components/Notifications.vue
+++ b/src/components/Notifications.vue
@@ -10,8 +10,8 @@
     <oc-drop
       id="oc-notification-drop"
       toggle="#oc-notification-bell"
-      boundary="#oc-notification"
-      class="uk-overflow-auto uk-height-large uk-width-large"
+      position="bottom-right"
+      class="uk-overflow-auto uk-height-large uk-width-3-4 uk-width-large@s"
     >
       <div
         v-for="(el, index) in activeNotifications"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Added a procentual width(75%) instead of a fixed width to all small devices (<640px = all common mobile devices) and removed the boundary

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #1505 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Generate a test notification via occ
- Check if the notification panel is fully visible on large as well as small devices

## Screenshots (if appropriate):
![Bildschirmfoto von »2019-09-10 13-51-31«](https://user-images.githubusercontent.com/2546997/64611821-99e49c80-d3d2-11e9-9e42-2f70a4fe8702.png)
![Bildschirmfoto von »2019-09-10 13-51-06«](https://user-images.githubusercontent.com/2546997/64611825-9c46f680-d3d2-11e9-931c-0dace120a821.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...