### PR TITLE
Test resharing with different permissions

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -26,6 +26,7 @@ config = {
 				'webUISharingInternalGroups': 'SharingInternalGroups',
 				'webUISharingInternalUsers': 'SharingInternalUsers',
 				'webUISharingPermissions': 'SharingPermissions',
+				'webUIResharing': 'Resharing',
 				'webUISharingPublic': 'SharingPublic',
 				'webUITrashbin': 'Trashbin',
 				'webUIUpload': 'Upload',

--- a/.drone.yml
+++ b/.drone.yml
@@ -1907,6 +1907,193 @@ depends_on:
 ---
 kind: pipeline
 type: docker
+name: Resharing-chrome
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: phoenix
+
+steps:
+- name: npm-install
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - yarn install
+
+- name: build-phoenix
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - yarn dist
+  - cp tests/drone/config.json dist/config.json
+
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    version: daily-master-qa
+
+- name: clone-oauth
+  pull: always
+  image: owncloud/ubuntu:16.04
+  commands:
+  - git clone -b master https://github.com/owncloud/oauth2.git /var/www/owncloud/apps/oauth2
+
+- name: setup-server-phoenix
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/
+  - php occ a:e testing
+  - php occ config:system:set trusted_domains 1 --value=owncloud
+  - php occ config:system:set cors.allowed-domains 0 --value=http://phoenix
+  - php occ log:manage --level 2
+  - php occ config:list
+  - php occ a:e oauth2
+  - php occ oauth2:add-client Phoenix Cxfj9F9ZZWQbQZps1E1M0BszMz6OOFq3lxjSuc8Uh4HLEYb9KIfyRMmgY5ibXXrU 930C6aA0U1VhM03IfNiheR2EwSzRi4hRSpcNqIhhbpeSGU6h38xssVfNcGP0sSwQ http://phoenix/oidc-callback.html
+  - php occ config:system:set skeletondirectory --value=/var/www/owncloud/apps/testing/data/webUISkeleton
+  - php occ config:system:set dav.enable.tech_preview  --type=boolean --value=true
+  - php occ config:system:set phoenix.baseUrl --value="http://phoenix"
+
+- name: owncloud-log
+  pull: always
+  image: owncloud/ubuntu:16.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/data/owncloud.log
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/
+  - chown www-data * -R
+
+- name: webui-acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/phoenix
+  - curl http://phoenix/oidc-callback.html
+  - yarn run acceptance-tests-drone
+  environment:
+    TEST_CONTEXT: webUIResharing
+    TEST_TAGS: not @skip
+
+- name: upload-screenshots
+  pull: if-not-exists
+  image: plugins/s3
+  settings:
+    acl: public-read
+    bucket: phoenix
+    endpoint: https://minio.owncloud.com/
+    path_style: true
+    source: /var/www/owncloud/phoenix/tests/reports/screenshots/**/*
+    strip_prefix: /var/www/owncloud/phoenix/tests/reports/screenshots
+    target: /screenshots/${DRONE_BUILD_NUMBER}
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: aws_access_key_id
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: aws_secret_access_key
+  when:
+    event:
+    - pull_request
+    status:
+    - failure
+
+- name: build-github-comment
+  pull: always
+  image: owncloud/ubuntu:16.04
+  commands:
+  - cd /var/www/owncloud/phoenix/tests/reports/screenshots/
+  - "echo \"<details><summary>:boom: Acceptance tests <strong>Resharing</strong> failed. Please find the screenshots inside ...</summary>\\n\\n${DRONE_BUILD_LINK}/${DRONE_JOB_NUMBER}\\n\\n<p>\\n\\n\" >> comments.file"
+  - for f in *.png; do echo '!'"[$f](https://minio.owncloud.com/phoenix/screenshots/${DRONE_BUILD_NUMBER}/$f)" >> comments.file; done
+  - "echo \"\n</p></details>\" >> comments.file"
+  - more comments.file
+  environment:
+    TEST_CONTEXT: webUIResharing
+  when:
+    event:
+    - pull_request
+    status:
+    - failure
+
+- name: github-comment
+  pull: if-not-exists
+  image: jmccann/drone-github-comment:1
+  settings:
+    message_file: /var/www/owncloud/phoenix/tests/reports/screenshots/comments.file
+  environment:
+    PLUGIN_API_KEY:
+      from_secret: plugin_api_key
+  when:
+    event:
+    - pull_request
+    status:
+    - failure
+
+services:
+- name: phoenix
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir dist
+  - /usr/local/bin/apachectl -e debug -D FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/phoenix/dist
+
+- name: owncloud
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:latest
+
+- name: mysql
+  pull: always
+  image: mysql:5.5
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+trigger:
+  ref:
+  - refs/tags/**
+  - refs/pull/**
+  - refs/pull-requests/**
+  - refs/merge-requests/**
+  - refs/heads/master
+  - refs/heads/release*
+  - refs/heads/develop*
+
+depends_on:
+- lint-test
+
+---
+kind: pipeline
+type: docker
 name: SharingPublic-chrome
 
 platform:
@@ -3257,6 +3444,7 @@ depends_on:
 - SharingInternalGroups-chrome
 - SharingInternalUsers-chrome
 - SharingPermissions-chrome
+- Resharing-chrome
 - SharingPublic-chrome
 - Trashbin-chrome
 - Upload-chrome

--- a/tests/acceptance/features/webUIResharing/reshareUsers.feature
+++ b/tests/acceptance/features/webUIResharing/reshareUsers.feature
@@ -1,0 +1,180 @@
+Feature: Resharing shared files with different permissions
+  As a user
+  I want to reshare received files and folders with other users with different permissions
+  So that I can control the access on those files/folders by other collaborators
+
+  Background:
+    Given these users have been created with default attributes:
+      | username |
+      | user1    |
+      | user2    |
+      | user3    |
+
+  Scenario: Reshare a folder without share permissions using API and check if it is listed on the collaborators list for original owner
+      Given user "user2" has shared folder "simple-folder" with user "user1" with "read, share" permissions
+      And user "user1" has shared folder "simple-folder (2)" with user "user3" with "read" permissions
+      And user "user2" has logged in using the webUI
+      When the user opens the share dialog for folder "simple-folder" using the webUI
+      Then user "User Three" should be listed as "Viewer" in the collaborators list for folder "simple-folder" on the webUI
+      And no custom permissions should be set for collaborator "User Three" for folder "simple-folder" on the webUI
+
+  Scenario: Reshare a folder without share permissions using API and check if it is listed on the collaborators list for resharer
+      Given user "user2" has shared folder "simple-folder" with user "user1" with "read, share" permissions
+      And user "user1" has shared folder "simple-folder (2)" with user "user3" with "read" permissions
+      And user "user1" has logged in using the webUI
+      When the user opens the share dialog for folder "simple-folder (2)" using the webUI
+      Then user "User Three" should be listed as "Viewer" in the collaborators list for folder "simple-folder (2)" on the webUI
+      And no custom permissions should be set for collaborator "User Three" for folder "simple-folder (2)" on the webUI
+
+  Scenario: Reshare a folder without share permissions using API and check if the receiver can reshare
+    Given user "user2" has shared folder "simple-folder" with user "user1" with "read, share" permissions
+    And user "user1" has shared folder "simple-folder (2)" with user "user3" with "read" permissions
+    When the user "user3" logs in using the webUI
+    Then the user should not be able to share folder "simple-folder (2)" using the webUI
+
+  Scenario Outline: share a received folder with another user with same permissions(including share permissions) and check if the user is displayed in collaborators list for resharer
+    Given user "user2" has shared folder "simple-folder" with user "user1" with "<permissions>" permissions
+    And user "user1" has logged in using the webUI
+    When the user shares folder "simple-folder (2)" with user "User Three" as "<role>" with permissions "<collaborators-permissions>" using the webUI
+    Then user "User Three" should be listed as "<displayed-role>" in the collaborators list for folder "simple-folder (2)" on the webUI
+    And custom permissions "<displayed-permissions>" should be set for user "User Three" for folder "simple-folder (2)" on the webUI
+    And user "user3" should have received a share with these details:
+    | field       | value              |
+    | uid_owner   | user1              |
+    | share_with  | user3              |
+    | file_target | /simple-folder (2) |
+    | item_type   | folder             |
+    | permissions | <permissions>      |
+    Examples:
+    | role        | displayed-role | collaborators-permissions     | displayed-permissions | permissions                         |
+    | Viewer      | Viewer         | share                         | share                 | read, share                         |
+    | Editor      | Editor         | share                         | share                 | all                                 |
+    | Custom Role | Custom role    | share, create                 | share, create         | read, share, create                 |
+    | Custom Role | Editor         | change, share                 | share                 | read, change, share                 |
+    | Custom Role | Editor         | delete, share, create, change | share                 | read, share, delete, change, create |
+
+  Scenario Outline: share a received folder with another user with same permissions(including share permissions) and check if the user is displayed in collaborators list for original owner
+    Given user "user2" has shared folder "simple-folder" with user "user1" with "<permissions>" permissions
+    And user "user1" has logged in using the webUI
+    When the user shares folder "simple-folder (2)" with user "User Three" as "<role>" with permissions "<collaborators-permissions>" using the webUI
+    And the user re-logs in as "user2" using the webUI
+    Then user "User Three" should be listed as "<displayed-role>" in the collaborators list for folder "simple-folder" on the webUI
+    And custom permissions "<displayed-permissions>" should be set for user "User Three" for folder "simple-folder" on the webUI
+    And user "User One" should be listed as "<displayed-role>" in the collaborators list for folder "simple-folder" on the webUI
+    And custom permissions "<displayed-permissions>" should be set for user "User One" for folder "simple-folder" on the webUI
+    And user "user3" should have received a share with these details:
+    | field       | value              |
+    | uid_owner   | user1              |
+    | share_with  | user3              |
+    | file_target | /simple-folder (2) |
+    | item_type   | folder             |
+    | permissions | <permissions>      |
+    And user "user1" should have received a share with these details:
+    | field       | value              |
+    | uid_owner   | user2              |
+    | share_with  | user1              |
+    | file_target | /simple-folder (2) |
+    | item_type   | folder             |
+    | permissions | <permissions>      |
+    Examples:
+    | role        | displayed-role | collaborators-permissions     | displayed-permissions | permissions                         |
+    | Viewer      | Viewer         | share                         | share                 | read, share                         |
+    | Editor      | Editor         | share                         | share                 | all                                 |
+    | Custom Role | Custom role    | share, create                 | share, create         | read, share, create                 |
+    | Custom Role | Editor         | change, share                 | share                 | read, change, share                 |
+    | Custom Role | Editor         | delete, share, create, change | share                 | read, share, delete, change, create |
+
+  Scenario: share a folder with another user with share permissions and reshare without share permissions to different user, and check if user is displayed for original sharer
+    Given user "user2" has shared folder "simple-folder" with user "user1" with "read, share" permissions
+    And user "user1" has logged in using the webUI
+    When the user shares folder "simple-folder (2)" with user "User Three" as "Viewer" with permissions "," using the webUI
+    And the user re-logs in as "user2" using the webUI
+    Then user "User Three" should be listed as "Viewer" in the collaborators list for folder "simple-folder" on the webUI
+    And no custom permissions should be set for collaborator "User Three" for folder "simple-folder" on the webUI
+    And user "User One" should be listed as "Viewer" in the collaborators list for folder "simple-folder" on the webUI
+    And custom permissions "share" should be set for user "User One" for folder "simple-folder" on the webUI
+    And user "user1" should have received a share with these details:
+    | field       | value              |
+    | uid_owner   | user2              |
+    | share_with  | user1              |
+    | file_target | /simple-folder (2) |
+    | item_type   | folder             |
+    | permissions | read, share        |
+    And user "user3" should have received a share with these details:
+    | field       | value              |
+    | uid_owner   | user1              |
+    | share_with  | user3              |
+    | file_target | /simple-folder (2) |
+    | item_type   | folder             |
+    | permissions | read               |
+
+  Scenario: share a folder with another user with share permissions and reshare without share permissions to different user, and check if user is displayed for the receiver
+    Given user "user2" has shared folder "simple-folder" with user "user1" with "read, share" permissions
+    And user "user1" has logged in using the webUI
+    When the user shares folder "simple-folder (2)" with user "User Three" as "Viewer" with permissions "," using the webUI
+    And user "user3" should have received a share with these details:
+    | field       | value              |
+    | uid_owner   | user1              |
+    | share_with  | user3              |
+    | file_target | /simple-folder (2) |
+    | item_type   | folder             |
+    | permissions | read               |
+
+  Scenario Outline: share a file/folder without share permissions and check if another user can reshare
+    Given user "user2" has shared folder "<shared-entry-name>" with user "user1" with "read" permissions
+    When the user "user1" logs in using the webUI
+    Then the user should not be able to share resource "<received-entry-name>" using the webUI
+    Examples:
+    | shared-entry-name | received-entry-name |
+    | simple-folder     | simple-folder (2)   |
+    | lorem.txt         | lorem (2).txt       |
+    | simple-folder     | simple-folder (2)   |
+    | lorem.txt         | lorem (2).txt       |
+
+  Scenario Outline: share a received file/folder without share permissions and check if another user can reshare
+    Given user "user2" has shared folder "<shared-entry-name>" with user "user1" with "all" permissions
+    And user "user1" has shared folder "<received-entry-name>" with user "user3" with "read" permissions
+    When the user "user3" logs in using the webUI
+    Then the user should not be able to share resource "<received-entry-name>" using the webUI
+    Examples:
+    | shared-entry-name | received-entry-name |
+    | simple-folder     | simple-folder (2)   |
+    | lorem.txt         | lorem (2).txt       |
+
+  Scenario: User is allowed to reshare a file/folder with the equivalent received permissions, and collaborators should not be listed for the receiver
+    Given user "user2" has shared folder "simple-folder" with user "user1" with "read, share, delete" permissions
+    And user "user1" has logged in using the webUI
+    When the user shares folder "simple-folder (2)" with user "User Three" as "Custom role" with permissions "share, delete" using the webUI
+    And the user re-logs in as "user3" using the webUI
+    Then the collaborators list for folder "simple-folder (2)" should be empty
+    And user "user3" should have received a share with these details:
+    | field       | value               |
+    | uid_owner   | user1               |
+    | share_with  | user3               |
+    | file_target | /simple-folder (2)  |
+    | item_type   | folder              |
+    | permissions | share, delete, read |
+
+  Scenario: User is allowed to reshare a file/folder with the lesser permissions, and check if it is listed for original owner
+    Given user "user2" has shared folder "simple-folder" with user "user1" with "read, share, delete" permissions
+    And user "user1" has logged in using the webUI
+    When the user shares folder "simple-folder (2)" with user "User Three" as "Custom role" with permissions "delete" using the webUI
+    And the user re-logs in as "user2" using the webUI
+    Then user "User One" should be listed as "Custom role" in the collaborators list for folder "simple-folder" on the webUI
+    And custom permissions "share, delete" should be set for user "User One" for folder "simple-folder" on the webUI
+    And user "User Three" should be listed as "Custom role" in the collaborators list for folder "simple-folder" on the webUI
+    And custom permissions "delete" should be set for user "User Three" for folder "simple-folder" on the webUI
+    And user "user3" should have received a share with these details:
+    | field       | value              |
+    | uid_owner   | user1              |
+    | share_with  | user3              |
+    | file_target | /simple-folder (2) |
+    | item_type   | folder             |
+    | permissions | delete, read       |
+
+  Scenario: User is not allowed to reshare a file/folder with the higher permissions
+    Given user "user2" has shared folder "simple-folder" with user "user1" with "read, share, delete" permissions
+    And user "user1" has logged in using the webUI
+    When the user shares folder "simple-folder (2)" with user "User Three" as "Custom role" with permissions "share, delete, change" using the webUI
+    Then the error message "Error while sharing." should be displayed on the webUI
+    And as "user3" folder "simple-folder (2)" should not exist

--- a/tests/acceptance/features/webUISharingPermissions/sharePermissionsUsers.feature
+++ b/tests/acceptance/features/webUISharingPermissions/sharePermissionsUsers.feature
@@ -215,12 +215,12 @@ Feature: Sharing files and folders with internal users with different permission
     When the user sets custom permission for current role of collaborator "User One" for file "lorem.txt" to "share" using the webUI
     Then custom permission "share" should be set for user "User One" for file "lorem.txt" on the webUI
     And user "user1" should have received a share with these details:
-      | field       | value               |
-      | uid_owner   | user2               |
-      | share_with  | user1               |
-      | file_target | /lorem (2).txt      |
-      | item_type   | file                |
-      | permissions | <permissions>       |
+      | field       | value          |
+      | uid_owner   | user2          |
+      | share_with  | user1          |
+      | file_target | /lorem (2).txt |
+      | item_type   | file           |
+      | permissions | <permissions>  |
     Examples:
       | initial-permissions | permissions         |
       | read, change        | read, share, change |
@@ -233,12 +233,12 @@ Feature: Sharing files and folders with internal users with different permission
     When the user disables all the custom permissions of collaborator "User One" for file "lorem.txt" using the webUI
     Then no custom permissions should be set for collaborator "User One" for file "lorem.txt" on the webUI
     And user "user1" should have received a share with these details:
-      | field       | value               |
-      | uid_owner   | user2               |
-      | share_with  | user1               |
-      | file_target | /lorem (2).txt      |
-      | item_type   | file                |
-      | permissions | read                |
+      | field       | value          |
+      | uid_owner   | user2          |
+      | share_with  | user1          |
+      | file_target | /lorem (2).txt |
+      | item_type   | file           |
+      | permissions | read           |
 
   Scenario Outline: share a file with another internal user assigning a role and the permissions
     Given user "user2" has logged in using the webUI
@@ -246,14 +246,21 @@ Feature: Sharing files and folders with internal users with different permission
     Then user "User One" should be listed as "<displayed-role>" in the collaborators list for file "lorem.txt" on the webUI
     And custom permissions "<displayed-permissions>" should be set for user "User One" for file "lorem.txt" on the webUI
     And user "user1" should have received a share with these details:
-      | field       | value              |
-      | uid_owner   | user2              |
-      | share_with  | user1              |
-      | file_target | /lorem (2).txt     |
-      | item_type   | file               |
-      | permissions | <permissions>      |
+      | field       | value          |
+      | uid_owner   | user2          |
+      | share_with  | user1          |
+      | file_target | /lorem (2).txt |
+      | item_type   | file           |
+      | permissions | <permissions>  |
     Examples:
-      | role        | displayed-role | collaborators-permissions     | displayed-permissions | permissions                         |
-      | Viewer      | Viewer         | share                         | share                 | read, share                         |
-      | Editor      | Editor         | share                         | share                 | read, share, change                 |
-      | Custom Role | Editor         | share, change                 | share                 | read, share, change                 |
+      | role        | displayed-role | collaborators-permissions | displayed-permissions | permissions         |
+      | Viewer      | Viewer         | share                     | share                 | read, share         |
+      | Editor      | Editor         | share                     | share                 | read, share, change |
+      | Custom Role | Editor         | share, change             | share                 | read, share, change |
+
+  Scenario: Share a folder without share permissions using API and check if it is listed on the collaborators list for original owner
+    Given user "user2" has shared folder "simple-folder" with user "user1" with "read" permissions
+    And user "user2" has logged in using the webUI
+    When the user opens the share dialog for folder "simple-folder" using the webUI
+    Then user "User One" should be listed as "Viewer" in the collaborators list for folder "simple-folder" on the webUI
+    And no custom permissions should be set for collaborator "User One" for folder "simple-folder" on the webUI

--- a/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
@@ -23,6 +23,23 @@ module.exports = {
       return util.format(this.elements.permissionButton.selector, permission)
     },
 
+    assertSharingNotAllowed: function () {
+      // eslint-disable-next-line no-unused-expressions
+      this.api.expect.element(this.elements.sharingAutoComplete.selector).not.to.be.present
+      return this.api.getText(this.elements.sharingSidebarRoot.selector,
+        function (result) {
+          const noSharePermissionsMsgFormat = "You don't have permission to share this %s"
+          const noSharePermissionsFileMsg = util.format(noSharePermissionsMsgFormat, 'file')
+          const noSharePermissionsFolderMsg = util.format(noSharePermissionsMsgFormat, 'folder')
+
+          this.assert.ok(
+            noSharePermissionsFileMsg === result.value ||
+            noSharePermissionsFolderMsg === result.value
+          )
+        }
+      )
+    },
+
     /**
      *
      * @param {string} sharee
@@ -410,6 +427,9 @@ module.exports = {
     }
   },
   elements: {
+    sharingSidebarRoot: {
+      selector: '#oc-files-sharing-sidebar'
+    },
     sharingAutoComplete: {
       selector: '#oc-sharing-autocomplete .oc-autocomplete-input'
     },

--- a/tests/acceptance/stepDefinitions/loginContext.js
+++ b/tests/acceptance/stepDefinitions/loginContext.js
@@ -1,7 +1,6 @@
 const { client } = require('nightwatch-api')
 const { Given, Then, When } = require('cucumber')
 const loginHelper = require('../helpers/loginHelper')
-const userSettings = require('../helpers/userSettings')
 
 Given(/^the user has browsed to the login page$/,
   () => {
@@ -18,8 +17,7 @@ When('the user logs in with username {string} and password {string} using the we
 )
 
 When('the user {string} logs in using the webUI',
-  (username) => client.page.ownCloudLoginPage()
-    .login(username, userSettings.getPasswordForUser(username))
+  (username) => loginHelper.loginAsUser(username)
 )
 
 When('the user authorizes access to phoenix',

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -218,11 +218,11 @@ Then('no custom permissions should be set for collaborator {string} for file/fol
     .assertPermissionIsDisplayed(user)
 })
 
-When('the user shares file/folder {string} with group {string} as {string} using the webUI', userSharesFileOrFolderWithGroup)
+When('the user shares file/folder/resource {string} with group {string} as {string} using the webUI', userSharesFileOrFolderWithGroup)
 
-When('the user shares file/folder {string} with user {string} as {string} using the webUI', userSharesFileOrFolderWithUser)
+When('the user shares file/folder/resource {string} with user {string} as {string} using the webUI', userSharesFileOrFolderWithUser)
 
-When('the user shares file/folder {string} with user {string} as {string} with permission/permissions {string} using the webUI', function (resource, shareWithUser, role, permissions) {
+When('the user shares file/folder/resource {string} with user {string} as {string} with permission/permissions {string} using the webUI', function (resource, shareWithUser, role, permissions) {
   return userSharesFileOrFolderWithUserOrGroup(resource, shareWithUser, false, role, permissions)
 })
 
@@ -360,7 +360,7 @@ Then('item {string} should not be listed in the autocomplete list on the webUI',
     })
 })
 
-When('the user opens the share dialog for file/folder {string} using the webUI', function (file) {
+When('the user opens the share dialog for file/folder/resource {string} using the webUI', function (file) {
   return client.page.FilesPageElement.filesList().openSharingDialog(file)
 })
 
@@ -421,4 +421,23 @@ Then('user {string} should have a share with these details:', function (user, ex
 
 Given('user {string} has created a new public link for resource {string}', function (user, resource) {
   return shareFileFolder(resource, user, '', SHARE_TYPES.public_link)
+})
+
+Then('the user should not be able to share file/folder/resource {string} using the webUI', function (resource) {
+  return client.page
+    .FilesPageElement
+    .filesList()
+    .closeSidebar(100)
+    .openSharingDialog(resource)
+    .assertSharingNotAllowed()
+})
+
+Then('the collaborators list for file/folder/resource {string} should be empty', async function (resource) {
+  const count = (await client.page
+    .FilesPageElement
+    .filesList()
+    .closeSidebar(100)
+    .openSharingDialog(resource)
+    .getCollaboratorsList()).length
+  assert.strictEqual(count, 0, `Expected to have no collaborators for '${resource}', Found: ${count}`)
 })


### PR DESCRIPTION
This adds different resharing options. 

Part of #1614 

More tests are required, which is blocked by, not being able to click the permissions' button when multiple collaborators are present. 