### PR TITLE
Add labels to checkboxes, table heads

### DIFF
--- a/apps/files/src/components/FileList.vue
+++ b/apps/files/src/components/FileList.vue
@@ -6,9 +6,9 @@
           <thead>
             <oc-table-row>
               <oc-table-cell shrink type="head">
-                <oc-checkbox class="uk-margin-small-left" id="filelist-check-all" @click.native="toggleAll" :value="selectedAll" />
+                <oc-checkbox class="uk-margin-small-left" id="filelist-check-all" labelVisuallyHidden="true" :label="labelSelectAllItems" @click.native="toggleAll" :value="selectedAll" />
               </oc-table-cell>
-              <oc-table-cell shrink type="head" v-if="!publicPage()" />
+              <oc-table-cell shrink type="head" v-if="!publicPage()"><span class="oc-visually-hidden">{{favoritesHeaderText}}</span></oc-table-cell>
               <oc-table-cell type="head" class="uk-text-truncate" v-translate>Name</oc-table-cell>
               <oc-table-cell shrink type="head" :class="{ 'uk-visible@s' : !_sidebarOpen, 'uk-visible@m'  : _sidebarOpen }"><translate>Size</translate></oc-table-cell>
               <oc-table-cell shrink type="head" :class="{ 'uk-visible@s' : !_sidebarOpen, 'uk-visible@m'  : _sidebarOpen }" class="uk-text-nowrap" v-translate>Modification Time</oc-table-cell>
@@ -18,7 +18,7 @@
           <oc-table-group>
             <oc-table-row v-for="(item, index) in fileData" :key="index" :class="_rowClasses(item)" @click="selectRow(item, $event)" :id="'file-row-' + item.id">
               <oc-table-cell>
-                <oc-checkbox class="uk-margin-small-left" @click.stop @change.native="$emit('toggle', item)" :value="selectedFiles.indexOf(item) >= 0" />
+                <oc-checkbox class="uk-margin-small-left" @click.stop @change.native="$emit('toggle', item)" :value="selectedFiles.indexOf(item) >= 0" :label="labelSelectSingleItem(item)"/>
               </oc-table-cell>
               <oc-table-cell class="uk-padding-remove" v-if="!publicPage()">
                 <oc-star class="uk-display-block" @click.native.stop="toggleFileFavorite(item)" :shining="item.starred" />
@@ -139,6 +139,13 @@ export default {
   mounted () {
     this.$_ocFilesFolder_getFolder()
   },
+  data () {
+    return {
+      labelSelectAllItems: this.$gettext('Select all items'),
+      labelSelectSingleItemText: this.$gettext('Select %{type} %{name}'),
+      favoritesHeaderText: this.$gettext('Favorites')
+    }
+  },
   methods: {
     ...mapActions('Files', ['loadFolder', 'setFilterTerm', 'markFavorite',
       'setFilesDeleteMessage', 'setHighlightedFile', 'setPublicLinkPassword']),
@@ -187,6 +194,9 @@ export default {
         })
       })
     },
+    labelSelectSingleItem (item) {
+      return this.$gettextInterpolate(this.labelSelectSingleItemText, { name: item.name, type: item.type }, true)
+    },
     toggleFileFavorite (item) {
       this.markFavorite({
         client: this.$client,
@@ -226,7 +236,6 @@ export default {
     ...mapState(['route']),
     ...mapGetters('Files', ['selectedFiles', 'loadingFolder', 'filesDeleteMessage', 'highlightedFile', 'activeFiles', 'quota', 'filesTotalSize', 'activeFilesCount', 'actionsInProgress']),
     ...mapGetters(['configuration']),
-
     item () {
       return this.$route.params.item
     }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Improves labels in FileList component, see #2332 

## Related Issue 
- **Dependency to https://github.com/owncloud/owncloud-design-system/pull/524**
- **Dependency to https://github.com/owncloud/owncloud-design-system/pull/525**
- **Dependency to https://github.com/owncloud/owncloud-design-system/pull/498**
- Fixes #2332

## Motivation and Context
Improve screen reader operability

## How Has This Been Tested?
Firefox Accessibility Web Inspector Pane, Chrome Accessibility Web Inspector Pane (to visualize Accessibility Tree)
**Needs proper user testing!**

## Screenshots (if appropriate):
![See ussue #2332](https://user-images.githubusercontent.com/505181/67686512-1b01ee00-f997-11e9-8dd6-e91bb9d8d51a.png)

## Legend:
1. This table header item/column header conains just an unlabel checkbox, therefore no text information that could serve as label
2. This table header item/column header is completely empty
3. This checkbox is not labelled
4. This star image is semantically speaking not a control but a clickable div (covered in ODS PR owncloud/owncloud-design-system#525)
5. This File/Folder label is also just a clickable span (covered in #2317)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
