### PR TITLE
Adjust 'the user' steps

### DIFF
--- a/tests/acceptance/customCommands/waitForAjaxCallsToStartAndFinish.js
+++ b/tests/acceptance/customCommands/waitForAjaxCallsToStartAndFinish.js
@@ -16,7 +16,7 @@ const checkSumStartedAjaxRequests = function (api) {
   api.execute('return window.sumStartedAjaxRequests', [], sleepWhenNoNewAjaxCallsStarted)
 }
 exports.command = function () {
-  // init the ajax caounters if they haven't been initialized yet
+  // init the ajax counters if they haven't been initialized yet
   this.execute('return (typeof window.sumStartedAjaxRequests === "undefined")', [], function (result) {
     if (result.value === true) {
       this.initAjaxCounters()

--- a/tests/acceptance/features/webUIFiles/fileDetails.feature
+++ b/tests/acceptance/features/webUIFiles/fileDetails.feature
@@ -85,7 +85,7 @@ Feature: User can open the details panel for any file or folder
   @yetToImplement
   @comments-app-required
   Scenario: user shares a folder via link and then the details dialog should work in a Shared with others page
-    Given the user "user1" has created a new public link for resource "simple-folder"
+    Given user "user1" has created a new public link for resource "simple-folder"
     When the user browses to the shared-with-others page
     Then folder "simple-folder" should be listed on the webUI
     When the user picks the row of folder "simple-folder" in the webUI

--- a/tests/acceptance/features/webUINotifications/displayNotificationsOnWebUI.feature
+++ b/tests/acceptance/features/webUINotifications/displayNotificationsOnWebUI.feature
@@ -16,4 +16,4 @@ Feature: display notifications on the webUI
     When user "user1" is sent a notification
     Then the user should see the notification bell on the webUI after a page reload
     And the user marks the notification as read
-    Then the notification bell should dissapear on the webUI
+    Then the notification bell should disappear on the webUI

--- a/tests/acceptance/features/webUISharingNotifications/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingNotifications/shareWithUsers.feature
@@ -14,7 +14,7 @@ Feature: Sharing files and folders with internal users
 
   @smokeTest
   @skip @yetToImplement
-  Scenario: notifications about new share is displayed when autoacepting is disabled
+  Scenario: notifications about new share is displayed when auto-accepting is disabled
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "user1" has shared folder "/simple-folder" with user "user2"
     And user "user1" has shared folder "/data.zip" with user "user2"

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -65,7 +65,7 @@ Feature: Share by public link
     Then there should be no files/folders listed on the webUI
 
   Scenario: public link share shows up on shared-with-others page
-    Given the user "user1" has created a new public link for resource "simple-folder"
+    Given user "user1" has created a new public link for resource "simple-folder"
     When the user browses to the shared-with-others page using the webUI
     Then folder "simple-folder" should be listed on the webUI
     But file "data.zip" should not be listed on the webUI

--- a/tests/acceptance/features/webUIUpload/upload.feature
+++ b/tests/acceptance/features/webUIUpload/upload.feature
@@ -16,7 +16,7 @@ Feature: File Upload
     And as "user1" the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 
   @smokeTest
-  Scenario: uploading a big file (when chunking in implemented that upload should be chunked)
+  Scenario: uploading a big file (when chunking is implemented this upload should be chunked)
     Given a file with the size of "30000000" bytes and the name "big-video.mp4" has been created locally
     When the user uploads file "big-video.mp4" using the webUI
     Then no message should be displayed on the webUI
@@ -25,7 +25,7 @@ Feature: File Upload
 
   @skipOnFIREFOX
   @skip @yetToImplement
-  Scenario: conflict with a big file (when chunking in implemented that upload should be chunked)
+  Scenario: conflict with a big file (when chunking is implemented this upload should be chunked)
     Given a file with the size of "30000000" bytes and the name "big-video.mp4" has been created locally
     When the user renames file "lorem.txt" to "big-video.mp4" using the webUI
     And the user uploads overwriting file "big-video.mp4" using the webUI and retries if the file is locked

--- a/tests/acceptance/stepDefinitions/generalContext.js
+++ b/tests/acceptance/stepDefinitions/generalContext.js
@@ -5,11 +5,11 @@ const fs = require('fs')
 let createdFiles = []
 
 Given('a file with the size of {string} bytes and the name {string} has been created locally', function (size, name) {
-  const fullPathOflocalFile = client.globals.filesForUpload + name
-  const fh = fs.openSync(fullPathOflocalFile, 'w')
+  const fullPathOfLocalFile = client.globals.filesForUpload + name
+  const fh = fs.openSync(fullPathOfLocalFile, 'w')
   fs.writeSync(fh, 'A', Math.max(0, size - 1))
   fs.closeSync(fh)
-  createdFiles.push(fullPathOflocalFile)
+  createdFiles.push(fullPathOfLocalFile)
 })
 
 Then('the error message {string} should be displayed on the webUI', function (folder) {
@@ -33,16 +33,16 @@ Then('no message should be displayed on the webUI', function () {
 })
 
 Then('as {string} the content of {string} should be the same as the local {string}', function (userId, remoteFile, localFile) {
-  const fullPathOflocalFile = client.globals.filesForUpload + localFile
+  const fullPathOfLocalFile = client.globals.filesForUpload + localFile
   return webdavHelper
     .download(userId, remoteFile)
-    .then(body => assertContentOFLocalFileIs(fullPathOflocalFile, body))
+    .then(body => assertContentOFLocalFileIs(fullPathOfLocalFile, body))
 })
 
-const assertContentOFLocalFileIs = function (fullPathOflocalFile, expectedContent) {
-  const actualContent = fs.readFileSync(fullPathOflocalFile, { encoding: 'utf-8' })
+const assertContentOFLocalFileIs = function (fullPathOfLocalFile, expectedContent) {
+  const actualContent = fs.readFileSync(fullPathOfLocalFile, { encoding: 'utf-8' })
   return client.assert.strictEqual(
-    actualContent, expectedContent, 'asserting content of local file "' + fullPathOflocalFile + '"'
+    actualContent, expectedContent, 'asserting content of local file "' + fullPathOfLocalFile + '"'
   )
 }
 

--- a/tests/acceptance/stepDefinitions/notificationsContext.js
+++ b/tests/acceptance/stepDefinitions/notificationsContext.js
@@ -23,6 +23,6 @@ Then('the user should see the notification bell on the webUI after a page reload
   return client.page.phoenixPage().waitForElementVisible('@notificationBell')
 })
 
-Then('the notification bell should dissapear on the webUI', function () {
+Then('the notification bell should disappear on the webUI', function () {
   return client.page.phoenixPage().waitForElementNotPresent('@notificationBell')
 })

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -394,6 +394,6 @@ Then('user {string} should have a share with these details:', function (user, ex
   return sharingHelper.assertUserHasShareWithDetails(user, expectedDetailsTable)
 })
 
-Given('the user {string} has created a new public link for resource {string}', function (user, resource) {
+Given('user {string} has created a new public link for resource {string}', function (user, resource) {
   return shareFileFolder(resource, user, '', SHARE_TYPES.public_link)
 })

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -50,7 +50,7 @@ const userSharesFileOrFolderWithGroup = function (file, sharee, role) {
  *
  * @param {string} elementToShare  path of file/folder being shared
  * @param {string} sharer  username of the sharer
- * @param {string} receiver  username of the reciever
+ * @param {string} receiver  username of the receiver
  * @param {number} shareType  Type of share 0 = user, 1 = group, 3 = public (link), 6 = federated (cloud share).
  * @param {string} permissions  permissions of the share for valid permissions see sharingHelper.PERMISSION_TYPES
  */
@@ -239,7 +239,7 @@ Then('all users and groups that contain the string {string} in their name should
 
           assert.ok(
             itemsList.includes(userString),
-            `could not find '${userDisplayName}' in autocomple share list`
+            `could not find '${userDisplayName}' in autocomplete share list`
           )
         }
       }
@@ -251,7 +251,7 @@ Then('all users and groups that contain the string {string} in their name should
 
           assert.ok(
             itemsList.includes(groupString),
-            `could not find '${groupString}' in autocomple share list`
+            `could not find '${groupString}' in autocomplete share list`
           )
         }
       })
@@ -345,9 +345,9 @@ When('the user deletes {string} as collaborator for the current file/folder usin
 
 When(
   'the user changes the collaborator role of {string} for file/folder {string} to {string} using the webUI',
-  function (collaborator, ressource, newRole) {
+  function (collaborator, resource, newRole) {
     return client.page.FilesPageElement.filesList()
-      .openSharingDialog(ressource)
+      .openSharingDialog(resource)
       .changeCollaboratorRole(collaborator, newRole)
   }
 )


### PR DESCRIPTION
## Description
1) there was a `Given` step starting `Given the user "userxxx"...` - remove `the` so it matches the usual form.
2) Other minor typos fixed

## Motivation and Context
Make acceptance tests great again.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
