### PR TITLE
Use sharetype keys that are human readable instead of number

### DIFF
--- a/tests/acceptance/helpers/sharingHelper.js
+++ b/tests/acceptance/helpers/sharingHelper.js
@@ -4,20 +4,20 @@ const fetch = require('node-fetch')
 const assert = require('assert')
 
 module.exports = {
-  PERMISSION_TYPES: {
+  SHARE_TYPES: Object.freeze({
+    user: 0,
+    group: 1,
+    public_link: 3,
+    federated_cloud_share: 6
+  }),
+  PERMISSION_TYPES: Object.freeze({
     read: 1,
     change: 2,
     create: 4,
     delete: 8,
     share: 16,
     all: 31
-  },
-  SHARE_TYPES: {
-    user: 0,
-    group: 1,
-    public_link: 3,
-    federated_cloud_share: 6
-  },
+  }),
   /**
    *
    * @param permissionsString string of permissions separated by comma. For valid permissions see this.PERMISSION_TYPES

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -7,6 +7,7 @@ require('url-search-params-polyfill')
 const httpHelper = require('../helpers/httpHelper')
 const userSettings = require('../helpers/userSettings')
 const sharingHelper = require('../helpers/sharingHelper')
+const { SHARE_TYPES } = require('../helpers/sharingHelper')
 
 /**
  *
@@ -53,7 +54,7 @@ const userSharesFileOrFolderWithGroup = function (file, sharee, role) {
  * @param {number} shareType  Type of share 0 = user, 1 = group, 3 = public (link), 6 = federated (cloud share).
  * @param {string} permissions  permissions of the share for valid permissions see sharingHelper.PERMISSION_TYPES
  */
-const shareFileFolder = function (elementToShare, sharer, receiver, shareType = 0, permissionString = 'all') {
+const shareFileFolder = function (elementToShare, sharer, receiver, shareType = SHARE_TYPES.user, permissionString = 'all') {
   const permissions = sharingHelper.humanReadablePermissionsToBitmask(permissionString)
   const params = new URLSearchParams()
   params.append('shareType', shareType)
@@ -140,12 +141,12 @@ Given('the user has shared file/folder {string} with user {string}', function (s
 Given(
   'user {string} has shared file/folder {string} with user {string} with {string} permissions',
   function (sharer, elementToShare, receiver, permissions) {
-    return shareFileFolder(elementToShare, sharer, receiver, 0, permissions)
+    return shareFileFolder(elementToShare, sharer, receiver, SHARE_TYPES.user, permissions)
   }
 )
 
 Given('user {string} has shared file/folder {string} with group {string}', function (sharer, elementToShare, receiver) {
-  return shareFileFolder(elementToShare, sharer, receiver, 1)
+  return shareFileFolder(elementToShare, sharer, receiver, SHARE_TYPES.group)
 })
 
 When('the user types {string} in the share-with-field', function (input) {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Use human readable strings instead of number.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #2047 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...