### PR TITLE
Fix exit link on access denied page

### DIFF
--- a/src/pages/accessDenied.vue
+++ b/src/pages/accessDenied.vue
@@ -12,8 +12,8 @@
                 You are not allowed to use this application.
               </h4>
               <br>
-              <div v-translate class="uk-margin-remove">
-                If you like to login with a different user please proceed to <a @click="logout()">exit</a>.
+              <div v-translate class="uk-margin-remove" @click="performLogout">
+                If you like to login with a different user please proceed to <a id='exitAnchor'>exit</a>.
               </div>
               <br>
               <div v-translate class="uk-margin-remove">
@@ -33,7 +33,12 @@ import { mapGetters, mapActions } from 'vuex'
 export default {
   name: 'AccessDeniedPage',
   methods: {
-    ...mapActions(['logout'])
+    ...mapActions(['logout']),
+    performLogout (event) {
+      if (event.target.id === 'exitAnchor') {
+        this.logout()
+      }
+    }
   },
   computed: {
     ...mapGetters(['configuration']),


### PR DESCRIPTION
## Description
Due to https://github.com/Polyconseil/vue-gettext#caveat-when-using-v-translate-with-vue-components-or-vue-specific-attributes it is not *yet* possible to bind events on translated elements

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...