### PR TITLE
Handle remove from progress in its own mutation

### DIFF
--- a/apps/files/src/FileUpload.js
+++ b/apps/files/src/FileUpload.js
@@ -1,11 +1,12 @@
 class FileUpload {
-  constructor (file, path, url, headers = {}, onProgress = () => {}, type = 'POST') {
+  constructor (file, path, url, headers = {}, onProgress = () => {}, type = 'POST', onUploadEnded = () => {}) {
     this.file = file
     this.path = path
     this.url = url
     this.headers = headers
     this.onProgress = onProgress
     this.type = type
+    this.onUploadEnded = onUploadEnded
   }
 
   upload (options = {}) {
@@ -31,9 +32,13 @@ class FileUpload {
     xhr.upload.addEventListener('progress', (e) => {
       this.onProgress(e, this.file)
     }, false)
+
     const promise = new Promise((resolve, reject) => {
       xhr.onload = e => {
         xhr.status >= 200 && xhr.status < 400 ? resolve(e) : reject(new Error(xhr.statusText))
+      }
+      xhr.onloadend = e => {
+        this.onUploadEnded(this.file)
       }
       xhr.onerror = e => {
         reject(e)

--- a/apps/files/src/mixins.js
+++ b/apps/files/src/mixins.js
@@ -121,7 +121,7 @@ export default {
   methods: {
     ...mapActions('Files', ['resetSearch', 'addFileToProgress', 'resetFileSelection', 'addFileSelection',
       'removeFileSelection', 'setOverwriteDialogTitle', 'setOverwriteDialogMessage', 'deleteFiles', 'renameFile',
-      'setHighlightedFile', 'setFilesDeleteMessage']),
+      'setHighlightedFile', 'setFilesDeleteMessage', 'removeFileFromProgress']),
     ...mapActions(['showMessage']),
 
     formDateFromNow (date) {
@@ -395,7 +395,8 @@ export default {
         this.$_addFileToUploadProgress(file)
       }
 
-      const fileUpload = new FileUpload(file, path, this.url, this.headers, this.$_ocUpload_onProgress, this.requestType)
+      const fileUpload = new FileUpload(file, path, this.url, this.headers, this.$_ocUpload_onProgress, this.requestType, this.removeFileFromProgress)
+
       return fileUpload
         .upload({
           overwrite: overwrite
@@ -412,6 +413,7 @@ export default {
     $_ocUpload_onProgress (e, file) {
       const progress = parseInt(e.loaded * 100 / e.total)
       this.$emit('progress', {
+        id: file.id,
         fileName: file.name,
         progress
       })

--- a/apps/files/src/store/actions.js
+++ b/apps/files/src/store/actions.js
@@ -400,6 +400,11 @@ export default {
   addFileToProgress ({ commit }, file) {
     commit('ADD_FILE_TO_PROGRESS', file)
   },
+
+  removeFileFromProgress ({ commit }, file) {
+    commit('REMOVE_FILE_FROM_PROGRESS', file)
+  },
+
   loadFiles (context, { currentFolder, files }) {
     currentFolder = _buildFile(currentFolder)
     files = files.map(_buildFile)

--- a/apps/files/src/store/mutations.js
+++ b/apps/files/src/store/mutations.js
@@ -1,25 +1,14 @@
 export default {
   UPDATE_FILE_PROGRESS (state, file) {
     const fileIndex = state.inProgress.findIndex((f) => {
-      return f.name === file.fileName
+      return f.id === file.id
     })
 
     if (fileIndex === -1) return
 
-    if (file.progress < 100) {
-      state.inProgress[fileIndex].progress = file.progress
-      return
-    }
-
-    state.inProgress.splice(fileIndex, 1)
-    if (state.inProgress.length < 1) {
-      state.inProgress = []
-      state.uploaded = []
-      return
-    }
-
-    state.uploaded.push(file)
+    state.inProgress[fileIndex].progress = file.progress
   },
+
   ADD_FILE_TO_PROGRESS (state, file) {
     state.inProgress.push({
       id: file.id,
@@ -30,6 +19,23 @@ export default {
       action: 'upload'
     })
   },
+
+  REMOVE_FILE_FROM_PROGRESS (state, file) {
+    const fileIndex = state.inProgress.findIndex((f) => {
+      return f.id === file.id
+    })
+
+    state.inProgress.splice(fileIndex, 1)
+    if (state.inProgress.length < 1) {
+      state.inProgress = []
+      state.uploaded = []
+      return
+    }
+
+    file.progress = 100
+    state.uploaded.push(file)
+  },
+
   LOAD_FILES (state, { currentFolder, files }) {
     state.currentFolder = currentFolder
     state.files = files


### PR DESCRIPTION
## Description
Move remove from progress into its own method, use id instead of name to find the right progress and call the action on requests loadend event.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually
1. Upload one file
2. Upload multiple files
3. Upload folder

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 