### PR TITLE
Added logout step for acceptance tests

### DIFF
--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -6,7 +6,7 @@
       <translate>Account</translate>
     </oc-sidebar-nav-item>
 
-    <oc-sidebar-nav-item active icon="exit_to_app" @click="logout()" :isolate="true">{{ _logoutItemText }}</oc-sidebar-nav-item>
+    <oc-sidebar-nav-item id="logoutMenuItem" active icon="exit_to_app" @click="logout()" :isolate="true">{{ _logoutItemText }}</oc-sidebar-nav-item>
 
     <span class="uk-position-bottom uk-padding-small">Version: {{appVersion.version}}-{{appVersion.hash}} ({{appVersion.buildDate}})</span>
   </oc-application-menu>

--- a/tests/acceptance/features/webUILogin/login.feature
+++ b/tests/acceptance/features/webUILogin/login.feature
@@ -14,3 +14,13 @@ Feature: login users
     And the user authorizes access to phoenix
     Then the files table should be displayed
     And the files table should not be empty
+
+  Scenario: logging out
+    Given these users have been created with default attributes:
+      | username |
+      | user1    |
+    And user "user1" has logged in using the webUI
+    And the user has browsed to the files page
+    When the user logs out of the webUI
+    Then the authentication page should be visible
+

--- a/tests/acceptance/helpers/loginHelper.js
+++ b/tests/acceptance/helpers/loginHelper.js
@@ -59,5 +59,16 @@ module.exports = {
     await startWebDriver({ env })
     await createSession({ env })
     return this.loginAsUser(userId)
+  },
+
+  logout: function (userId) {
+    const phoenixPage = client.page.phoenixPage()
+    return phoenixPage
+      .navigate()
+      .waitForElementVisible('@menuButton')
+      .click('@menuButton')
+      .waitForElementVisible('@logoutMenuItem')
+      .waitForAnimationToFinish()
+      .click('@logoutMenuItem')
   }
 }

--- a/tests/acceptance/pageObjects/phoenixPage.js
+++ b/tests/acceptance/pageObjects/phoenixPage.js
@@ -87,6 +87,9 @@ module.exports = {
       selector: '//ul[contains(@class, "oc-main-menu")]/li/a[contains(text(),"%s")]',
       locateStrategy: 'xpath'
     },
+    logoutMenuItem: {
+      selector: '#logoutMenuItem'
+    },
     messageCloseIcon: {
       selector: '.oc-alert-close-icon'
     }

--- a/tests/acceptance/stepDefinitions/loginContext.js
+++ b/tests/acceptance/stepDefinitions/loginContext.js
@@ -55,9 +55,21 @@ Then('the files table should not be empty',
       .waitForElementVisible('@fileRows')
   })
 
+Then('the authentication page should be visible',
+  () => {
+    const loginPage = client
+      .page.loginPage()
+    return loginPage
+      .waitForElementPresent('@authenticateButton')
+  })
+
 // combined step
 Given('user {string} has logged in using the webUI', (user) => {
   return loginHelper.loginAsUser(user)
+})
+
+When('the user logs out of the webUI', () => {
+  return loginHelper.logout()
 })
 
 When('the user re-logs in as {string} using the webUI', (user) => {


### PR DESCRIPTION
## Description
Added logout step.
Added logout test case that includes the step and checks that the login
page appears after logging out.

## Related Issue

## Motivation and Context
Needed to be able to log out in some test cases, especially the public link ones.

## How Has This Been Tested?
- manual run

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

