### PR TITLE
Fix public link permissions mix up

### DIFF
--- a/apps/files/src/components/FileLinkForm.vue
+++ b/apps/files/src/components/FileLinkForm.vue
@@ -24,18 +24,18 @@
       </div>
       <div v-if="$_isFolder" class="uk-margin uk-grid-small" uk-grid>
       <div class="uk-width-auto">
-        <input type="radio" class="uk-radio" v-model="permissions" value="15" id="oc-files-file-link-collaborator-role-contributor" />
+        <input type="radio" class="uk-radio" v-model="permissions" value="5" id="oc-files-file-link-collaborator-role-contributor" />
       </div>
-      <label class="uk-width-expand" @click="permissions = 15">
+      <label class="uk-width-expand" @click="permissions = 5">
         <span v-translate>Contributor</span><br>
         <span class="uk-text-meta" v-translate>Recipients can view, download and upload contents.</span>
       </label>
       </div>
       <div v-if="$_isFolder" class="uk-margin uk-grid-small" uk-grid>
       <div class="uk-width-auto">
-        <input type="radio" class="uk-radio" v-model="permissions" value="5" id="oc-files-file-link-collaborator-role-editor" />
+        <input type="radio" class="uk-radio" v-model="permissions" value="15" id="oc-files-file-link-collaborator-role-editor" />
       </div>
-      <label class="uk-width-expand" @click="permissions = 5">
+      <label class="uk-width-expand" @click="permissions = 15">
         <span v-translate>Editor</span><br>
         <span class="uk-text-meta" v-translate>Recipients can view, download, edit, delete and upload contents.</span>
       </label>

--- a/apps/files/src/store/actions.js
+++ b/apps/files/src/store/actions.js
@@ -162,17 +162,18 @@ function _buildLink (l, $gettext) {
   const link = l.shareInfo
   let description = ''
 
+  // FIXME: use bitmask matching with constants
   switch (link.permissions) {
-    case ('1'):
+    case ('1'): // read (1)
       description = $gettext('Viewer')
       break
-    case ('15'):
+    case ('5'): // read (1) + create (4)
       description = $gettext('Contributor')
       break
-    case ('4'):
+    case ('4'): // create (4)
       description = $gettext('Uploader')
       break
-    case ('5'):
+    case ('15'): // read (1) + update (2) + create (4) + delete (8)
       description = $gettext('Editor')
       break
   }

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -30,6 +30,40 @@ Feature: Share by public link
       | simple-folder   |
       | lorem.txt       |
 
+  @smokeTest
+  Scenario Outline: simple sharing by public link with different roles
+    When the user creates a new public link for folder "simple-folder" using the webUI with
+      | role | <role> |
+    Then user "user1" should have a share with these details:
+      | field       | value          |
+      | share_type  | public_link    |
+      | uid_owner   | user1          |
+      | permissions | <permissions>  |
+      | path        | /simple-folder |
+      | name        | Public link    |
+    And a link named "Public link" should be listed with role "<role>" in the public link list of folder "simple-folder" on the webUI
+    When the public uses the webUI to access the last public link created by user "user1"
+    Then file "lorem.txt" should be listed on the webUI
+    Examples:
+      | role        | permissions                  |
+      | Viewer      | read                         |
+      | Editor      | read, change, create, delete |
+      | Contributor | read, create                 |
+
+  Scenario: sharing by public link with "Uploader" role
+    When the user creates a new public link for folder "simple-folder" using the webUI with
+      | role | Uploader |
+    Then user "user1" should have a share with these details:
+      | field       | value          |
+      | share_type  | public_link    |
+      | uid_owner   | user1          |
+      | permissions | create         |
+      | path        | /simple-folder |
+      | name        | Public link    |
+    And a link named "Public link" should be listed with role "Uploader" in the public link list of folder "simple-folder" on the webUI
+    When the public uses the webUI to access the last public link created by user "user1"
+    Then there should be no files/folders listed on the webUI
+
   @skip @yetToImplement
   Scenario: creating a public link with read & write permissions makes it possible to delete files via the link
     When the user creates a new public link for folder "simple-folder" using the webUI with

--- a/tests/acceptance/pageObjects/FilesPageElement/publicLinksDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/publicLinksDialog.js
@@ -4,13 +4,20 @@ module.exports = {
      * creates a new public link
      * @returns {*}
      */
-    addNewLink: function () {
+    addNewLink: async function (role = null) {
       const addLinkButtonXpath = this.elements.publicLinkContainer.selector + this.elements.addLinkButton.selector
       const createLinkButtonXpath = this.elements.publicLinkContainer.selector + this.elements.createLinkButton.selector
-      return this
+      this
         .click({ locateStrategy: 'xpath', selector: addLinkButtonXpath })
         .waitForElementVisible({ locateStrategy: 'xpath', selector: createLinkButtonXpath })
-        .click({ locateStrategy: 'xpath', selector: createLinkButtonXpath })
+
+      if (role !== null) {
+        const util = require('util')
+        const roleSelectorXpath = util.format(this.elements.roleButton.selector, role)
+        await this.click({ locateStrategy: 'xpath', selector: roleSelectorXpath })
+      }
+
+      return this.click({ locateStrategy: 'xpath', selector: createLinkButtonXpath })
         .waitForOutstandingAjaxCalls()
         .waitForElementNotPresent({ locateStrategy: 'xpath', selector: createLinkButtonXpath })
     },
@@ -54,6 +61,9 @@ module.exports = {
     createLinkButton: {
       selector: '//button[contains(.,"Create")]',
       locateStrategy: 'xpath'
+    },
+    roleButton: {
+      selector: '//*[contains(@class,"oc-files-file-link-form")]//*[.="%s"]'
     }
   }
 }

--- a/tests/acceptance/stepDefinitions/publicLinkContext.js
+++ b/tests/acceptance/stepDefinitions/publicLinkContext.js
@@ -17,6 +17,18 @@ When(
   }
 )
 
+When(
+  'the user creates a new public link for file/folder/resource {string} using the webUI with',
+  function (resource, settingsTable) {
+    const settings = settingsTable.rowsHash()
+    return client.page.FilesPageElement
+      .filesList()
+      .closeSidebar(100)
+      .openPublicLinkDialog(resource)
+      .addNewLink(settings.role)
+  }
+)
+
 When('the public uses the webUI to access the last public link created by user {string}', async function (linkCreator) {
   const headers = httpHelper.createAuthHeader(linkCreator)
   const apiURL = client.globals.backend_url + '/ocs/v2.php/apps/files_sharing/api/v1/shares?format=json'


### PR DESCRIPTION
## Description
The permissions for Editor and Contributor got mixed up.
This swaps them.

## Related Issue
Fixes https://github.com/owncloud/phoenix/issues/1979

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Notes

Test will come separately in https://github.com/owncloud/phoenix/pull/1980