### PR TITLE
Use 2 spaces instead of tab for feature files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ charset = utf-8
 trim_trailing_whitespace = true
 end_of_line = lf
 
-[*.{js,json,vue}]
+[*.{js,json,vue,feature}]
 indent_style = space
 indent_size = 2
 

--- a/tests/acceptance/features/webUILogin/login.feature
+++ b/tests/acceptance/features/webUILogin/login.feature
@@ -1,16 +1,16 @@
 Feature: login users
-	As a user
-	I want to be able to log into my account
-	So that I have access to my files
+  As a user
+  I want to be able to log into my account
+  So that I have access to my files
 
-	As an admin
-	I want only authorised users to log in
-	So that unauthorised access is impossible
+  As an admin
+  I want only authorised users to log in
+  So that unauthorised access is impossible
 
-	Scenario: admin login
-		Given the user has browsed to the login page
-		When the user clicks the authenticate button
-		And the user logs in with username "admin" and password "admin" using the webUI
-		And the user authorizes access to phoenix
-		Then the files table should be displayed
-		And the files table should not be empty
+  Scenario: admin login
+    Given the user has browsed to the login page
+    When the user clicks the authenticate button
+    And the user logs in with username "admin" and password "admin" using the webUI
+    And the user authorizes access to phoenix
+    Then the files table should be displayed
+    And the files table should not be empty


### PR DESCRIPTION
Adjusted `.editorconfig` for feature files.
Adjusted one feature file that still had tabs.