### PR TITLE
Test: Reject promise if invalid response during permalink check

### DIFF
--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -489,11 +489,9 @@ When('the user browses to the folder {string} on the files page', (folderName) =
 When('the user copies the permalink of the current folder using the webUI', function () {
   return client.page.filesPage().copyPermalinkFromFilesAppBar()
 })
-Then('the clipboard content should match permalink of resource {string}', function (folderName) {
+Then('the clipboard content should match permalink of resource {string}', async function (folderName) {
+  const folderData = await webdav.getProperties(folderName, client.globals.currentUser, ['oc:privatelink'])
   return client.getClipBoardContent(function (value) {
-    webdav.getProperties(folderName, client.globals.currentUser, ['oc:privatelink'])
-      .then(folderData => {
-        assert.strictEqual(folderData['oc:privatelink'], value)
-      })
+    assert.strictEqual(folderData['oc:privatelink'], value)
   })
 })


### PR DESCRIPTION
The following scenario was failing a lot (given other are fixed). 
https://github.com/owncloud/phoenix/blob/417dd1e771f7e45b070c2b4bef893374cbf98525/tests/acceptance/features/webUIFiles/copyPrivateLinks.feature#L11-L18
This adds a better error handling on why the given scenario is failing. Also, as this uses `async`/`await`, it should be able to handle edge cases as well. 

Example failures:
https://drone.owncloud.com/owncloud/phoenix/5433/3/13
https://drone.owncloud.com/owncloud/phoenix/5432/3/13