### PR TITLE
Enable loading apps from external sites

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,5 +116,8 @@
       "yarn lint --fix",
       "git add"
     ]
+  },
+  "dependencies": {
+    "deepmerge": "^4.0.0"
   }
 }

--- a/src/phoenix.js
+++ b/src/phoenix.js
@@ -132,6 +132,9 @@ function loadApps () {
       store.registerModule(app.appInfo.name, app.store.default)
     }
     store.dispatch('registerApp', app.appInfo)
+    if (config.external_apps) {
+      store.dispatch('loadExternalAppConfig', { app: app.appInfo, config })
+    }
   }
   router.addRoutes(routes.flat())
   sync(store, router)
@@ -217,9 +220,17 @@ function requireError (err) {
       config.state = 'missing'
     })
     config = await config.json()
+
+    // Loads apps from internal server
     apps = config.apps.map((app) => {
       return `./apps/${app}/${app}.bundle.js`
     })
+
+    // Loads apps from external servers
+    if (config.external_apps) {
+      config.external_apps.map(app => apps.push(app.path))
+    }
+
     requirejs(apps, loadApps, requireError)
   } catch (err) {
     router.push('missing-config')

--- a/src/store/apps.js
+++ b/src/store/apps.js
@@ -1,3 +1,5 @@
+const merge = require('deepmerge')
+
 const state = {
   file: {
     path: '',
@@ -30,8 +32,36 @@ const actions = {
       }
     })
   },
-  registerApp ({ commit }, app) {
+  registerApp ({ commit, dispatch }, app) {
     commit('REGISTER_APP', app)
+  },
+
+  /**
+   * Load config for external app
+   * @param {Object} app      AppInfo containing information about app and local config
+   * @param {Object} config   Config from config.json which can overwrite local config from AppInfo
+   */
+  loadExternalAppConfig ({ dispatch }, { app, config }) {
+    config.external_apps.map(extension => {
+      // Check if app is loaded from external server
+      // Extension id = id from external apps array
+      // App id = id specified in AppInfo
+      if (extension.id === app.id && (app.config || extension.config)) {
+        if (app.config && extension.config) {
+          dispatch(`${app.name}/loadConfig`, merge(app.config, extension.config), { root: true })
+          return
+        }
+
+        if (app.config) {
+          dispatch(`${app.name}/loadConfig`, app.config, { root: true })
+          return
+        }
+
+        if (extension.config) {
+          dispatch(`${app.name}/loadConfig`, extension.config, { root: true })
+        }
+      }
+    })
   }
 }
 


### PR DESCRIPTION
## Description
Load also external apps via requirejs and load their config either from appInfo, config.json or both. Define apps in config with:
```
"external_apps": [
    {
      "id": "<app-id-specified-in-appinfo>",
      "path": "<path-to-app-bundle.js>",
      "config": {
        ...
      }
    }
  ]
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #1151

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually
Tested with https://github.com/owncloud/ocis-hello

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 