### PR TITLE
Switch to show instead of if in upload progress bar

### DIFF
--- a/apps/files/src/components/FilesApp.vue
+++ b/apps/files/src/components/FilesApp.vue
@@ -1,7 +1,7 @@
   <template>
     <div id="files" class="uk-flex uk-flex-column">
       <files-app-bar />
-      <upload-progress v-if="inProgress.length" class="uk-padding-small uk-background-muted" />
+      <upload-progress v-show="inProgress.length" class="uk-padding-small uk-background-muted" />
       <oc-grid class="uk-height-1-1">
         <div class="uk-width-expand uk-overflow-auto uk-height-1-1" @dragover="$_ocApp_dragOver" :class="{ 'uk-visible@m' : _sidebarOpen }">
           <oc-loader id="files-list-progress" v-if="loadingFolder"></oc-loader>

--- a/tests/acceptance/pageObjects/filesPage.js
+++ b/tests/acceptance/pageObjects/filesPage.js
@@ -71,7 +71,7 @@ module.exports = {
           this.api.globals.waitForConditionPollInterval,
           false
         )
-        .waitForElementNotPresent('@fileUploadProgress')
+        .waitForElementNotVisible('@fileUploadProgress')
         .click('@newFileMenuButton')
     },
     showHiddenFiles: function () {


### PR DESCRIPTION
## Description
With `v-if` were an issue in displaying the progress bar too late.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually
1. Upload a folder

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 