### PR TITLE
More watch exclusions

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -22,7 +22,13 @@ module.exports = merge(common, {
     port: 8300,
     disableHostCheck: true,
     watchOptions: {
-      ignored: [path.resolve(__dirname, 'tests'), path.resolve(__dirname, 'node_modules')]
+      ignored: [
+        path.resolve(__dirname, 'tests'),
+        path.resolve(__dirname, 'build'),
+        path.resolve(__dirname, 'dist'),
+        path.resolve(__dirname, 'node_modules'),
+        path.resolve(__dirname, 'apps') + '/*/node_modules'
+      ]
     }
   }
 })


### PR DESCRIPTION
For some reason I got an error again today about too many watchers and it was pointing at a file in "apps/*/node_modules".

This PR also excludes apps' "node_modules" and additionally "dist" and "build", just in case...
