### PR TITLE
Add more close options to file actions menu

### DIFF
--- a/apps/files/src/components/FileActions.vue
+++ b/apps/files/src/components/FileActions.vue
@@ -1,7 +1,13 @@
 <template>
   <div v-if="isOpen" :id="id" uk-offcanvas="mode: slide" class="oc-file-actions uk-offcanvas-bottom uk-open" style="display: block !important;">
     <div class="uk-offcanvas-bar">
-      <span v-text="_label"></span>
+      <oc-button
+        icon="close"
+        class="uk-position-top-right uk-position-absolute uk-margin-top uk-margin-right"
+        @click="closeActions"
+        aria-label="$_closeActionsButtonLabel"
+      />
+      <div v-text="$_label" class="uk-margin-small-bottom" />
       <ul class="uk-nav">
         <li v-for="(action, i) in actions" :key="i">
           <a class="uk-inline" @click="selectAction(action)">
@@ -30,6 +36,21 @@ export default {
       isOpen: false
     }
   },
+  computed: {
+    $_label () {
+      const translated = this.$gettext('Open %{fileName} in')
+      return this.$gettextInterpolate(translated, { fileName: this.filename })
+    },
+
+    $_closeActionsButtonLabel () {
+      return this.$gettext('Close file actions menu')
+    }
+  },
+  watch: {
+    $route () {
+      this.closeActions()
+    }
+  },
   mounted () {
     this.$root.$on('oc-file-actions:open', file => {
       this.showActions(file)
@@ -49,12 +70,6 @@ export default {
     selectAction (action) {
       this.closeActions()
       action.onClick()
-    }
-  },
-  computed: {
-    _label () {
-      const translated = this.$gettext('Open %{fileName} in')
-      return this.$gettextInterpolate(translated, { fileName: this.filename })
     }
   }
 }


### PR DESCRIPTION
## Description
Added close button and trigger close action on route change for file action menu.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #2078

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually
1. Open file actions menu by clicking on file name
2. Close the menu with close button
3. Repeat step 1
4. Navigate to some other route

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/25989331/66208224-e27f3500-e6b4-11e9-95ca-d3da686d5b4e.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 