### PR TITLE
Prevent duplicate token refresh calls

### DIFF
--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -58,15 +58,6 @@ export function initVueAuthenticate (config) {
     Log.logger = console
     Log.level = openIdConfig.logLevel
 
-    mgr.events.addUserLoaded(function (user) {
-      console.log('New User Loaded：', arguments)
-      console.log('Access_token: ', user.access_token)
-    })
-
-    mgr.events.addSilentRenewError(function () {
-      console.error('Silent Renew Error：', arguments)
-    })
-
     mgr.events.addUserSignedOut(function () {
       console.log('UserSignedOut：', arguments)
     })


### PR DESCRIPTION
## Description
Due to programming error two token refresh calls are issued to the IdP.
This is fixed now and more logging information is written to the console.

## How Has This Been Tested?
- to test with a true OpenId Connect IdP - e.g. PingId

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...