### PR TITLE
Rename and delete will be disallowed in case the parent folder has no…

### DIFF
--- a/apps/files/src/components/FileList.vue
+++ b/apps/files/src/components/FileList.vue
@@ -40,7 +40,7 @@
                     v-for="(action, index) in actions"
                    :key="index"
                    @click.stop="action.handler(item, action.handlerData)"
-                   :disabled="!action.isEnabled(item) || $_actionInProgress(item)"
+                   :disabled="!action.isEnabled(item, parentFolder) || $_actionInProgress(item)"
                    :icon="action.icon"
                    :ariaLabel="action.ariaLabel"
                    :uk-tooltip="$_disabledActionTooltip(item)"
@@ -128,7 +128,7 @@ export default {
     Mixins
   ],
   name: 'FileList',
-  props: ['fileData', 'starsEnabled', 'checkboxEnabled', 'dateEnabled'],
+  props: ['fileData', 'starsEnabled', 'checkboxEnabled', 'dateEnabled', 'parentFolder'],
   mounted () {
     this.$_ocFilesFolder_getFolder()
   },
@@ -196,7 +196,7 @@ export default {
     },
 
     enabledActions (item) {
-      return this.actions.filter(action => action.isEnabled(item))
+      return this.actions.filter(action => action.isEnabled(item, this.parentFolder))
     },
 
     $_actionInProgress (item) {

--- a/apps/files/src/components/FilesApp.vue
+++ b/apps/files/src/components/FilesApp.vue
@@ -6,7 +6,7 @@
           <oc-loader id="files-list-progress" v-if="loadingFolder"></oc-loader>
           <trash-bin v-if="$route.name === 'files-trashbin'" :fileData="activeFiles" />
           <SharedFilesList v-else-if="sharedList" @toggle="toggleFileSelect" :fileData="activeFiles" />
-          <file-list v-else @toggle="toggleFileSelect" @FileAction="openFileActionBar" :fileData="activeFiles" @sideBarOpen="openSideBar" />
+          <file-list v-else @toggle="toggleFileSelect" @FileAction="openFileActionBar" :fileData="activeFiles" :parentFolder="currentFolder" @sideBarOpen="openSideBar" />
         </div>
         <file-details
           v-if="_sidebarOpen && $route.name !== 'files-trashbin'"
@@ -131,7 +131,7 @@ export default {
   },
 
   computed: {
-    ...mapGetters('Files', ['selectedFiles', 'activeFiles', 'dropzone', 'loadingFolder', 'highlightedFile']),
+    ...mapGetters('Files', ['selectedFiles', 'activeFiles', 'dropzone', 'loadingFolder', 'highlightedFile', 'currentFolder']),
     ...mapGetters(['extensions', 'privateLinkUrlPath']),
 
     _sidebarOpen () {

--- a/apps/files/src/components/FilesAppBar.vue
+++ b/apps/files/src/components/FilesAppBar.vue
@@ -5,7 +5,7 @@
       <div class="uk-width-expand">
         <div class="uk-flex">
           <oc-breadcrumb id="files-breadcrumb" :items="breadcrumbs" v-if="showBreadcrumb" home></oc-breadcrumb>
-          <span class="uk-margin-small-left" v-if="showBreadcrumb && currentFolder.privateLink">
+          <span class="uk-margin-small-left" v-if="showBreadcrumb && currentFolder && currentFolder.privateLink">
           <oc-icon name="ready" v-show="linkCopied" />
           <oc-icon id="files-permalink-copy" name="link" v-clipboard="() => currentFolder.privateLink"
                    v-show="!linkCopied"

--- a/apps/files/src/mixins.js
+++ b/apps/files/src/mixins.js
@@ -52,7 +52,10 @@ export default {
           icon: 'edit',
           handler: this.changeName,
           ariaLabel: this.$gettext('Rename'),
-          isEnabled: function (item) {
+          isEnabled: function (item, parent) {
+            if (!parent.canRename()) {
+              return false
+            }
             return item.canRename()
           }
         },
@@ -68,7 +71,10 @@ export default {
           icon: 'delete',
           ariaLabel: this.$gettext('Delete'),
           handler: this.deleteFile,
-          isEnabled: function (item) {
+          isEnabled: function (item, parent) {
+            if (!parent.canBeDeleted()) {
+              return false
+            }
             return item.canBeDeleted()
           }
         }


### PR DESCRIPTION
… permissions fot these two operations.

## Description
In some setups (Samba) the permission of the parent folder has a higher priority to disallow rename and delete then the child item itself.

## How Has This Been Tested?
- needs to be verified on acl environment

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...