### PR TITLE
Remove file from progress after download on IE11

### DIFF
--- a/src/plugins/phoenix.js
+++ b/src/plugins/phoenix.js
@@ -64,7 +64,6 @@ export default {
                 anchor.click()
                 document.body.removeChild(anchor)
                 window.URL.revokeObjectURL(objectUrl)
-                this.removeActionFromProgress(file)
 
                 // TODO: Bring back when progress bar for download is figured out
                 // Items with small size can be fetched too fast for progress listener
@@ -74,6 +73,8 @@ export default {
                 //   progress: 100
                 // })
               }
+
+              this.removeActionFromProgress(file)
             }
           })
 


### PR DESCRIPTION
## Description
After the request for a file has been finished in download action, remove the file from the progress queue.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #2286

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: IE11, Chrome, FF, Safari
1. Download a file

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 