### PR TITLE
wait till animations are finished after deleting file

### DIFF
--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -20,7 +20,6 @@ module.exports = {
   test_settings: {
     default: {
       globals: {
-        waitForConditionTimeout: 10000,
         waitForConditionPollInterval: 10,
         filesForUpload: FILES_FOR_UPLOAD
       }
@@ -28,6 +27,7 @@ module.exports = {
     local: {
       launch_url: LOCAL_LAUNCH_URL,
       globals: {
+        waitForConditionTimeout: 10000,
         backend_url: LOCAL_BACKEND_URL,
         backend_admin_username: BACKEND_ADMIN_USERNAME,
         backend_admin_password: BACKEND_ADMIN_PASSWORD
@@ -58,6 +58,7 @@ module.exports = {
     drone: {
       launch_url: 'http://phoenix',
       globals: {
+        waitForConditionTimeout: 20000,
         backend_url: 'http://owncloud',
         backend_admin_username: 'admin',
         backend_admin_password: 'admin'

--- a/tests/acceptance/customCommands/waitForAnimationToFinish.js
+++ b/tests/acceptance/customCommands/waitForAnimationToFinish.js
@@ -1,3 +1,7 @@
+/**
+ * try to use waitForElementEnabled() instead of this
+ * @returns {exports}
+ */
 exports.command = function () {
   // till we have a better idea how to detect that an animation is finished
   console.log('waiting for 500ms ...')

--- a/tests/acceptance/customCommands/waitForCSSPropertyEquals.js
+++ b/tests/acceptance/customCommands/waitForCSSPropertyEquals.js
@@ -1,0 +1,23 @@
+/**
+ * waits till a css property equals the given value
+ * @param selector
+ * @param locateStrategy 'css selector' or 'xpath'
+ * @param property the CSS property
+ * @param value the status to wail till
+ * @param timeout defaults to this.globals.waitForConditionTimeout
+ * @returns {exports}
+ */
+
+module.exports.command = function (
+  { selector, locateStrategy = 'css selector', property, value, timeout = this.globals.waitForConditionTimeout }
+) {
+  if (locateStrategy === 'xpath') {
+    this.useXpath()
+  } else if (locateStrategy === 'css selector') {
+    this.useCss()
+  } else {
+    this.assert.fail('invalid locateStrategy')
+  }
+  this.expect.element(selector).to.have.css(property).which.equals(value).before(timeout)
+  return this
+}

--- a/tests/acceptance/customCommands/waitForElementEnabled.js
+++ b/tests/acceptance/customCommands/waitForElementEnabled.js
@@ -1,0 +1,29 @@
+/**
+ *
+ * waits till the element is enabled, at that stage it is "clickable"
+ * this function seems to wait longer than waitForElementVisible() and waitForElementNotVisible() for animated elements
+ * for animated elements waitForElementVisible and waitForElementNotVisible already finish before the animation is finished
+ * elements behind the disappearing animated element might not be clickable yet when waitForElementNotVisible finish
+ * also when trying to use an element that is animated to appear, waitForElementVisible does not always wait long enough
+ *
+ * copied from: https://gist.github.com/deterralba/5862ec98613dbf073545a7d7e87a637d
+ * More info https://github.com/nightwatchjs/nightwatch/issues/705
+ *
+ * @param selector
+ * @param locateStrategy 'css selector' or 'xpath'
+ * @param timeout defaults to this.globals.waitForConditionTimeout
+ * @returns {exports}
+ */
+module.exports.command = function (
+  selector, locateStrategy = 'css selector', timeout = this.globals.waitForConditionTimeout
+) {
+  if (locateStrategy === 'xpath') {
+    this.useXpath()
+  } else if (locateStrategy === 'css selector') {
+    this.useCss()
+  } else {
+    this.assert.fail('invalid locateStrategy')
+  }
+  this.expect.element(selector).enabled.before(timeout)
+  return this
+}

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -108,10 +108,19 @@ module.exports = {
         .waitForFileVisible(fileName)
         .useXpath()
         .performFileAction(fileName, 'delete')
-        .waitForElementVisible('@deleteFileConfirmationBtn')
-        .waitForAnimationToFinish()
+        .waitForElementEnabled(
+          this.elements.deleteFileConfirmationBtn.selector,
+          this.elements.deleteFileConfirmationBtn.locateStrategy
+        )
         .click('@deleteFileConfirmationBtn')
-        .waitForElementNotVisible('@deleteFileConfirmationDialog')
+        .waitForCSSPropertyEquals(
+          {
+            selector: this.elements.deleteFileConfirmationDialog.selector,
+            locateStrategy: this.elements.deleteFileConfirmationBtn.locateStrategy,
+            property: 'display',
+            value: 'none'
+          }
+        )
         .waitForOutstandingAjaxCalls()
         .useCss()
     },
@@ -461,7 +470,8 @@ module.exports = {
       locateStrategy: 'xpath'
     },
     deleteFileConfirmationDialog: {
-      selector: '#delete-file-confirmation-dialog'
+      selector: '#delete-file-confirmation-dialog',
+      locateStrategy: 'css selector'
     },
     deleteButtonInFileRow: {
       selector: '//button[@aria-label="Delete"]',


### PR DESCRIPTION
## Description
after file deletion we sometimes get
```
Error while running .clickElement() protocol action: element click intercepted: Element <button aria-label="show-file-actions" class="oc-button uk-button-default uk-hidden@m uk-open" id="files-file-list-action-button-small-resolution-4" aria-expanded="false">...</button> is not clickable at point (702, 170). Other element would receive the click: <div id="delete-file-confirmation-dialog" uk-modal="" class="uk-modal" style="display: block;">...</div>
```

I guess that even `waitForElementNotVisible`  reports the item to have gone the animation is still in the process of disappearing

so lets wait till the CSS property "display" is set to "none"
bonus: a new function `waitForElementEnabled()` it waits till an element is clickable. For the fading in dialogue that waits longer than `waitForElementVisible()`

## Related Issue
part of #2240

## Motivation and Context
make CI great again

## How Has This Been Tested?
run it multiple times #2323

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...