### PR TITLE
Properly reset capabilities on logout

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -15,7 +15,12 @@ Vue.use(Vuex)
 const vuexPersist = new VuexPersistence({
   key: 'phoenixState',
   storage: window.localStorage,
-  filter: (mutation) => (['SET_USER', 'SET_TOKEN', 'SET_PRIVATE_LINK_URL_PATH'].indexOf(mutation.type) > -1),
+  filter: (mutation) => ([
+    'SET_USER',
+    'SET_TOKEN',
+    'SET_CAPABILITIES',
+    'SET_PRIVATE_LINK_URL_PATH'
+  ].indexOf(mutation.type) > -1),
   modules: ['user', 'links']
 })
 


### PR DESCRIPTION
# Description
When logging out, we also reset capabilities in the SET_CAPABILITIES
mutation. To make sure that the cleared capabilities are persisted in
localStorage, we must include the above mutation in the whitelist for
vuex-persist.

See more detailed analysis here: https://github.com/owncloud/phoenix/issues/1882#issuecomment-537012974

## Related Issue
Indirectly related to https://github.com/owncloud/phoenix/issues/1882

## Motivation and Context
Proper cleanup on log out and avoid side effects with public pages like public links.

## How Has This Been Tested?
Login then log out. Then check local storage in the browser console, key "phoenixState" and in the JSON look at "user.capabilities" and "user.versions".
Before the fix, logging out would leave the values there.
After the fix, those arrays are properly cleared.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...