### PR TITLE
Bugfix/logout on access denied page

### DIFF
--- a/src/pages/accessDenied.vue
+++ b/src/pages/accessDenied.vue
@@ -4,13 +4,20 @@
           <h1 class="oc-login-logo" v-translate>
               ownCloud
           </h1>
-          <div class="oc-login-card-body">
+          <div class="oc-login-card-body uk-width-large">
               <h3 class="oc-login-card-title">
                   <span v-translate>Login Error</span>
               </h3>
               <h4 v-translate class="uk-margin-remove">
                 You are not allowed to use this application.
               </h4>
+              <br>
+              <div v-translate class="uk-margin-remove">
+                If you like to login with a different user please proceed to <a @click="logout()">exit</a>.
+              </div>
+              <br>
+              <div v-translate class="uk-margin-remove">
+                <strong>Attention:</strong> this will log you out from all applications you are running in this browser with your current user.</div>
           </div>
           <div class="oc-login-card-footer uk-width-large">
               <p>
@@ -22,14 +29,21 @@
   </div>
 </template>
 <script>
-import { mapGetters } from 'vuex'
+import { mapGetters, mapActions } from 'vuex'
 export default {
   name: 'AccessDeniedPage',
+  methods: {
+    ...mapActions(['logout'])
+  },
   computed: {
     ...mapGetters(['configuration']),
     helpDeskText () {
-      if (this.configuration.theme.general.helpDeskText) {
-        return this.configuration.theme.general.helpDeskText
+      if (this.configuration.theme.general.helpDeskText && this.configuration.theme.general.helpDeskText.en) {
+        const lang = this.$language.current
+        if (this.configuration.theme.general.helpDeskText[lang]) {
+          return this.configuration.theme.general.helpDeskText[lang]
+        }
+        return this.configuration.theme.general.helpDeskText.en
       }
       return this.$gettext('Please contact your administrator if you think this message shows up in error.')
     },


### PR DESCRIPTION
## Description
1. there is a logout link now in the access denied page including some descriptive text about it
2. themable helpdesk message now translated

## How to test
- add following to themes/owncloud.json file
```json
{
  "general": {
    "name": "ownCloud",
    "slogan": "ownCloud – A safe home for all your data",
    "helpDeskText": {
      "en": "You are not one of the 300 Spartans, if you think this message shows up in error please contact King Leonidas",
      "de": "Sie keiner der 300 Spartiaten. Wenn Sie der Meinung sind, dass diese Meldung irrtümlich angezeigt wird, wenden Sie sich bitte an König Leonidas"
    },
  },
  "logo": {
    "favicon": "themes/owncloud/favicon.jpg"
  }
}
```

## Screenshots (if appropriate):
![Screenshot from 2019-10-08 16-58-07](https://user-images.githubusercontent.com/1005065/66407025-d82ea500-e9ec-11e9-8742-9258a1e0a586.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...