### PR TITLE
Acceptance test to receive shares with same name from different users

### DIFF
--- a/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
+++ b/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
@@ -49,15 +49,6 @@ Feature: accept/decline shares coming from internal users
       | /simple-folder%20(2)/from_user1/ |
       | /simple-folder%20(3)/from_user2/ |
 
-  @skip @yetToImplement
-  Scenario: receive shares with same name from different users
-    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-    And user "user2" has shared folder "/simple-folder" with user "user3"
-    And user "user1" has shared folder "/simple-folder" with user "user3"
-    When user "user3" logs in using the webUI
-    Then folder "simple-folder" shared by "User One" should be in state "Pending" in the shared-with-you page on the webUI
-    And folder "simple-folder" shared by "User Two" should be in state "Pending" in the shared-with-you page on the webUI
-
   @smokeTest
   @skip @yetToImplement
   Scenario: accept an offered share
@@ -312,6 +303,49 @@ Feature: accept/decline shares coming from internal users
     Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
     And user "user1" has shared file "lorem.txt" with user "user2"
     When the user browses to the shared-with-me page using the webUI
-    Then the file "lorem.txt" on the webUI should be in "Pending" state
+    Then the file "lorem.txt" should be in "Pending" state on the webUI
     When the user browses to the files page
     Then file "lorem (2).txt" should not be listed on the webUI
+
+  Scenario: shared file is in pending state when the Automatically accept incoming shares is disabled
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And user "user1" has shared file "lorem.txt" with user "user2"
+    When the user browses to the shared-with-me page using the webUI
+    Then the file "lorem.txt" should be in "Pending" state on the webUI
+    When the user browses to the files page
+    Then file "lorem (2).txt" should not be listed on the webUI
+
+  Scenario: receive shares with same name from different users
+    Given user "user3" has been created with default attributes
+    And the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And user "user3" has shared file "lorem.txt" with user "user2"
+    And user "user1" has shared file "lorem.txt" with user "user2"
+    When the user browses to the shared-with-me page using the webUI
+    Then file "lorem.txt" shared by "User One" should be in "Pending" state on the webUI
+    And file "lorem.txt" shared by "User Three" should be in "Pending" state on the webUI
+
+  Scenario: decline an offered (pending) share
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And user "user1" has shared file "lorem.txt" with user "user2"
+    And user "user1" has shared file "testimage.jpg" with user "user2"
+    And the user has browsed to the shared-with-me page
+    When the user declines share "lorem.txt" offered by user "User One" using the webUI
+    Then the file "lorem.txt" should be in "Declined" state on the webUI
+    And the file "testimage.jpg" should be in "Pending" state on the webUI
+    When the user browses to the files page
+    Then file "lorem (2).txt" should not be listed on the webUI
+    And file "testimage (2).jpg" should not be listed on the webUI
+
+  Scenario: accept an offered (pending) share
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And user "user1" has shared file "lorem.txt" with user "user2"
+    And user "user1" has shared file "testimage.jpg" with user "user2"
+    And the user has browsed to the shared-with-me page
+    When the user accepts share "lorem.txt" offered by user "User One" using the webUI
+    Then the file "lorem (2).txt" should be in "Accepted" state on the webUI
+    And the file "testimage.jpg" should be in "Pending" state on the webUI
+    And the file "lorem (2).txt" should be in "Accepted" state on the webUI after a page reload
+    And the file "testimage.jpg" should be in "Pending" state on the webUI after a page reload
+    When the user browses to the files page
+    Then file "lorem (2).txt" should be listed on the webUI
+    And file "testimage (2).jpg" should not be listed on the webUI

--- a/tests/acceptance/pageObjects/sharedWithMePage.js
+++ b/tests/acceptance/pageObjects/sharedWithMePage.js
@@ -14,18 +14,55 @@ module.exports = {
         this.url(), this.page.FilesPageElement.filesList().elements.filesListProgressBar
       )
     },
-    assertFileStatusIsShown: function (filename, status) {
+    /**
+     * @param {string} filename
+     * @param {string} status - It takes one of the following : declined, pending or '' for accepted
+     * @param {string} user
+     * Checks if the file-row of the desired file-name with the username consists of the desired status of accepted,
+     * declined or pending
+     */
+    assertDesiredStatusIsPresent: function (filename, status, user) {
+      let requiredXpath = this.api.page.FilesPageElement.filesList().getFileRowSelectorByFileName(filename) +
+        util.format(this.elements.assertStatusFileRow.selector, status)
+      requiredXpath = user === undefined ? requiredXpath : requiredXpath +
+                      util.format(this.elements.getSharedFromUserName.selector, user)
       return this.waitForElementVisible({
-        locateStrategy: this.elements.fileStatusOfFileRow.locateStrategy,
-        selector: this.api.page
-          .FilesPageElement.filesList().getFileRowSelectorByFileName(filename) +
-          util.format(this.elements.fileStatusOfFileRow.selector, status)
+        locateStrategy: this.elements.assertStatusFileRow.locateStrategy,
+        selector: requiredXpath
       })
+    },
+    /**
+     * @param {string} filename
+     * @param {string} action - It takes one of the following : Decline and Accept
+     * @param {string} user
+     *Performs required action, such as accept and decline, on the file row element of the desired file name
+     *  shared by specific user
+     */
+    declineAcceptFile: function (action, filename, user) {
+      const actionLocatorButton = {
+        locateStrategy: this.elements.actionOnFileRow.locateStrategy,
+        selector: this.api.page.FilesPageElement.filesList().getFileRowSelectorByFileName(filename) +
+          util.format(this.elements.getSharedFromUserName.selector, user) +
+          util.format(this.elements.actionOnFileRow.selector, action)
+      }
+      return this
+        .initAjaxCounters()
+        .waitForElementVisible(actionLocatorButton)
+        .click(actionLocatorButton)
+        .waitForOutstandingAjaxCalls()
     }
   },
   elements: {
-    fileStatusOfFileRow: {
-      selector: '//span[.="%s"]',
+    assertStatusFileRow: {
+      selector: '//span[.="%s"]/../..',
+      locateStrategy: 'xpath'
+    },
+    getSharedFromUserName: {
+      selector: '//div[normalize-space(.)="%s"]',
+      locateStrategy: 'xpath'
+    },
+    actionOnFileRow: {
+      selector: '/../..//a[.="%s"]',
       locateStrategy: 'xpath'
     }
   }

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -35,6 +35,12 @@ When('the user browses to the shared-with-me page', function () {
     .navigateAndWaitTillLoaded()
 })
 
+Given('the user has browsed to the shared-with-me page', function () {
+  return client
+    .page.sharedWithMePage()
+    .navigateAndWaitTillLoaded()
+})
+
 When('the user browses to the shared-with-me page using the webUI', function () {
   return client
     .page.phoenixPage()

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -442,6 +442,25 @@ Then('the collaborators list for file/folder/resource {string} should be empty',
   assert.strictEqual(count, 0, `Expected to have no collaborators for '${resource}', Found: ${count}`)
 })
 
-Then('the file/folder/resource {string} on the webUI should be in {string} state', function (filename, status) {
-  return client.page.sharedWithMePage().assertFileStatusIsShown(filename, status)
+Then('the file/folder/resource {string} should be in {string} state on the webUI', function (filename, status) {
+  status = status === 'Accepted' ? '' : status
+  return client.page.sharedWithMePage().assertDesiredStatusIsPresent(filename, status)
+})
+
+Then('file {string} shared by {string} should be in {string} state on the webUI', function (filename, user, status) {
+  return client.page.sharedWithMePage().assertDesiredStatusIsPresent(filename, status, user)
+})
+
+When('the user declines share {string} offered by user {string} using the webUI', function (filename, user) {
+  return client.page.sharedWithMePage().declineAcceptFile('Decline', filename, user)
+})
+
+When('the user accepts share {string} offered by user {string} using the webUI', function (filename, user) {
+  return client.page.sharedWithMePage().declineAcceptFile('Accept', filename, user)
+})
+
+Then('the file {string} should be in {string} state on the webUI after a page reload', async function (filename, status) {
+  status = status === 'Accepted' ? '' : status
+  await client.refresh()
+  return client.page.sharedWithMePage().assertDesiredStatusIsPresent(filename, status)
 })


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Add acceptance test for accept/decline an offered(pending) shares

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
:robot:

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...