### PR TITLE
Fixed structure of folders in folder upload

### DIFF
--- a/apps/files/src/mixins.js
+++ b/apps/files/src/mixins.js
@@ -314,19 +314,30 @@ export default {
         const directoriesToCreate = []
         for (const file of files) {
           directoryPath = file.webkitRelativePath.replace('/' + file.name, '')
+
+          if (directoriesToCreate.indexOf(directoryPath) > -1) {
+            continue
+          }
+
           const directories = directoryPath.split('/')
           for (let i = 0; i < directories.length; i++) {
-            const directoryName = directories[i]
-            directories[i] = ''
-            for (let temp = directories.length - 1 - i; temp < directories.length - 1; temp++) {
-              directories[i] += directories[temp] + '/'
+            if (i === 0) {
+              if (directoriesToCreate.indexOf(directories[0]) === -1) {
+                directoriesToCreate.push(directories[0])
+              }
+
+              continue
             }
-            directories[i] += directoryName
-            if (!directoriesToCreate.includes(directories[i])) {
-              directoriesToCreate.push(directories[i])
+
+            const parentDirectory = directories.slice(0, i).join('/')
+            const currentDirectory = `${parentDirectory}/${directories[i]}`
+
+            if (directoriesToCreate.indexOf(currentDirectory) === -1) {
+              directoriesToCreate.push(currentDirectory)
             }
           }
         }
+
         // Create folder structure
         const createFolderPromises = []
         const rootDir = directoriesToCreate[0]


### PR DESCRIPTION
## Description
With previous structure we were getting sometimes empty strings leading to duplicate slashes in the path for folders.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually
+ In Edge
+ In Chrome
+ In Firefox
1. Upload folder with subfolders

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 