### PR TITLE
Download feedback spinner

### DIFF
--- a/apps/files/src/components/FileList.vue
+++ b/apps/files/src/components/FileList.vue
@@ -27,6 +27,12 @@
                 <oc-file @click.native.stop="item.type === 'folder' ? navigateTo(item.path.substr(1)) : openFileActionBar(item)"
                         :name="$_ocFileName(item)" :extension="item.extension" class="file-row-name" :icon="fileTypeIcon(item)"
                         :filename="item.name" :key="item.id"/>
+                <oc-spinner
+                  v-if="$_actionInProgress(item)"
+                  size="small"
+                  :uk-tooltip="$_disabledActionTooltip(item)"
+                  class="uk-margin-small-left"
+                />
               </oc-table-cell>
               <oc-table-cell class="uk-text-meta uk-text-nowrap" :class="{ 'uk-visible@s' : !_sidebarOpen, 'uk-visible@m'  : _sidebarOpen }">
                 {{ item.size | fileSize }}
@@ -48,8 +54,9 @@
                 </div>
                 <oc-button
                   :id="'files-file-list-action-button-small-resolution-' + index"
-                  icon="menu"
+                  icon="more_vert"
                   :class="{ 'uk-hidden@m' : !_sidebarOpen, 'uk-visible@s uk-hidden@xl' : _sidebarOpen }"
+                  :disabled="$_actionInProgress(item)"
                   :aria-label="'show-file-actions'"
                   @click.stop
                 />
@@ -200,13 +207,16 @@ export default {
     },
 
     $_actionInProgress (item) {
-      return this.inProgress.some(itemInProgress => itemInProgress.id === item.id)
+      return this.actionsInProgress.some(itemInProgress => itemInProgress.id === item.id)
     },
 
     $_disabledActionTooltip (item) {
       if (this.$_actionInProgress(item)) {
-        const message = this.$gettext('Another action is currently in progress for this %{itemType}')
-        return this.$gettextInterpolate(message, { itemType: item.type })
+        if (item.type === 'folder') {
+          return this.$gettext('There is currently an action in progress for this folder')
+        }
+
+        return this.$gettext('There is currently an action in progress for this file')
       }
 
       return null
@@ -214,7 +224,7 @@ export default {
   },
   computed: {
     ...mapState(['route']),
-    ...mapGetters('Files', ['selectedFiles', 'loadingFolder', 'filesDeleteMessage', 'highlightedFile', 'activeFiles', 'quota', 'filesTotalSize', 'activeFilesCount', 'inProgress']),
+    ...mapGetters('Files', ['selectedFiles', 'loadingFolder', 'filesDeleteMessage', 'highlightedFile', 'activeFiles', 'quota', 'filesTotalSize', 'activeFilesCount', 'actionsInProgress']),
     ...mapGetters(['configuration']),
 
     item () {

--- a/apps/files/src/store/actions.js
+++ b/apps/files/src/store/actions.js
@@ -752,5 +752,13 @@ export default {
           status: 'danger'
         }, { root: true })
       })
+  },
+
+  addActionToProgress ({ commit }, item) {
+    commit('ADD_ACTION_TO_PROGRESS', item)
+  },
+
+  removeActionFromProgress ({ commit }, item) {
+    commit('REMOVE_ACTION_FROM_PROGRESS', item)
   }
 }

--- a/apps/files/src/store/getters.js
+++ b/apps/files/src/store/getters.js
@@ -118,5 +118,6 @@ export default {
   linksLoading: state => {
     return state.linksLoading
   },
-  uploaded: state => state.uploaded
+  uploaded: state => state.uploaded,
+  actionsInProgress: state => state.actionsInProgress
 }

--- a/apps/files/src/store/mutations.js
+++ b/apps/files/src/store/mutations.js
@@ -187,5 +187,17 @@ export default {
 
       return link
     })
+  },
+
+  ADD_ACTION_TO_PROGRESS (state, item) {
+    state.actionsInProgress.push(item)
+  },
+
+  REMOVE_ACTION_FROM_PROGRESS (state, item) {
+    const itemIndex = state.actionsInProgress.findIndex(i => {
+      return i === item
+    })
+
+    state.actionsInProgress.splice(itemIndex, 1)
   }
 }

--- a/apps/files/src/store/state.js
+++ b/apps/files/src/store/state.js
@@ -42,5 +42,6 @@ export default {
   collaboratorSaving: false,
   publicLinkPassword: null,
   collaboratorsEditInProgress: false,
-  uploaded: []
+  uploaded: [],
+  actionsInProgress: []
 }

--- a/src/plugins/phoenix.js
+++ b/src/plugins/phoenix.js
@@ -8,7 +8,7 @@ export default {
         ...mapGetters('Files', ['publicLinkPassword'])
       },
       methods: {
-        ...mapActions('Files', ['addFileToProgress', 'updateFileProgress']),
+        ...mapActions('Files', ['addActionToProgress', 'removeActionFromProgress']),
         ...mapActions(['showMessage']),
 
         publicPage () {
@@ -17,7 +17,7 @@ export default {
           return !this.isAuthenticated || this.$route.meta.auth === false
         },
         downloadFile (file) {
-          this.addFileToProgress(file)
+          this.addActionToProgress(file)
           let headers = null
           if (this.publicPage()) {
             const url = this.$client.publicFiles.getFileUrl(file.path)
@@ -48,10 +48,7 @@ export default {
               })
 
               // Remove item from progress queue in case the request failed
-              this.updateFileProgress({
-                fileName: file.name,
-                progress: 100
-              })
+              this.removeActionFromProgress(file)
             } else if (request.readyState === 4 && request.status === 200) {
               // Download has finished
               if (window.navigator && window.navigator.msSaveOrOpenBlob) { // for IE
@@ -67,24 +64,27 @@ export default {
                 anchor.click()
                 document.body.removeChild(anchor)
                 window.URL.revokeObjectURL(objectUrl)
+                this.removeActionFromProgress(file)
 
+                // TODO: Bring back when progress bar for download is figured out
                 // Items with small size can be fetched too fast for progress listener
                 // This ensures that they'll be removed from progress queue
-                this.updateFileProgress({
-                  fileName: file.name,
-                  progress: 100
-                })
+                // this.updateFileProgress({
+                //   fileName: file.name,
+                //   progress: 100
+                // })
               }
             }
           })
 
-          request.addEventListener('progress', e => {
-            const progress = (e.loaded / e.total) * 100
-            this.updateFileProgress({
-              fileName: file.name,
-              progress
-            })
-          })
+          // TODO: Bring back when progress bar for download is figured out
+          // request.addEventListener('progress', e => {
+          //   const progress = (e.loaded / e.total) * 100
+          //   this.updateFileProgress({
+          //     fileName: file.name,
+          //     progress
+          //   })
+          // })
 
           request.send()
         },


### PR DESCRIPTION
## Description
Use spinner to show that item has action in progress and remove download from upload menu

## Motivation and Context
Upload menu was now restructured and the download doesn't fit there anymore and since actions in general and their feedback is going to be reworked (already were some mockups for this but haven't been worked on it since) and quick solution is needed now it doesn't make too much sense to me to spend now a lot of effort to try to keep them together in a nice way in the upload menu.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually
1. Download any file

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/25989331/66415647-5c3c5900-e9fc-11e9-88fc-0a6e6ca273bc.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 