### PR TITLE
Added progress bar for upload

### DIFF
--- a/apps/files/src/components/FilesApp.vue
+++ b/apps/files/src/components/FilesApp.vue
@@ -1,7 +1,8 @@
   <template>
-    <div id="files">
+    <div id="files" class="uk-flex uk-flex-column">
       <files-app-bar />
-      <oc-grid class="uk-height-1-1" oc-scroll-offset=".oc-app-bar">
+      <upload-progress v-if="inProgress.length" class="uk-padding-small uk-background-muted" />
+      <oc-grid class="uk-height-1-1">
         <div class="uk-width-expand uk-overflow-auto uk-height-1-1" @dragover="$_ocApp_dragOver" :class="{ 'uk-visible@m' : _sidebarOpen }">
           <oc-loader id="files-list-progress" v-if="loadingFolder"></oc-loader>
           <trash-bin v-if="$route.name === 'files-trashbin'" :fileData="activeFiles" />
@@ -26,6 +27,7 @@ import TrashBin from './Trashbin.vue'
 import SharedFilesList from './Collaborators/SharedFilesList.vue'
 import { mapActions, mapGetters } from 'vuex'
 import FileActions from './FileActions.vue'
+const UploadProgress = () => import('./UploadProgress.vue')
 
 export default {
   mixins: [
@@ -37,7 +39,8 @@ export default {
     FilesAppBar,
     FileActions,
     TrashBin,
-    SharedFilesList
+    SharedFilesList,
+    UploadProgress
   },
   data () {
     return {
@@ -131,7 +134,7 @@ export default {
   },
 
   computed: {
-    ...mapGetters('Files', ['selectedFiles', 'activeFiles', 'dropzone', 'loadingFolder', 'highlightedFile', 'currentFolder']),
+    ...mapGetters('Files', ['selectedFiles', 'activeFiles', 'dropzone', 'loadingFolder', 'highlightedFile', 'currentFolder', 'inProgress']),
     ...mapGetters(['extensions']),
 
     _sidebarOpen () {

--- a/apps/files/src/components/FilesAppBar.vue
+++ b/apps/files/src/components/FilesAppBar.vue
@@ -18,12 +18,6 @@
           <span class="uk-text-lead">{{pageTitle}}</span>
         </span>
       </div>
-      <div v-show="inProgress.length > 0" class="uk-width-auto">
-        <oc-spinner id="oc-progress-pie" size="small" />
-        <oc-drop toggle="#oc-progress-pie" mode="click">
-          <upload-menu :items="inProgress" />
-        </oc-drop>
-      </div>
       <div v-if="!publicPage()" class="uk-width-auto uk-visible@m">
         <oc-search-bar @search="onFileSearch" :value="searchTerm" :label="searchLabel" :loading="isLoadingSearch" :button="false"/>
       </div>
@@ -74,7 +68,6 @@ import FileUpload from './FileUpload.vue'
 import FolderUpload from './FolderUpload.vue'
 import FileFilterMenu from './FileFilterMenu.vue'
 import OcDialogPrompt from './ocDialogPrompt.vue'
-import UploadMenu from './UploadMenu.vue'
 import FileDrop from './FileDrop.vue'
 import { mapActions, mapGetters, mapState } from 'vuex'
 import Mixins from '../mixins'
@@ -85,8 +78,7 @@ export default {
     FolderUpload,
     OcDialogPrompt,
     FileFilterMenu,
-    FileDrop,
-    UploadMenu
+    FileDrop
   },
   mixins: [
     Mixins
@@ -105,7 +97,7 @@ export default {
   }),
   computed: {
     ...mapGetters(['getToken', 'configuration']),
-    ...mapGetters('Files', ['activeFiles', 'inProgress', 'searchTerm', 'atSearchPage', 'currentFolder', 'davProperties', 'quota', 'selectedFiles', 'overwriteDialogTitle', 'overwriteDialogMessage', 'publicLinkPassword']),
+    ...mapGetters('Files', ['activeFiles', 'searchTerm', 'atSearchPage', 'currentFolder', 'davProperties', 'quota', 'selectedFiles', 'overwriteDialogTitle', 'overwriteDialogMessage', 'publicLinkPassword']),
     ...mapState(['route']),
     searchLabel () {
       return this.$gettext('Search')
@@ -478,11 +470,6 @@ export default {
       setTimeout(() => {
         self.linkCopied = false
       }, 1000)
-    }
-  },
-  filters: {
-    roundNumber (value) {
-      return parseInt(value.toFixed(0))
     }
   },
   watch: {

--- a/apps/files/src/components/UploadMenu.vue
+++ b/apps/files/src/components/UploadMenu.vue
@@ -1,19 +1,17 @@
 <template>
   <ul class="uk-list uk-margin-remove">
-    <li v-if="items.length > 2">{{ headline }}</li>
-    <li v-for="(item, index) in items" :key="index">
+    <li v-for="(item, index) in items" :key="item.name">
       <div class="uk-flex">
-        <oc-icon name="file_copy" class="uk-margin-small-right uk-flex-none" />
-        <div class="uk-flex-1">
-          <span class="uk-text-bold">{{ item.name }}</span>
+        <oc-icon name="file_copy" class="uk-margin-small-right" />
+        <div class="uk-width-expand">
+          <div class="uk-text-bold" v-text="$_truncateFileName(item.name)" />
           <div class="uk-flex uk-flex-middle">
-            <span class="uk-flex-2 uk-margin-small-right">{{ item.size | fileSize }}</span>
+            <span class="uk-margin-small-right uk-text-nowrap">{{ item.size | fileSize }}</span>
             <oc-progress
-              color="primary"
               :value="item.progress | toInt"
               :max="100"
               class="uk-flex-1 uk-margin-remove"
-            ></oc-progress>
+            />
           </div>
         </div>
       </div>
@@ -38,14 +36,17 @@ export default {
     }
   },
   filters: {
-    toInt (int) {
-      return parseInt(int)
+    toInt (value) {
+      return parseInt(value)
     }
   },
-  computed: {
-    headline () {
-      const translated = this.$gettext('%{number} items to upload remaining…')
-      return this.$gettextInterpolate(translated, { number: this.items.length }, true)
+  methods: {
+    $_truncateFileName (name) {
+      if (name.length > 15) {
+        return `${name.substr(0, 6)}...${name.substr(name.length - 6)}`
+      }
+
+      return name
     }
   }
 }

--- a/apps/files/src/components/UploadProgress.vue
+++ b/apps/files/src/components/UploadProgress.vue
@@ -1,0 +1,87 @@
+<template>
+  <div id="files-upload-progress" class="uk-clearfix">
+    <oc-grid
+      gutter="small"
+      flex
+      class="uk-margin-remove uk-align-right"
+    >
+      <oc-button
+        id="files-upload-progress-dropdown-trigger"
+        icon="expand_more"
+      />
+      <translate
+        :translate-n="count"
+        translate-plural="Uploading %{ count } items"
+      >
+        Uploading %{ count } item
+      </translate>
+      <oc-grid
+        gutter="small"
+        flex
+        class="uk-width-1-1 uk-width-medium@s"
+      >
+        <oc-progress
+          :value="totalUploadProgress"
+          :max="100"
+          class="uk-width-expand uk-margin-remove-bottom"
+        />
+        <span>
+          {{ totalUploadProgress | roundNumber}} %
+        </span>
+      </oc-grid>
+    </oc-grid>
+    <oc-drop
+      toggle="#files-upload-progress-dropdown-trigger"
+      mode="click"
+      :options="{ offset: 0 }"
+    >
+      <upload-menu class="uk-width-1-1" :items="inProgress" />
+    </oc-drop>
+  </div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+import UploadMenu from './UploadMenu.vue'
+import Mixins from '../mixins'
+
+export default {
+  name: 'UploadProgress',
+
+  components: {
+    UploadMenu
+  },
+
+  mixins: [
+    Mixins
+  ],
+
+  computed: {
+    ...mapGetters('Files', ['inProgress', 'uploaded']),
+
+    count () {
+      return this.inProgress.length
+    },
+
+    totalUploadProgress () {
+      let progressTotal = 0
+
+      for (const item of this.inProgress) {
+        progressTotal = progressTotal + item.progress
+      }
+
+      for (const item of this.uploaded) {
+        progressTotal = progressTotal + item.progress
+      }
+
+      if (this.inProgress.length !== 0) {
+        progressTotal = progressTotal / (this.inProgress.length + this.uploaded.length)
+      } else {
+        progressTotal = 100
+      }
+
+      return progressTotal
+    }
+  }
+}
+</script>

--- a/apps/files/src/mixins.js
+++ b/apps/files/src/mixins.js
@@ -16,6 +16,10 @@ export default {
       return filesize(int, {
         round: 2
       })
+    },
+
+    roundNumber (int) {
+      return parseInt(int.toFixed(0))
     }
   },
   data: () => ({

--- a/apps/files/src/store/actions.js
+++ b/apps/files/src/store/actions.js
@@ -388,12 +388,8 @@ export default {
       context.commit('UPDATE_FOLDER_LOADING', false)
     })
   },
-  updateFileProgress ({ commit }, progress) {
-    if (progress.progress === 100) {
-      commit('REMOVE_FILE_FROM_PROGRESS', { name: progress.fileName })
-    } else {
-      commit('UPDATE_FILE_PROGRESS', progress)
-    }
+  updateFileProgress ({ commit, getters }, progress) {
+    commit('UPDATE_FILE_PROGRESS', progress)
   },
   addFileToProgress ({ commit }, file) {
     commit('ADD_FILE_TO_PROGRESS', file)

--- a/apps/files/src/store/getters.js
+++ b/apps/files/src/store/getters.js
@@ -117,5 +117,6 @@ export default {
   },
   linksLoading: state => {
     return state.linksLoading
-  }
+  },
+  uploaded: state => state.uploaded
 }

--- a/apps/files/src/store/mutations.js
+++ b/apps/files/src/store/mutations.js
@@ -1,16 +1,24 @@
 export default {
-  UPDATE_FILE_PROGRESS (state, progress) {
+  UPDATE_FILE_PROGRESS (state, file) {
     const fileIndex = state.inProgress.findIndex((f) => {
-      return f.name === progress.fileName
+      return f.name === file.fileName
     })
+
     if (fileIndex === -1) return
-    state.inProgress[fileIndex].progress = progress.progress
-  },
-  REMOVE_FILE_FROM_PROGRESS (state, file) {
-    const fileIndex = state.inProgress.findIndex((f) => {
-      return f.name === file.name
-    })
-    state.inProgress.splice(fileIndex - 1, 1)
+
+    if (file.progress < 100) {
+      state.inProgress[fileIndex].progress = file.progress
+      return
+    }
+
+    state.inProgress.splice(fileIndex, 1)
+    if (state.inProgress.length < 1) {
+      state.inProgress = []
+      state.uploaded = []
+      return
+    }
+
+    state.uploaded.push(file)
   },
   ADD_FILE_TO_PROGRESS (state, file) {
     state.inProgress.push({

--- a/apps/files/src/store/state.js
+++ b/apps/files/src/store/state.js
@@ -41,5 +41,6 @@ export default {
   highlightedFile: null,
   collaboratorSaving: false,
   publicLinkPassword: null,
-  collaboratorsEditInProgress: false
+  collaboratorsEditInProgress: false,
+  uploaded: []
 }

--- a/tests/acceptance/pageObjects/filesPage.js
+++ b/tests/acceptance/pageObjects/filesPage.js
@@ -71,7 +71,7 @@ module.exports = {
           this.api.globals.waitForConditionPollInterval,
           false
         )
-        .waitForElementNotVisible('@fileUploadProgress')
+        .waitForElementNotPresent('@fileUploadProgress')
         .click('@newFileMenuButton')
     },
     showHiddenFiles: function () {
@@ -222,7 +222,7 @@ module.exports = {
       selector: '#fileUploadInput'
     },
     fileUploadProgress: {
-      selector: '#oc-progress-pie'
+      selector: '#files-upload-progress'
     },
     deleteFileConfirmationBtn: {
       selector: '#oc-dialog-delete-confirm'


### PR DESCRIPTION
## Description
Removed upload spinner and added progress bar to make it more visible to user that upload is in progress.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually
1. Upload files or folder

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/25989331/66392207-7744a400-e9cf-11e9-8e37-2e1845e0712f.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Fix "jump" of progress bar when the progress number next to it goes over 10
- [x] Fix height of files list
- [x] Adjust tests