### PR TITLE
Fix detection of public pages despite existing auth

### DIFF
--- a/src/plugins/phoenix.js
+++ b/src/plugins/phoenix.js
@@ -12,7 +12,9 @@ export default {
         ...mapActions(['showMessage']),
 
         publicPage () {
-          return !this.isAuthenticated
+          // public page is either when not authenticated
+          // but also when accessing pages that require no auth even when authenticated
+          return !this.isAuthenticated || this.$route.meta.auth === false
         },
         downloadFile (file) {
           this.addFileToProgress(file)


### PR DESCRIPTION
## Description
When opening public links while a session exists, we should still
consider the page a public page whenever the route is not requiring
auth. The latter is the case for public files and files drop pages.


## Related Issue
Fixes https://github.com/owncloud/phoenix/issues/1884

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- [x] TEST: access public link while authentication exists and delete a file must work
- [x] TEST: access public link while no authentication exists and delete a file must work
- [x] TEST: smoke test regular file list while authenticated

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

