### PR TITLE
Only fetch notifications if capability is set

### DIFF
--- a/src/components/Top-Bar.vue
+++ b/src/components/Top-Bar.vue
@@ -48,15 +48,19 @@ export default {
     if (this.publicPage()) {
       return
     }
-    this.fetchNotifications(this.$client).then(() => {
-      this.intervalId = setInterval(() => {
-        this.fetchNotifications(this.$client).catch(() => {
-          if (this.intervalId) {
-            clearInterval(this.intervalId)
-          }
-        })
-      }, 30000)
-    })
+
+    // only fetch notifications if the server supports them
+    if (this.user.capabilities.notifications) {
+      this.fetchNotifications(this.$client).then(() => {
+        this.intervalId = setInterval(() => {
+          this.fetchNotifications(this.$client).catch(() => {
+            if (this.intervalId) {
+              clearInterval(this.intervalId)
+            }
+          })
+        }, 30000)
+      })
+    }
   },
   destroyed: function () {
     if (this.intervalId) {


### PR DESCRIPTION
## Description
Whenever the server does not support notifications, don't bother pinging
its API

## Related Issue
Fixes https://github.com/owncloud/phoenix/issues/1957

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- [x] TEST: manual test notifications app disabled with network console: no entry
- [x] TEST: manual test notifications app enabled with network console: notifications API is called

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
