### PR TITLE
Handle OAuth/OpenIdConnect error in callback request query string

### DIFF
--- a/src/pages/oidcCallback.vue
+++ b/src/pages/oidcCallback.vue
@@ -4,14 +4,22 @@
             <h1 class="oc-login-logo" v-translate>
                 ownCloud
             </h1>
-            <div class="oc-login-card-body">
-                <h3 class="oc-login-card-title">
-                    <translate>Redirecting</translate>
-                </h3>
-                <p v-translate>
-                    Please wait a while. You are being redirected.
-                </p>
-            </div>
+          <div v-show="error" class="oc-login-card-body">
+            <h3 class="oc-login-card-title">
+              <translate>Authentication failed</translate>
+            </h3>
+            <p v-translate>
+              Please contact the administrator if this error persists.
+            </p>
+          </div>
+          <div v-show="!error" class="oc-login-card-body">
+            <h3 class="oc-login-card-title">
+              <translate>Redirecting</translate>
+            </h3>
+            <p v-translate>
+              Please wait a while. You are being redirected.
+            </p>
+          </div>
             <div class="oc-login-card-footer">
                 <p>
                     {{ configuration.theme.general.slogan }}
@@ -27,11 +35,18 @@ export default {
   name: 'OidcCallbackPage',
   mounted () {
     this.$nextTick(() => {
+      if (this.$route.query.error) {
+        this.error = true
+        console.warn('OAuth error: ' + this.$route.query.error + ' - ' + this.$route.query.error_description)
+        return
+      }
       this.callback()
     })
   },
   data () {
-    return {}
+    return {
+      error: false
+    }
   },
   computed: {
     ...mapGetters(['configuration'])


### PR DESCRIPTION
## Description
Handle OAuthh/OpenIdConnect error in callback request query string

## Related Issue
- requires https://github.com/owncloud/oauth2/pull/220


## How Has This Been Tested?
- connect with owncloud and OAuth2 app as per PR above
- send wrong request type in https://github.com/owncloud/phoenix/blob/e93dd8bcddf19b966476e2c5bcb9025cda5f178c/src/services/auth.js#L49 - e.g. 'oken' instead of 'token'
- see the redirect page being called with a general error message

## Screenshots (if appropriate):
![Screenshot from 2019-09-18 18-14-24](https://user-images.githubusercontent.com/1005065/65166017-2e3ca800-da40-11e9-8719-da4837bd43f9.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...