### PR TITLE
File list star is now a button

### DIFF
--- a/apps/files/src/components/FileList.vue
+++ b/apps/files/src/components/FileList.vue
@@ -21,7 +21,9 @@
                 <oc-checkbox class="uk-margin-small-left" @click.stop @change.native="$emit('toggle', item)" :value="selectedFiles.indexOf(item) >= 0" />
               </oc-table-cell>
               <oc-table-cell class="uk-padding-remove" v-if="!publicPage()">
-                <oc-star class="uk-display-block" @click.native.stop="toggleFileFavorite(item)" :shining="item.starred" />
+                <oc-button variation="link" @click.native.stop="toggleFileFavorite(item)" :ariaLabel="$_ocMarkFavoriteLabel(item.starred)">
+                  <oc-star class="uk-display-block" :shining="item.starred" />
+                </oc-button>
               </oc-table-cell>
               <oc-table-cell class="uk-text-truncate">
                 <oc-file @click.native.stop="item.type === 'folder' ? navigateTo(item.path.substr(1)) : openFileActionBar(item)"
@@ -187,6 +189,10 @@ export default {
         file: item
       })
     },
+    $_ocMarkFavoriteLabel (state) {
+      return state ? this.$gettext('Unmark as favorite') : this.$gettext('Mark as favorite')
+    },
+
     $_ocFileName (item) {
       if (this.$route.name === 'files-favorites') {
         const pathSplit = item.path.substr(1).split('/')


### PR DESCRIPTION
## Description
This brings the following benefits:
- hand mouse cursor on hover
- readable by accessibility tools

## Related Issue
- Fixes https://github.com/owncloud/phoenix/issues/1645

## Motivation and Context
Mostly accessibility

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] REQUIRES: design PR: https://github.com/owncloud/owncloud-design-system/pull/481