### PR TITLE
Render full file path in trashbin

### DIFF
--- a/apps/files/src/components/Trashbin.vue
+++ b/apps/files/src/components/Trashbin.vue
@@ -17,8 +17,8 @@
             <oc-checkbox class="uk-margin-small-left" @change.native="$_ocTrashbin_toggleFileSelect(item)" :value="selectedFiles.indexOf(item) >= 0" />
           </oc-table-cell>
           <oc-table-cell class="uk-text-truncate">
-            <oc-file :name="item.basename" :extension="item.extension" class="file-row-name"
-                    :filename="item.name" :icon="fileTypeIcon(item)" :key="item.path" />
+            <oc-file :name="$_ocTrashbin_fileName(item)" :extension="item.extension" class="file-row-name"
+                    :filename="item.name" :icon="fileTypeIcon(item)" :key="item.originalLocation" />
           </oc-table-cell>
           <oc-table-cell class="uk-text-meta uk-text-nowrap">
             {{ formDateFromNow(item.deleteTimestamp) }}
@@ -197,6 +197,15 @@ export default {
 
     $_ocTrashbin_removeFileFromList (files) {
       this.removeFilesFromTrashbin(files)
+    },
+
+    $_ocTrashbin_fileName (item) {
+      if (item && item.originalLocation) {
+        const pathSplit = item.originalLocation.split('/')
+        if (pathSplit.length === 2) return `${pathSplit[pathSplit.length - 2]}/${item.basename}`
+        if (pathSplit.length > 2) return `…/${pathSplit[pathSplit.length - 2]}/${item.basename}`
+      }
+      return item.basename
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Applied the same logic on the trashbin files as file-favorites uses

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #1525 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- See #1525 

## Screenshots (if appropriate):
![Bildschirmfoto von »2019-09-10 15-09-53«](https://user-images.githubusercontent.com/2546997/64618007-bb985080-d3df-11e9-8380-a8f76029c2b3.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...