### PR TITLE
Fixed wrong method for copy action of public link

### DIFF
--- a/apps/files/src/components/FileLink.vue
+++ b/apps/files/src/components/FileLink.vue
@@ -146,7 +146,7 @@ export default {
       this.linkId = false
     },
     $_copyToClipboard (link) {
-      this.$clipboard(link.url)
+      this.$copyText(link.url)
 
       const clone = event.currentTarget.firstElementChild.cloneNode(true)
       clone.classList.add('_clipButton')


### PR DESCRIPTION
## Description
Replaced method for copying the public link from old package to the new one.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually
1. Create public link
2. Copy the link with the clipboard icon
3. Navigate to the public link

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 