### PR TITLE
clear filelocks after test run

### DIFF
--- a/tests/acceptance/stepDefinitions/generalContext.js
+++ b/tests/acceptance/stepDefinitions/generalContext.js
@@ -1,6 +1,8 @@
 const { client } = require('nightwatch-api')
 const { After, Before, Given, Then } = require('cucumber')
 const webdavHelper = require('../helpers/webdavHelper')
+const httpHelper = require('../helpers/httpHelper')
+const fetch = require('node-fetch')
 const fs = require('fs')
 let createdFiles = []
 
@@ -91,7 +93,16 @@ Before(function (testCase) {
   console.log('  ' + testCase.sourceLocation.uri + ':' + testCase.sourceLocation.line + '\n')
 })
 
-After(function (testCase) {
+After(async function (testCase) {
   console.log('\n  Result: ' + testCase.result.status + '\n')
+
   createdFiles.forEach(fileName => fs.unlinkSync(fileName))
+
+  // clear file locks
+  const headers = httpHelper.createAuthHeader(client.globals.backend_admin_username)
+  const body = new URLSearchParams()
+  body.append('global', 'true')
+  await fetch(`${client.globals.backend_url}/ocs/v2.php/apps/testing/api/v1/lockprovisioning`,
+    { method: 'DELETE', body: body, headers: headers }
+  )
 })


### PR DESCRIPTION
## Description
delete all locks after every test scenario

## Related Issue
#2240

## Motivation and Context
sometimes UI tests break because of not released locks after user deletion.
e.g. https://drone.owncloud.com/owncloud/phoenix/5772/15/11
```

{"reqId":"f5d7cc12-203b-449e-ae2d-224f0b108c3c","level":4,"time":"2019-10-17T03:05:23+00:00","remoteAddr":"192.168.80.4","user":"user1","app":"webdav","method":"MOVE","url":"\/remote.php\/dav\/trash-bin\/user1\/5278","message":"Exception: HTTP\/1.1 423 \"files\/4ba94e5b88b19d9c0e3c178dda39c1dc\" is locked: {\"Exception\":\"OCA\\\\DAV\\\\Connector\\\\Sabre\\\\Exception\\\\FileLocked\",\"Message\":\"\\\"files\\\/4ba94e5b88b19d9c0e3c178dda39c1dc\\\" is locked\",\"Code\":0,\"Trace\":\"#0 \\\/var\\\/www\\\/owncloud\\\/apps\\\/dav\\\/lib\\\/Connector\\\/Sabre\\\/Directory.php(411): OCA\\\\DAV\\\\TrashBin\\\\AbstractTrashBinNode->restore('\\\/\\\/lorem-big.txt')\\n#1 \\\/var\\\/www\\\/owncloud\\\/lib\\\/composer\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/Tree.php(164): OCA\\\\DAV\\\\Connector\\\\Sabre\\\\Directory->moveInto('lorem-big.txt', 'trash-bin\\\/user1...', Object(OCA\\\\DAV\\\\TrashBin\\\\TrashBinFile))\\n#2 \\\/var\\\/www\\\/owncloud\\\/lib\\\/composer\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/CorePlugin.php(641): Sabre\\\\DAV\\\\Tree->move('trash-bin\\\/user1...', 'files\\\/user1\\\/lor...')\\n#3 \\\/var\\\/www\\\/owncloud\\\/lib\\\/composer\\\/sabre\\\/event\\\/lib\\\/WildcardEmitterTrait.php(96): Sabre\\\\DAV\\\\CorePlugin->httpMove(Object(Sabre\\\\HTTP\\\\Request), Object(Sabre\\\\HTTP\\\\Response))\\n#4 \\\/var\\\/www\\\/owncloud\\\/lib\\\/composer\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/Server.php(464): Sabre\\\\DAV\\\\Server->emit('method:MOVE', Array)\\n#5 \\\/var\\\/www\\\/owncloud\\\/lib\\\/composer\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/Server.php(241): Sabre\\\\DAV\\\\Server->invokeMethod(Object(Sabre\\\\HTTP\\\\Request), Object(Sabre\\\\HTTP\\\\Response))\\n#6 \\\/var\\\/www\\\/owncloud\\\/apps\\\/dav\\\/lib\\\/Server.php(326): Sabre\\\\DAV\\\\Server->start()\\n#7 \\\/var\\\/www\\\/owncloud\\\/apps\\\/dav\\\/appinfo\\\/v2\\\/remote.php(31): OCA\\\\DAV\\\\Server->exec()\\n#8 \\\/var\\\/www\\\/owncloud\\\/remote.php(165): require_once('\\\/var\\\/www\\\/ownclo...')\\n#9 {main}\",\"File\":\"\\\/var\\\/www\\\/owncloud\\\/apps\\\/dav\\\/lib\\\/TrashBin\\\/AbstractTrashBinNode.php\",\"Line\":131}"}
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...