### PR TITLE
Remove unused password arg from webdav.propfind

### DIFF
--- a/tests/acceptance/helpers/webdavHelper.js
+++ b/tests/acceptance/helpers/webdavHelper.js
@@ -1,7 +1,6 @@
 const { client } = require('nightwatch-api')
 const fetch = require('node-fetch')
 const httpHelper = require('../helpers/httpHelper')
-const userSettings = require('../helpers/userSettings')
 const convert = require('xml-js')
 
 /**
@@ -70,11 +69,10 @@ exports.move = function (userId, fromName, toName) {
  *
  * @param {string} path
  * @param {string} userId
- * @param {string} password
  * @param {array} properties
  * @param {number} folderDepth
  */
-exports.propfind = function (path, userId, password, properties, folderDepth = 1) {
+exports.propfind = function (path, userId, properties, folderDepth = 1) {
   const headers = httpHelper.createAuthHeader(userId)
   headers.Depth = folderDepth
   const davPath = client.globals.backend_url + '/remote.php/dav' + path
@@ -111,7 +109,7 @@ exports.propfind = function (path, userId, password, properties, folderDepth = 1
  */
 exports.getTrashBinElements = function (user) {
   return new Promise((resolve) => {
-    exports.propfind(`/trash-bin/${user}`, user, userSettings.getPasswordForUser(user),
+    exports.propfind(`/trash-bin/${user}`, user,
       [
         'oc:trashbin-original-filename',
         'oc:trashbin-original-location',
@@ -179,7 +177,7 @@ exports.getProperties = function (path, userId, requestedProps) {
   return new Promise((resolve) => {
     const trimmedPath = path.replace(/^\/+/, '') // remove a leading slash
     const relativePath = `/files/${userId}/${trimmedPath}`
-    exports.propfind(relativePath, userId, userSettings.getPasswordForUser(userId), requestedProps,
+    exports.propfind(relativePath, userId, requestedProps,
       0)
       .then(str => {
         const response = JSON.parse(convert.xml2json(str, { compact: true }))['d:multistatus']['d:response']


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
The `password` argument was unused. Removing it here as `httpHelper.createAuthHeader()` already uses password from given userid.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...