### PR TITLE
Hide custom role entry for file shares

### DIFF
--- a/apps/files/src/components/Collaborators/mixins.js
+++ b/apps/files/src/components/Collaborators/mixins.js
@@ -1,9 +1,10 @@
 import { mapGetters, mapActions } from 'vuex'
 
 export default {
-  data () {
-    return {
-      roles: {
+  computed: {
+    ...mapGetters(['getToken']),
+    roles () {
+      const roles = {
         viewer: {
           tag: 'viewer',
           name: this.$gettext('Viewer'),
@@ -22,10 +23,11 @@ export default {
           description: this.$gettext('Set detailed permissions')
         }
       }
+      if (this.highlightedFile.type === 'file') {
+        delete roles.custom
+      }
+      return roles
     }
-  },
-  computed: {
-    ...mapGetters(['getToken'])
   },
   methods: {
     ...mapActions('Files', ['toggleCollaboratorsEdit']),

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -52,7 +52,6 @@ Feature: Sharing files and folders with internal groups
       | set-role    | expected-role | permissions-folder         | permissions-file |
       | Viewer      | Viewer        | read                       | read             |
       | Editor      | Editor        | read,change,create, delete | read,change      |
-      | Custom Role | Viewer        | read                       | read             |
 
   @skip @yetToImplement
   Scenario: share a file with an internal group a member overwrites and unshares the file

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -47,7 +47,6 @@ Feature: Sharing files and folders with internal users
       | set-role    | expected-role | permissions-folder        | permissions-file |
       | Viewer      | Viewer        | read                      | read             |
       | Editor      | Editor        | read,change,create,delete | read,change      |
-      | Custom Role | Viewer        | read                      | read             |
 
   Scenario Outline: change the collaborators of a file & folder
     Given user "user2" has logged in using the webUI

--- a/tests/acceptance/features/webUISharingPermissions/sharePermissionsGroup.feature
+++ b/tests/acceptance/features/webUISharingPermissions/sharePermissionsGroup.feature
@@ -55,10 +55,6 @@ Feature: Sharing files and folders with internal groups with permissions
     | Viewer      | Viewer         | ,                 | ,                     | read                |
     | Editor      | Editor         | share             | share                 | share, read, change |
     | Editor      | Editor         | ,                 | ,                     | read, change        |
-    | Custom Role | Viewer         | ,                 | ,                     | read                |
-    | Custom Role | Viewer         | share             | share                 | read, share         |
-    | Custom Role | Editor         | change            | ,                     | read, change        |
-    | Custom Role | Editor         | share, change     | share                 | read, change, share |
 
   @issue-1837 @issue-1897
   Scenario Outline: share a folder with multiple users with different roles and permissions

--- a/tests/acceptance/features/webUISharingPermissions/sharePermissionsUsers.feature
+++ b/tests/acceptance/features/webUISharingPermissions/sharePermissionsUsers.feature
@@ -203,10 +203,6 @@ Feature: Sharing files and folders with internal users with different permission
       | Viewer      | Viewer         | ,                 | ,                     | read                |
       | Editor      | Editor         | share             | share                 | share, read, change |
       | Editor      | Editor         | ,                 | ,                     | read, change        |
-      | Custom Role | Viewer         | ,                 | ,                     | read                |
-      | Custom Role | Viewer         | share             | share                 | read, share         |
-      | Custom Role | Editor         | change            | ,                     | read, change        |
-      | Custom Role | Editor         | share, change     | share                 | read, change, share |
 
   Scenario Outline: Change permissions of the previously shared file
     Given user "user2" has shared file "lorem.txt" with user "user1" with "<initial-permissions>" permissions
@@ -256,7 +252,6 @@ Feature: Sharing files and folders with internal users with different permission
       | role        | displayed-role | collaborators-permissions | displayed-permissions | permissions         |
       | Viewer      | Viewer         | share                     | share                 | read, share         |
       | Editor      | Editor         | share                     | share                 | read, share, change |
-      | Custom Role | Editor         | share, change             | share                 | read, share, change |
 
   Scenario: Share a folder without share permissions using API and check if it is listed on the collaborators list for original owner
     Given user "user2" has shared folder "simple-folder" with user "user1" with "read" permissions


### PR DESCRIPTION

## Description
Filter out `custom` collaborator type for file shares

## Related Issue
- Fixes #1961

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...