### PR TITLE
Hide comma before mdate if size is in pending state

### DIFF
--- a/apps/files/src/components/FileDetails.vue
+++ b/apps/files/src/components/FileDetails.vue
@@ -16,7 +16,11 @@
           </template>
         </div>
         <div v-if="$route.name !== 'files-shared-with-others'">
-          <oc-star v-if="!publicPage()" class="uk-inline" :shining="highlightedFile.starred"/> {{ highlightedFile.size | fileSize }}, {{ formDateFromNow(highlightedFile.mdate) }}
+          <oc-star v-if="!publicPage()" class="uk-inline" :shining="highlightedFile.starred"/>
+          <template v-if="highlightedFile.size > -1">
+            {{ highlightedFile.size | fileSize }},
+          </template>
+          {{ formDateFromNow(highlightedFile.mdate) }}
         </div>
       </div>
     </template>


### PR DESCRIPTION
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually
1. Get item which returns no size
2. See no comma before mdata

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/25989331/65607368-b543d000-dfac-11e9-9260-1270d05a0869.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 