### PR TITLE
[accentance tests] wait for at least one file to appear in the list

### DIFF
--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -306,7 +306,9 @@ module.exports = {
      * @returns {Promise.<[]>} Array of files/folders element
      */
     allFileRows: async function () {
-      this.waitForElementNotPresent('@filesListProgressBar')
+      this
+        .waitForElementNotPresent('@filesListProgressBar')
+        .waitForElementVisible({ selector: '@fileRows', abortOnFailure: false })
       return new Promise((resolve, reject) => {
         this.api.elements('css selector', this.elements.fileRows, function (result) {
           resolve(result)


### PR DESCRIPTION
## Description
wait for at least one item in the list, but do not fail if there is none, so that an empty list can be reported back

## Related Issue
noticed when working on #2008 with saucelabs the timing was different and so some faivorites tests would fail

## Motivation and Context
stabilise tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...