### PR TITLE
In case of auth errors (access denied, invalid token or cannot refres…

### DIFF
--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -92,6 +92,9 @@ export function initVueAuthenticate (config) {
       logout () {
         return mgr.signoutRedirect()
       },
+      clearLoginState () {
+        return mgr.removeUser()
+      },
       mgr: mgr,
       events () {
         return mgr.events

--- a/src/store/user.js
+++ b/src/store/user.js
@@ -15,12 +15,17 @@ const state = {
 }
 
 const actions = {
+  cleanUpLoginState (context) {
+    // reset user to default state
+    context.commit('SET_USER', state)
+    // reset capabilities to default state
+    context.commit('SET_CAPABILITIES', { capabilities: null, version: null })
+    // clear oidc client state
+    vueAuthInstance.clearLoginState()
+  },
   logout (context) {
     const logoutFinalizer = () => {
-      // reset user to default state
-      context.commit('SET_USER', state)
-      // reset capabilities to default state
-      context.commit('SET_CAPABILITIES', { capabilities: null, version: null })
+      context.dispatch('cleanUpLoginState')
       // force redirect to login page after logout
       router.push({ name: 'login' })
     }
@@ -76,6 +81,7 @@ const actions = {
           })
       }).catch((e) => {
         console.warn('Seems that your token is invalid. Error:', e)
+        context.dispatch('cleanUpLoginState')
         router.push({ name: 'accessDenied' })
       })
     }
@@ -86,6 +92,7 @@ const actions = {
         init(client, user.access_token)
       }).catch(error => {
         console.warn('token refresh failed ' + error)
+        context.dispatch('cleanUpLoginState')
         router.push({ name: 'accessDenied' })
       })
     }
@@ -119,6 +126,7 @@ const actions = {
       context.dispatch('initAuth', true)
     }).catch((e) => {
       console.warn('error in OpenIdConnect:', e)
+      context.dispatch('cleanUpLoginState')
       router.push({ name: 'accessDenied' })
     })
   },


### PR DESCRIPTION

## Description
In case of auth errors (access denied, invalid token or cannot refresh token) the state is cleared - otherwise there is no way to get out of this

## How Has This Been Tested?
- login via oauth to owncloud
- wait until the token times out (30min afaik)
- access denied page pops up
- go back to login page
- login page shall appear (without this patch the accessDenied page will show up)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...