### PR TITLE
Test that user from an excluded group cannot share resource

### DIFF
--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -13,6 +13,7 @@ Feature: Sharing files and folders with internal users
   @smokeTest
   Scenario Outline: share a file & folder with another internal user
     Given user "user2" has logged in using the webUI
+    And the setting "shareapi_auto_accept_share" of app "core" has been set to "yes"
     When the user shares folder "simple-folder" with user "User One" as "<set-role>" using the webUI
     And the user shares file "testimage.jpg" with user "User One" as "<set-role>" using the webUI
     Then user "User One" should be listed as "<expected-role>" in the collaborators list for folder "simple-folder" on the webUI
@@ -161,7 +162,7 @@ Feature: Sharing files and folders with internal users
     And the user browses to the shared-with-others page
     Then file "lorem.txt" with path "" should be listed in the shared with others page on the webUI
     And file "lorem.txt" with path "/simple-folder" should be listed in the shared with others page on the webUI
-
+    
   @skip @yetToImplement
   Scenario: user tries to share a file from a group which is blacklisted from sharing
     Given group "grp1" has been created
@@ -172,87 +173,59 @@ Feature: Sharing files and folders with internal users
     And the administrator adds group "grp1" to the group sharing blacklist using the webUI
     Then user "user1" should not be able to share file "testimage.jpg" with user "user3" using the sharing API
 
-  @skip @yetToImplement
-  Scenario: user tries to share a folder from a group which is blacklisted from sharing
-    Given group "grp1" has been created
-    And user "user1" has been added to group "grp1"
-    And user "user3" has been created with default attributes
-    And the administrator has browsed to the admin sharing settings page
-    When the administrator enables exclude groups from sharing using the webUI
-    And the administrator adds group "grp1" to the group sharing blacklist using the webUI
-    Then user "user1" should not be able to share folder "simple-folder" with user "User Three" using the sharing API
-
-  @skip @yetToImplement
-  Scenario: member of a blacklisted from sharing group tries to re-share a file received as a share
+  Scenario: member of a blacklisted from sharing group tries to re-share a file or folder received as a share
     Given these users have been created with default attributes:
       | username |
       | user3    |
-      | user4    |
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
-    And the administrator has browsed to the admin sharing settings page
-    And user "user3" has shared file "/testimage.jpg" with user "user1"
-    And the administrator has enabled exclude groups from sharing from the admin sharing settings page
-    When the administrator adds group "grp1" to the group sharing blacklist using the webUI
-    Then user "user1" should not be able to share file "/testimage (2).jpg" with user "User Four" using the sharing API
+    And the setting "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    And user "user3" has shared file "testimage.jpg" with user "user1"
+    And user "user3" has shared folder "simple-folder" with user "user1"
+    And the administrator has enabled exclude groups from sharing
+    And the administrator has excluded group "grp1" from sharing
+    When user "user1" logs in using the webUI
+    Then the user should not be able to share file "testimage (2).jpg" using the webUI
+    And the user should not be able to share folder "simple-folder (2)" using the webUI
 
-  @skip @yetToImplement
-  Scenario: member of a blacklisted from sharing group tries to re-share a folder received as a share
-    Given these users have been created with default attributes:
-      | username |
-      | user3    |
-      | user4    |
-    And group "grp1" has been created
-    And user "user1" has been added to group "grp1"
-    And the administrator has browsed to the admin sharing settings page
-    And user "user3" has created folder "/common"
-    And user "user3" has shared folder "/common" with user "user1"
-    And the administrator has enabled exclude groups from sharing from the admin sharing settings page
-    When the administrator adds group "grp1" to the group sharing blacklist using the webUI
-    Then user "user1" should not be able to share folder "/common" with user "User Four" using the sharing API
-
-  @skip @yetToImplement
   Scenario: member of a blacklisted from sharing group tries to re-share a file inside a folder received as a share
     Given these users have been created with default attributes:
       | username |
       | user3    |
-      | user4    |
     And group "grp1" has been created
     And user "user1" has been added to group "grp1"
-    And the administrator has browsed to the admin sharing settings page
-    And user "user3" has created folder "/common"
-    And user "user3" has moved file "/testimage.jpg" to "/common/testimage.jpg"
-    And user "user3" has shared folder "/common" with user "user1"
-    And the administrator has enabled exclude groups from sharing from the admin sharing settings page
-    When the administrator adds group "grp1" to the group sharing blacklist using the webUI
-    Then user "user1" should not be able to share file "/common/testimage.jpg" with user "User Four" using the sharing API
+    And user "user3" has created folder "common"
+    And user "user3" has moved file "testimage.jpg" to "common/testimage.jpg"
+    And user "user3" has shared folder "common" with user "user1"
+    And the administrator has enabled exclude groups from sharing
+    And the administrator has excluded group "grp1" from sharing
+    And user "user1" has logged in using the webUI
+    When the user browses to the folder "common" on the files page
+    Then the user should not be able to share file "testimage.jpg" using the webUI
 
-  @skip @yetToImplement
   Scenario: member of a blacklisted from sharing group tries to re-share a folder inside a folder received as a share
     Given these users have been created with default attributes:
       | username |
       | user3    |
-      | user4    |
-    And the administrator has browsed to the admin sharing settings page
-    And user "user3" has created folder "/common"
-    And user "user3" has created folder "/common/inside-common"
-    And user "user3" has shared folder "/common" with user "user1"
-    And the administrator has enabled exclude groups from sharing from the admin sharing settings page
-    When the administrator adds group "grp1" to the group sharing blacklist using the webUI
-    Then user "user1" should not be able to share folder "/common/inside-common" with user "User Four" using the sharing API
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user3" has created folder "common"
+    And user "user3" has created folder "common/inside-common"
+    And user "user3" has shared folder "common" with user "user1"
+    And the administrator has enabled exclude groups from sharing
+    And the administrator has excluded group "grp1" from sharing
+    And user "user1" has logged in using the webUI
+    When the user browses to the folder "common" on the files page
+    Then the user should not be able to share folder "inside-common" using the webUI
 
-  @skip @yetToImplement
-  Scenario: user tries to share a file from a group which is blacklisted from sharing using webUI from files page
+  Scenario: user tries to share a file or folder from a group which is blacklisted from sharing from files page
     Given group "grp1" has been created
     And user "user1" has been added to group "grp1"
-    And user "user3" has been created with default attributes
-    And the administrator has browsed to the admin sharing settings page
-    And the administrator has enabled exclude groups from sharing from the admin sharing settings page
-    When the administrator adds group "grp1" to the group sharing blacklist using the webUI
-    And the user re-logs in as "user1" using the webUI
-    And the user opens the sharing tab from the file action menu of file "testimage.jpg" using the webUI
-    Then the user should see an error message on the share dialog saying "Sharing is not allowed"
-    And the share-with field should not be visible in the details panel
+    And the administrator has enabled exclude groups from sharing
+    And the administrator has excluded group "grp1" from sharing
+    When user "user1" logs in using the webUI
+    Then the user should not be able to share file "testimage.jpg" using the webUI
+    And the user should not be able to share folder "simple-folder" using the webUI
 
   @skip @yetToImplement
   Scenario: user tries to re-share a file from a group which is blacklisted from sharing using webUI from shared with you page

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -3,6 +3,8 @@ const assert = require('assert')
 const { Given, When, Then, Before } = require('cucumber')
 const webdav = require('../helpers/webdavHelper')
 const loginHelper = require('../helpers/loginHelper')
+const { createFolder } = require('../helpers/webdavHelper')
+const { move } = require('../helpers/webdavHelper')
 const path = require('path')
 let deletedElements
 let timeOfLastDeleteOperation = Date.now()
@@ -100,6 +102,14 @@ Given('the user has browsed to the files page', function () {
   return client
     .page.filesPage()
     .navigateAndWaitTillLoaded()
+})
+
+Given('user {string} has created folder {string}', function (user, folderName) {
+  return createFolder(user, folderName)
+})
+
+Given('user {string} has moved file {string} to {string}', function (user, fromName, toName) {
+  return move(user, fromName, toName)
 })
 
 When('the user creates a folder with the name {string} using the webUI', function (folderName) {


### PR DESCRIPTION


<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Add acceptance test to assert user from a shareapi excluded group is not able to share files and folders

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
:robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...