### PR TITLE
Handle errors while deleting and renaming files

### DIFF
--- a/apps/files/src/mixins.js
+++ b/apps/files/src/mixins.js
@@ -145,7 +145,17 @@ export default {
         publicPage: this.publicPage()
       }).then(setTimeout(_ => {
         this.originalName = null
-      }, 1000))
+      }, 1000)).catch(error => {
+        let translated = this.$gettext('Error while renaming "%{file}"')
+        if (error.statusCode === 423) {
+          translated = this.$gettext('Error while renaming "%{file}" - the file is locked')
+        }
+        const title = this.$gettextInterpolate(translated, { file: this.selectedFile.name }, true)
+        this.showMessage({
+          title: title,
+          status: 'danger'
+        })
+      })
     },
     fileTypeIcon (file) {
       if (file) {
@@ -426,11 +436,15 @@ export default {
       this.deleteFiles({
         client: this.$client,
         files: files,
-        publicPage: this.publicPage()
+        publicPage: this.publicPage(),
+        $gettext: this.$gettext,
+        $gettextInterpolate: this.$gettextInterpolate
       }).then(() => {
         this.fileToBeDeleted = ''
         this.setFilesDeleteMessage('')
         this.setHighlightedFile(null)
+      }).catch(error => {
+        console.log(error)
       })
     },
     _rowClasses (item) {

--- a/apps/files/src/store/actions.js
+++ b/apps/files/src/store/actions.js
@@ -446,7 +446,7 @@ export default {
       context.commit('ADD_FILE', _buildFile(file))
     }
   },
-  deleteFiles (context, { files, client, publicPage }) {
+  deleteFiles (context, { files, client, publicPage, $gettext, $gettextInterpolate }) {
     const promises = []
     for (const file of files) {
       let p = null
@@ -459,7 +459,15 @@ export default {
         context.commit('REMOVE_FILE', file)
         context.commit('REMOVE_FILE_SELECTION', file)
       }).catch(error => {
-        console.log('error: ' + file.path + ' not deleted: ' + error)
+        let translated = $gettext('Error while deleting "%{file}"')
+        if (error.statusCode === 423) {
+          translated = $gettext('Error while deleting "%{file}" - the file is locked')
+        }
+        const title = $gettextInterpolate(translated, { file: file.name }, true)
+        context.dispatch('showMessage', {
+          title: title,
+          status: 'danger'
+        }, { root: true })
       })
       promises.push(promise)
     }


### PR DESCRIPTION
## Description
Delete and rename operations did not handle error conditions at all before this PR.
While it is UX-wise far from good - this is better then nothing.

The whole error handling flow as well as the user confirmation flow is under review at the moment.

As say: better then nothing

## How Has This Been Tested?
- Lock a file using webdav locks (cadaver or manual insert into database)
- try to delete or rename
- see error notification

## Screenshots (if appropriate):
![Screenshot from 2019-10-08 14-17-53](https://user-images.githubusercontent.com/1005065/66395193-19b45580-e9d7-11e9-8bef-c52654f0b71e.png)
![Screenshot from 2019-10-08 14-17-39](https://user-images.githubusercontent.com/1005065/66395195-1a4cec00-e9d7-11e9-9fe1-ab59a8111eae.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...