### PR TITLE
Trigger add to progress before the folders creation

### DIFF
--- a/apps/files/src/mixins.js
+++ b/apps/files/src/mixins.js
@@ -313,6 +313,7 @@ export default {
         // Get folder structure
         const directoriesToCreate = []
         for (const file of files) {
+          this.$_addFileToUploadProgress(file)
           directoryPath = file.webkitRelativePath.replace('/' + file.name, '')
           const directories = directoryPath.split('/')
           for (let i = 0; i < directories.length; i++) {
@@ -345,7 +346,7 @@ export default {
         const uploadPromises = []
         Promise.all(createFolderPromises).then(() => {
           for (const file of files) {
-            uploadPromises.push(this.$_ocUpload(file, file.webkitRelativePath, null, false))
+            uploadPromises.push(this.$_ocUpload(file, file.webkitRelativePath, null, false, false))
           }
           // once all files are uploaded we emit the success event
           Promise.all(uploadPromises).then(() => {
@@ -367,10 +368,22 @@ export default {
         })
       })
     },
-    $_ocUpload (file, path, overwrite = null, emitSuccess = true) {
+
+    /**
+     * Adds file into the progress queue and assigns it unique id
+     * @param {Object} file File which is to be added into progress
+     */
+    $_addFileToUploadProgress (file) {
       file.id = this.uploadFileUniqueId
       this.uploadFileUniqueId++
       this.addFileToProgress(file)
+    },
+
+    $_ocUpload (file, path, overwrite = null, emitSuccess = true, addToProgress = true) {
+      if (addToProgress) {
+        this.$_addFileToUploadProgress(file)
+      }
+
       const fileUpload = new FileUpload(file, path, this.url, this.headers, this.$_ocUpload_onProgress, this.requestType)
       return fileUpload
         .upload({


### PR DESCRIPTION
## Description
Move addToProgress into its own function and trigger it before the folders creation.

## Motivation and Context
Since we wait until all folders are created and those promises are being processed one by one it would take quite some time before the actual progress bar is shown. This takes care of that. We need to figure out though how to handle if some specific folder fails.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually
1. Upload a folder with a lot of subfolders

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 