### PR TITLE
Feature/focus mgmt main menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,5 +119,9 @@
       "yarn lint --fix",
       "git add"
     ]
+  },
+  "dependencies": {
+    "deepmerge": "^4.0.0",
+    "inert-polyfill": "^0.2.5"
   }
 }

--- a/src/Phoenix.vue
+++ b/src/Phoenix.vue
@@ -17,6 +17,7 @@
   </div>
 </template>
 <script>
+import 'inert-polyfill'
 import { mapGetters, mapState, mapActions } from 'vuex'
 import TopBar from './components/Top-Bar.vue'
 import Menu from './components/Menu.vue'

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -1,7 +1,6 @@
 <template>
-  <oc-application-menu name="coreMenu" v-model="sidebarIsVisible" @close="sidebarIsVisible = false">
+  <oc-application-menu name="coreMenu" v-model="sidebarIsVisible" :inert="!sidebarIsVisible" @close="sidebarIsVisible = false" ref="sidebar">
     <oc-sidebar-nav-item v-for="(n, nid) in nav" :active="isActive(n)" :key="nid" :icon="n.iconMaterial" :target="n.route ? n.route.path : null" @click="openItem(n.url)">{{ translateMenu(n) }}</oc-sidebar-nav-item>
-
     <oc-sidebar-nav-item icon="account_circle" target="/account" :isolate="true">
       <translate>Account</translate>
     </oc-sidebar-nav-item>
@@ -26,6 +25,11 @@ export default {
   watch: {
     $route () {
       this.toggleSidebar(false)
+    },
+    sidebarIsVisible (val) {
+      if (val) {
+        this.focusFirstLink()
+      }
     }
   },
   computed: {
@@ -76,6 +80,16 @@ export default {
     },
     isActive (navItem) {
       return navItem.route.name === this.$route.name
+    },
+    focusFirstLink () {
+      /*
+      * Delay for two reasons:
+      * - for screen readers Virtual buffer
+      * - to outsmart uikit's focus management
+      */
+      setTimeout(() => {
+        this.$refs.sidebar.$el.querySelector('a:first-of-type').focus()
+      }, 500)
     }
   }
 }

--- a/src/components/Top-Bar.vue
+++ b/src/components/Top-Bar.vue
@@ -1,7 +1,7 @@
 <template>
   <oc-navbar id="oc-topbar" tag="header" class="oc-topbar">
     <oc-navbar-item position="left">
-      <oc-button icon="menu" variation="primary" class="oc-topbar-menu-burger uk-height-1-1" aria-label="Menu" @click="toggleSidebar(!isSidebarVisible)" v-if="!publicPage()">
+      <oc-button icon="menu" variation="primary" class="oc-topbar-menu-burger uk-height-1-1" aria-label="Menu" @click="toggleSidebar(!isSidebarVisible)" v-if="!publicPage()" ref="menubutton">
         <span class="oc-topbar-menu-burger-label" v-translate>Menu</span>
       </oc-button>
     </oc-navbar-item>
@@ -65,6 +65,18 @@ export default {
   destroyed: function () {
     if (this.intervalId) {
       clearInterval(this.intervalId)
+    }
+  },
+  watch: {
+    isSidebarVisible: function (val) {
+      if (!val) {
+        /*
+        * Delay for screen readers Virtual buffers
+        */
+        setTimeout(() => {
+          this.$refs.menubutton.$el.focus()
+        }, 500)
+      }
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
The content of this PR deals with keyboard focus management in the context of the off canvas navigation. It has got to major parts

1. Preventing that interactive items in *hidden* off-canvas menu can be focussed
2. Sending focus in the menu once it opens, back to triggering button once it closes 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #1647

## Motivation and Context
Improve Accessibility: Keyboard navigation is not only crucial for keyboard only users, but **all** screen reader users

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually by hitting tab key and logging the document.activeElement in the browser's console.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...