### PR TITLE
Remove private link from root

### DIFF
--- a/apps/files/src/store/actions.js
+++ b/apps/files/src/store/actions.js
@@ -39,7 +39,7 @@ function _buildFile (file) {
     permissions: file.fileInfo['{http://owncloud.org/ns}permissions'] || '',
     etag: file.fileInfo['{DAV:}getetag'],
     sharePermissions: file.fileInfo['{http://open-collaboration-services.org/ns}share-permissions'],
-    privateLink: file.fileInfo['{http://owncloud.org/ns}privatelink'],
+    privateLink: (file.name !== '') ? file.fileInfo['{http://owncloud.org/ns}privatelink'] : null,
     owner: {
       username: file.fileInfo['{http://owncloud.org/ns}owner-id'],
       displayName: file.fileInfo['{http://owncloud.org/ns}owner-display-name']
@@ -247,6 +247,7 @@ function _buildShare (s) {
 export default {
   loadFolder (context, { client, absolutePath, $gettext, routeName }) {
     context.commit('UPDATE_FOLDER_LOADING', true)
+    context.commit('UNSET_FOLDER')
 
     return new Promise((resolve, reject) => {
       let promise

--- a/apps/files/src/store/mutations.js
+++ b/apps/files/src/store/mutations.js
@@ -128,6 +128,10 @@ export default {
   UPDATE_FOLDER_LOADING (state, value) {
     state.loadingFolder = value
   },
+  UNSET_FOLDER (state) {
+    state.currentFolder = null
+    state.files = []
+  },
   CHECK_QUOTA (state, quota) {
     state.quota = quota
   },

--- a/tests/acceptance/features/webUIFiles/copyPrivateLinks.feature
+++ b/tests/acceptance/features/webUIFiles/copyPrivateLinks.feature
@@ -8,11 +8,8 @@ Feature: copy current path as a permanent link
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 
-  Scenario Outline: Copy permalink to clipboard
-    When the user browses to the folder <folder_name> on the files page
+  Scenario: Copy permalink to clipboard
+    When the user browses to the folder "simple-folder" on the files page
     And the user copies the permalink of the current folder using the webUI
-    Then the clipboard content should match permalink of resource <folder_name>
-    Examples:
-      | folder_name     |
-      | "/"             |
-      | "simple-folder" |
+    Then the clipboard content should match permalink of resource "simple-folder"
+


### PR DESCRIPTION
## Description
Remove privateLink attribute from the state for the root entry.
This removes the link anchor from the breadcrumb for the root entry.
Added UNSET_FOLDER mutation to clear the current folder, this makes the
anchor disappear during load while switching between root and subdir.

## Related Issue
Fixes https://github.com/owncloud/phoenix/issues/2095

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manual test switching between root and subfolders: during load the anchor never appears. After the folder is loaded, the anchor only appears for subfolders, not the root.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...