### PR TITLE
Set X-Requested-With header - required ownCloud 10.3

### DIFF
--- a/src/store/user.js
+++ b/src/store/user.js
@@ -46,6 +46,9 @@ const actions = {
         baseUrl: instance,
         auth: {
           bearer: token
+        },
+        headers: {
+          'X-Requested-With': 'XMLHttpRequest'
         }
       }
       if (context.state.id) {


### PR DESCRIPTION
## Description
Any request sent from phoenix to ownCloud has to include the header X-Requested-With
This is necessary to prevent browsers to popup an authentication dialog on a 401 response

This will only work with ownCloud 10.3

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...