### PR TITLE
Refactor collaborators to use helper classes and to map permissions

### DIFF
--- a/apps/files/src/components/Collaborators/AdditionalPermissions.vue
+++ b/apps/files/src/components/Collaborators/AdditionalPermissions.vue
@@ -1,0 +1,66 @@
+<template>
+  <oc-grid gutter="small">
+    <label v-for="permission in permissions" :key="permission.name">
+      <oc-checkbox
+        class="uk-margin-xsmall-right"
+        v-model="permission.value"
+        @change="permissionChecked"
+      />
+      {{ permission.description }}
+    </label>
+  </oc-grid>
+</template>
+
+<script>
+import filterObject from 'filter-obj'
+
+export default {
+  name: 'AdditionalPermissions',
+  props: {
+    /**
+     * Available permissions for the role
+     */
+    availablePermissions: {
+      type: Object,
+      required: true
+    },
+    /**
+     * Additional permissions of the collaborator with values
+     */
+    collaboratorsPermissions: {
+      type: Object,
+      required: false
+    }
+  },
+  computed: {
+    permissions () {
+      const permissions = this.availablePermissions
+
+      for (const permission in permissions) {
+        if (this.collaboratorsPermissions && this.collaboratorsPermissions[permission]) {
+          permissions[permission].value = true
+          continue
+        }
+
+        permissions[permission].value = false
+      }
+
+      return permissions
+    }
+  },
+  methods: {
+    permissionChecked () {
+      const selectedPermissions = []
+      const permissions = filterObject(this.permissions, (key, value) => {
+        return value.value === true
+      })
+
+      for (const permission in permissions) {
+        selectedPermissions.push(permission)
+      }
+
+      this.$emit('permissionChecked', selectedPermissions)
+    }
+  }
+}
+</script>

--- a/apps/files/src/components/Collaborators/AdditionalPermissions.vue
+++ b/apps/files/src/components/Collaborators/AdditionalPermissions.vue
@@ -1,8 +1,9 @@
 <template>
   <oc-grid gutter="small">
-    <label v-for="permission in permissions" :key="permission.name">
+    <label v-for="permission in permissions" :key="permission.name" class="files-collaborators-permission-label">
       <oc-checkbox
-        class="uk-margin-xsmall-right"
+        :id="`files-collaborators-permission-${permission.name}`"
+        class="uk-margin-xsmall-right files-collaborators-permission-checkbox"
         v-model="permission.value"
         @change="permissionChecked"
       />

--- a/apps/files/src/components/Collaborators/AutocompleteItem.vue
+++ b/apps/files/src/components/Collaborators/AutocompleteItem.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="uk-flex uk-flex-middle">
-    <oc-spinner v-if="loading" uk-spinner="ratio:1.6" class="uk-margin-small-right" />
+    <oc-spinner v-if="loading" uk-spinner="ratio:1.6" class="uk-margin-small-right" :aria-label="$gettext('Loading avatar')" />
     <template v-else>
       <oc-avatar v-if="avatar" :src="avatar" class="uk-margin-small-right" width=50 height=50 />
       <template v-else>
@@ -20,7 +20,7 @@
 </template>
 
 <script>
-import Mixins from './mixins'
+import Mixins from '../../mixins/collaborators'
 
 export default {
   name: 'AutocompleteItem',

--- a/apps/files/src/components/Collaborators/Collaborator.vue
+++ b/apps/files/src/components/Collaborators/Collaborator.vue
@@ -18,58 +18,23 @@
               ({{ collaborator.info.share_with_additional_info }})
             </span>
           </div>
-          <span class="oc-text">{{ roles[collaborator.role].name }}<template v-if="collaborator.expires"> | <translate :translate-params="{expires: formDateFromNow(collaborator.expires)}">Expires: %{expires}</translate></template></span>
-          <span class="uk-text-meta">{{ $_ocCollaborators_collaboratorType(collaborator.info.share_type) }}</span>
+          <span class="oc-text">{{ originalRole.label }}<template v-if="collaborator.expires"> | <translate :translate-params="{expires: formDateFromNow(collaborator.expires)}">Expires: %{expires}</translate></template></span>
+          <span class="uk-text-meta" v-text="$_ocCollaborators_collaboratorType(collaborator.info.share_type)" />
         </div>
       </div>
     </template>
     <template slot="content">
-      <oc-grid gutter="small" class="uk-margin-bottom">
-        <div class="uk-width-1-1 uk-position-relative">
-          <label class="oc-label"><translate>Role</translate></label>
-          <oc-button :id="`files-collaborators-role-button-${collaborator.info.id}`" class="uk-width-1-1 files-collaborators-role-button">{{ $_ocCollaborators_selectedRoleName(collaborator) }}</oc-button>
-          <p class="uk-text-meta uk-margin-remove">{{ $_ocCollaborators_selectedRoleDescription(collaborator) }}</p>
-          <oc-drop :dropId="`files-collaborators-roles-dropdown-${collaborator.info.id}`" closeOnClick :toggle="`#files-collaborators-role-button-${collaborator.info.id}`" mode="click" :options="{ offset: 0, delayHide: 0 }" class="oc-autocomplete-dropdown">
-            <ul class="oc-autocomplete-suggestion-list">
-              <li
-                v-for="(role, key) in roles"
-                :key="key"
-                class="oc-autocomplete-suggestion"
-                :class="rolesDropItemClass(role)"
-                @click="$_ocCollaborators_changeRole(role); onChange()"
-              >
-                <span class="uk-text-bold">{{ role.name }}</span>
-                <p class="uk-text-meta uk-margin-remove">{{ role.description }}</p>
-              </li>
-            </ul>
-          </oc-drop>
-        </div>
-        <div v-if="false" class="uk-width-1-1">
-          <label class="oc-label"><translate>Expiration date</translate> <translate class="uk-text-meta uk-remove-margin">(optional)</translate></label>
-          <oc-text-input type="date" class="uk-width-1-1 oc-button-role">04 - 07 - 2019</oc-text-input>
-        </div>
-        <oc-grid gutter="small">
-          <div class="uk-flex uk-flex-row uk-flex-wrap uk-flex-middle">
-            <oc-switch :key="switchKey" class="uk-margin-small-right" :model="canShare" @change="$_ocCollaborators_switchPermission('canShare')" /> <translate :class="{ 'uk-text-muted': !canShare }">Can share</translate>
-          </div>
-          <template v-if="(collaborator.role === 'custom' && !selectedNewRole) || (selectedNewRole && selectedNewRole.tag === 'custom')">
-            <div class="uk-flex uk-flex-row uk-flex-wrap uk-flex-middle">
-              <oc-switch :key="switchKey" class="uk-margin-small-right" :model="canChange" @change="$_ocCollaborators_switchPermission('canChange')" /> <translate :class="{ 'uk-text-muted': !canChange }">Can change</translate>
-            </div>
-            <div v-if="highlightedFile.type === 'folder'" class="uk-flex uk-flex-row uk-flex-wrap uk-flex-middle">
-              <oc-switch :key="switchKey" class="uk-margin-small-right" :model="canCreate" @change="$_ocCollaborators_switchPermission('canCreate')" /> <translate :class="{ 'uk-text-muted': !canCreate }">Can create</translate>
-            </div>
-            <div v-if="highlightedFile.type === 'folder'" class="uk-flex uk-flex-row uk-flex-wrap uk-flex-middle">
-              <oc-switch :key="switchKey" class="uk-margin-small-right" :model="canDelete" @change="$_ocCollaborators_switchPermission('canDelete')" /> <translate :class="{ 'uk-text-muted': !canDelete }">Can delete</translate>
-            </div>
-          </template>
-        </oc-grid>
-      </oc-grid>
+      <collaborators-edit-options
+        :existingRole="collaborator.role"
+        :collaboratorsPermissions="collaborator.customPermissions"
+        @optionChange="collaboratorOptionChanged"
+        class="uk-margin-bottom"
+      />
       <template v-if="editing">
         <oc-button :disabled="collaboratorSaving" @click="$_ocCollaborators_cancelChanges">
           <translate>Cancel</translate>
         </oc-button>
-        <oc-button variation="primary" :disabled="collaboratorSaving" :aria-label="_saveButtonLabel" @click="$_ocCollaborators_saveChanges(collaborator)">
+        <oc-button variation="primary" :disabled="collaboratorSaving" :aria-label="_saveButtonLabel" @click="saveChanges(collaborator)">
           <translate>Save</translate>
         </oc-button>
       </template>
@@ -81,10 +46,16 @@
 
 <script>
 import { mapGetters, mapActions } from 'vuex'
-import Mixins from './mixins'
+import Mixins from '../../mixins/collaborators'
+import { roleToBitmask } from '../../helpers/collaborators'
+
+const CollaboratorsEditOptions = () => import('./CollaboratorsEditOptions.vue')
 
 export default {
   name: 'Collaborator',
+  components: {
+    CollaboratorsEditOptions
+  },
   props: ['collaborator'],
   mixins: [
     Mixins
@@ -94,13 +65,9 @@ export default {
       avatar: '',
       loading: false,
       editing: false,
-      canShare: this.collaborator.canShare,
-      canChange: this.collaborator.customPermissions.change,
-      canCreate: this.collaborator.customPermissions.create,
-      canDelete: this.collaborator.customPermissions.delete,
-      selectedNewRole: null,
       permissionsChanged: false,
-      switchKey: Math.floor(Math.random() * 100) // Ensure switch gets back to orginal position after cancel
+      selectedRole: null,
+      additionalPermissions: null
     }
   },
   computed: {
@@ -116,7 +83,11 @@ export default {
     },
 
     originalRole () {
-      return this.roles[this.collaborator.role].tag
+      if (this.collaborator.role.name === 'advancedRole') {
+        return this.advancedRole
+      }
+
+      return this.roles[this.collaborator.role.name]
     }
   },
   mounted () {
@@ -130,60 +101,35 @@ export default {
         client: this.$client,
         share: share
       })
+      this.editing = false
+      this.toggleCollaboratorsEdit(false)
     },
-    $_ocCollaborators_saveChanges (collaborator) {
-      if (!this.selectedNewRole) this.selectedNewRole = this.roles[collaborator.role]
+    saveChanges (collaborator) {
+      if (!this.selectedRole) this.selectedRole = this.roles[collaborator.role.name]
       this.changeShare({
         client: this.$client,
         share: collaborator,
-        canShare: this.canShare,
-        canChange: this.canChange,
-        canCreate: this.canCreate,
-        canDelete: this.canDelete,
-        role: this.selectedNewRole.tag
+        role: this.selectedRole,
+        permissions: roleToBitmask(this.selectedRole, this.additionalPermissions, this.highlightedFile.type === 'folder')
       })
         .then(() => {
           this.editing = false
           this.toggleCollaboratorsEdit(false)
-          this.selectedNewRole = null
         })
     },
-    $_ocCollaborators_changeRole (role) {
-      this.selectedNewRole = role
-    },
-    $_ocCollaborators_selectedRoleName (collaborator) {
-      if (!this.selectedNewRole) {
-        return this.roles[collaborator.role].name
-      }
-
-      return this.selectedNewRole.name
-    },
-    $_ocCollaborators_selectedRoleDescription (collaborator) {
-      if (!this.selectedNewRole) {
-        return this.roles[collaborator.role].description
-      }
-
-      return this.selectedNewRole.description
-    },
     $_ocCollaborators_cancelChanges () {
-      this.selectedNewRole = null
-      this.canShare = this.collaborator.canShare
-      this.canChange = this.collaborator.customPermissions.change
-      this.canCreate = this.collaborator.customPermissions.create
-      this.canDelete = this.collaborator.customPermissions.delete
       this.editing = false
-      this.switchKey = Math.floor(Math.random() * 100)
       this.toggleCollaboratorsEdit(false)
     },
 
     onChange () {
-      if (this.selectedNewRole.tag === this.originalRole && !this.permissionsChanged) {
-        this.editing = false
-        this.toggleCollaboratorsEdit(false)
-        return
-      }
+      // TODO: Bring this back
+      // if (this.selectedRole.name === this.originalRole.name && !this.permissionsChanged) {
+      //   this.editing = false
+      //   this.toggleCollaboratorsEdit(false)
+      //   return
+      // }
 
-      this.editing = true
       this.toggleCollaboratorsEdit(true)
     },
 
@@ -197,6 +143,7 @@ export default {
 </script>
 
 <style>
+  /* TODO: Move to ODS  */
   .oc-text {
     font-size: 1rem;
   }

--- a/apps/files/src/components/Collaborators/CollaboratorsEditOptions.vue
+++ b/apps/files/src/components/Collaborators/CollaboratorsEditOptions.vue
@@ -1,0 +1,88 @@
+<template>
+  <oc-grid gutter="small" childWidth="1-1">
+    <roles-select
+      :selectedRole="role"
+      @roleSelected="selectRole"
+    />
+    <additional-permissions
+      :availablePermissions="role.additionalPermissions"
+      :collaboratorsPermissions="collaboratorsPermissions"
+      @permissionChecked="checkAdditionalPermissions"
+    />
+  </oc-grid>
+</template>
+
+<script>
+import collaboratorsMixins from '../../mixins/collaborators'
+
+const RolesSelect = () => import('./RolesSelect.vue')
+const AdditionalPermissions = () => import('./AdditionalPermissions.vue')
+
+export default {
+  name: 'CollaboratorsEditOptions',
+  mixins: [
+    collaboratorsMixins
+  ],
+  props: {
+    existingRole: {
+      type: Object,
+      required: false
+    },
+    collaboratorsPermissions: {
+      type: Object,
+      required: false
+    }
+  },
+  components: {
+    RolesSelect,
+    AdditionalPermissions
+  },
+  data () {
+    return {
+      selectedRole: null,
+      additionalPermissions: null
+    }
+  },
+  computed: {
+    role () {
+      // Returns default role
+      if (!this.existingRole && !this.selectedRole) {
+        const defaultRole = this.roles[Object.keys(this.roles)[0]]
+        this.selectRole(defaultRole, false)
+        return defaultRole
+      }
+
+      if (
+        (
+          this.existingRole && this.existingRole.name === 'advancedRole'
+        ) || (
+          this.selectedRole && this.selectedRole.name === 'advancedRole'
+        )
+      ) {
+        this.selectRole(this.advancedRole, false)
+        return this.advancedRole
+      }
+
+      if (this.existingRole && !this.selectedRole) {
+        this.selectRole(this.existingRole, false)
+        return this.existingRole
+      }
+
+      return this.selectedRole
+    }
+  },
+  methods: {
+    selectRole (role, propagate = true) {
+      this.selectedRole = role
+
+      this.$emit('optionChange', { role: this.selectedRole, permissions: this.additionalPermissions, propagate: propagate })
+    },
+
+    checkAdditionalPermissions (permissions) {
+      this.additionalPermissions = permissions
+
+      this.$emit('optionChange', { role: this.selectedRole, permissions: this.additionalPermissions })
+    }
+  }
+}
+</script>

--- a/apps/files/src/components/Collaborators/CollaboratorsEditOptions.vue
+++ b/apps/files/src/components/Collaborators/CollaboratorsEditOptions.vue
@@ -54,7 +54,7 @@ export default {
 
       if (
         (
-          this.existingRole && this.existingRole.name === 'advancedRole'
+          this.existingRole && this.existingRole.name === 'advancedRole' && !this.selectedRole
         ) || (
           this.selectedRole && this.selectedRole.name === 'advancedRole'
         )

--- a/apps/files/src/components/Collaborators/RolesSelect.vue
+++ b/apps/files/src/components/Collaborators/RolesSelect.vue
@@ -1,0 +1,59 @@
+<template>
+  <div>
+    <label class="oc-label">
+      <translate>Role</translate>:
+    </label>
+    <oc-button
+      id="files-collaborators-role-button"
+      class="uk-width-1-1 files-collaborators-role-button"
+      v-text="selectedRole.label"
+    />
+    <oc-drop
+      closeOnClick
+      dropId="files-collaborators-roles-dropdown"
+      toggle="#files-collaborators-role-button"
+      mode="click"
+      :options="{ offset: 0, delayHide: 0 }"
+      class="oc-autocomplete-dropdown"
+    >
+      <ul class="oc-autocomplete-suggestion-list">
+        <li
+          v-for="role in roles"
+          :key="role.name"
+          :id="`files-collaborator-new-collaborator-role-${role.name}`"
+          class="oc-autocomplete-suggestion"
+          :class="{ 'oc-autocomplete-suggestion-selected': role.name === selectedRole.name }"
+          @click="selectRole(role)"
+        >
+          <span class="uk-text-bold" v-text="role.label" />
+          <p
+            class="uk-text-meta uk-margin-remove"
+            v-text="role.description"
+          />
+        </li>
+      </ul>
+    </oc-drop>
+  </div>
+</template>
+
+<script>
+import collaboratorsMixin from '../../mixins/collaborators'
+
+export default {
+  name: 'RolesSelect',
+  mixins: [
+    collaboratorsMixin
+  ],
+  props: {
+    selectedRole: {
+      type: Object,
+      required: true
+    }
+  },
+  methods: {
+    selectRole (role) {
+      this.$emit('roleSelected', role)
+    }
+  }
+}
+</script>

--- a/apps/files/src/components/FileSharingSidebar.vue
+++ b/apps/files/src/components/FileSharingSidebar.vue
@@ -36,7 +36,7 @@
 
 <script>
 import { mapGetters, mapActions, mapState } from 'vuex'
-import Mixins from './Collaborators/mixins'
+import Mixins from '../mixins/collaborators'
 const NewCollaborator = _ => import('./Collaborators/NewCollaborator.vue')
 const Collaborator = _ => import('./Collaborators/Collaborator.vue')
 

--- a/apps/files/src/helpers/collaboratorRolesDefinition.js
+++ b/apps/files/src/helpers/collaboratorRolesDefinition.js
@@ -1,0 +1,69 @@
+// Return original string in case no translate function is provided
+function returnOriginal (string) {
+  return string
+}
+
+// TODO: Bring default role in here. Later might go to the roles API
+/**
+   * Returns object with collaborator roles
+   * @param {boolean} isFolder  Defines if the item is folder
+   * @param {function} $gettext  Function to translate neccessary strings
+   * @returns {object}  Collaborator roles
+   */
+export default ({ isFolder = false, $gettext = returnOriginal }) => {
+  if (isFolder) {
+    return {
+      viewer: {
+        name: 'viewer',
+        label: $gettext('Viewer'),
+        description: $gettext('Download and preview'),
+        permissions: ['read'],
+        additionalPermissions: {
+          share: {
+            name: 'share',
+            description: $gettext('Allow re-Sharing')
+          }
+        }
+      },
+      editor: {
+        name: 'editor',
+        label: $gettext('Editor'),
+        description: $gettext('Upload, edit, delete, download and preview'),
+        permissions: ['read', 'update', 'create', 'delete'],
+        additionalPermissions: {
+          share: {
+            name: 'share',
+            description: $gettext('Allow re-Sharing')
+          }
+        }
+      }
+    }
+  }
+
+  return {
+    viewer: {
+      name: 'viewer',
+      label: $gettext('Viewer'),
+      description: $gettext('Download and preview'),
+      permissions: ['read'],
+      additionalPermissions: {
+        share: {
+          name: 'share',
+          description: $gettext('Allow re-Sharing')
+        }
+      }
+    },
+    editor: {
+      name: 'editor',
+      label: $gettext('Editor'),
+      description: $gettext('Edit, download and preview'),
+      permissions: ['read', 'update'],
+      additionalPermissions: {
+        share: {
+          name: 'share',
+          description: $gettext('Allow re-Sharing')
+        }
+      }
+    }
+  }
+}

--- a/apps/files/src/helpers/collaborators.js
+++ b/apps/files/src/helpers/collaborators.js
@@ -27,7 +27,9 @@ export function roleToBitmask (role, additionalPermissions = []) {
 
   if (additionalPermissions) {
     for (const additionalPermission of additionalPermissions) {
-      bitmask |= permissionsBitmask[additionalPermission]
+      if (role.additionalPermissions[additionalPermission]) {
+        bitmask |= permissionsBitmask[additionalPermission]
+      }
     }
   }
 
@@ -64,7 +66,7 @@ export function bitmaskToRole (bitmask, isFolder) {
       rolePermissionsBitmask |= permissionsBitmask[additionalPermissions[additionalPermission].name]
     }
 
-    // TODO: Use bitmask
+    // TODO: Use bitmask to cover cases of more then one additional permission
     if (
       rolePermissionsBitmask === bitmask ||
       roleBasicPermissionsBitmask === bitmask

--- a/apps/files/src/helpers/collaborators.js
+++ b/apps/files/src/helpers/collaborators.js
@@ -1,0 +1,79 @@
+import roles from './collaboratorRolesDefinition'
+
+/**
+ * Bitmask of ownCloud permission
+ */
+export const permissionsBitmask = {
+  read: 1,
+  update: 2,
+  create: 4,
+  delete: 8,
+  share: 16,
+  all: 31
+}
+
+/**
+ * Maps role to its bitmask
+ * @param {object} role  Role which is to be mapped to permissions
+ * @param {array} additionalPermissions  Array of selected additional permissions
+ * @returns {integer}  Role bitmask
+ */
+export function roleToBitmask (role, additionalPermissions = []) {
+  let bitmask = 0
+
+  for (const permission of role.permissions) {
+    bitmask |= permissionsBitmask[permission]
+  }
+
+  if (additionalPermissions) {
+    for (const additionalPermission of additionalPermissions) {
+      bitmask |= permissionsBitmask[additionalPermission]
+    }
+  }
+
+  return bitmask
+}
+
+/**
+ * Maps bitmask to role
+ * @param {number} bitmask Permissions which are to be mapped to role
+ * @param {boolean} isFolder Defines if the item is folder
+ * @returns {object} Role mapped to the bitmask
+ */
+export function bitmaskToRole (bitmask, isFolder) {
+  // TODO: inject the result of "roles()" in the function header and have the caller of bitmaskToRole call roles() with appropriate arguments including translation
+  // Not passing in translation as we don't need it
+  const currentRoles = roles({ isFolder: isFolder })
+  bitmask = parseInt(bitmask, 10)
+
+  for (const role in currentRoles) {
+    const currentRole = currentRoles[role]
+    let rolePermissionsBitmask = 0
+
+    // Get bitmask of basic permissions
+    currentRole.permissions.forEach(permission => {
+      rolePermissionsBitmask |= permissionsBitmask[permission]
+    })
+
+    // Copy basic permissions bitmask so that in case that no additional permissions have been set, the role is still mapped
+    const roleBasicPermissionsBitmask = rolePermissionsBitmask
+
+    // Get bitmask of additional permissions
+    const additionalPermissions = currentRole.additionalPermissions
+    for (const additionalPermission in additionalPermissions) {
+      rolePermissionsBitmask |= permissionsBitmask[additionalPermissions[additionalPermission].name]
+    }
+
+    // TODO: Use bitmask
+    if (
+      rolePermissionsBitmask === bitmask ||
+      roleBasicPermissionsBitmask === bitmask
+    ) {
+      return currentRole
+    }
+  }
+
+  return {
+    name: 'advancedRole'
+  }
+}

--- a/apps/files/src/store/actions.js
+++ b/apps/files/src/store/actions.js
@@ -1,5 +1,5 @@
 import moment from 'moment'
-import { bitmaskToRole } from '../helpers/collaborators'
+import { bitmaskToRole, permissionsBitmask } from '../helpers/collaborators'
 
 function _buildFile (file) {
   let ext = ''
@@ -223,10 +223,10 @@ function _buildShare (s, file) {
       share.displayName = s.share_with_displayname
       // TODO: Refactor to work with roles / prepare for roles API
       share.customPermissions = {
-        update: s.permissions === '3' || s.permissions === '15' || s.permissions === '19' || s.permissions === '31',
-        create: s.permissions === '5' || s.permissions === '15' || s.permissions === '21' || s.permissions === '31',
-        delete: s.permissions === '9' || s.permissions === '15' || s.permissions === '25' || s.permissions === '31',
-        share: s.permissions === '17' || s.permissions === '19' || s.permissions === '21' || s.permissions === '25' || s.permissions === '31'
+        update: s.permissions & permissionsBitmask.update,
+        create: s.permissions & permissionsBitmask.create,
+        delete: s.permissions & permissionsBitmask.delete,
+        share: s.permissions & permissionsBitmask.share
       }
       // share.email = 'foo@djungle.com' // hm, where do we get the mail from? share_with_additional_info:Object?
       break

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "eslint-plugin-vue": "^5.2.3",
     "execa": "^2.0.3",
     "file-loader": "^4.1.0",
+    "filter-obj": "^2.0.1",
     "html-webpack-plugin": "^3.2.0",
     "husky": ">=3.0.5",
     "lint-staged": ">=9",

--- a/tests/acceptance/features/webUIFiles/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUIFiles/deleteFilesFolders.feature
@@ -140,7 +140,7 @@ Feature: deleting files and folders
     Then file "lorem.txt" should not be listed on the webUI
 
   Scenario: delete a file on a public share
-    Given user "user1" has shared folder "simple-folder" with link with "read, change, create, delete" permissions
+    Given user "user1" has shared folder "simple-folder" with link with "read, update, create, delete" permissions
     When the public uses the webUI to access the last public link created by user "user1"
     And the user deletes the following elements using the webUI
       | name                                  |
@@ -161,7 +161,7 @@ Feature: deleting files and folders
       |                          | "double" quotes |
       |                          | question?       |
       |                          | &and#hash       |
-    And user "user1" has shared folder "simple-folder" with link with "read, change, create, delete" permissions
+    And user "user1" has shared folder "simple-folder" with link with "read, update, create, delete" permissions
     When the public uses the webUI to access the last public link created by user "user1"
     And the user deletes the following file using the webUI
       | name-parts      |
@@ -185,7 +185,7 @@ Feature: deleting files and folders
 
   @skip @yetToImplement
   Scenario: Delete multiple files at once on a public share
-    Given user "user1" has shared folder "simple-folder" with link with "read, change, create, delete" permissions
+    Given user "user1" has shared folder "simple-folder" with link with "read, update, create, delete" permissions
     When the public uses the webUI to access the last public link created by user "user1"
     And the user batch deletes these files using the webUI
       | name                |

--- a/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
@@ -146,7 +146,7 @@ Feature: rename files
     Then the error message 'Error while renaming "data.zip" to "data.part"' should be displayed on the webUI
 
   Scenario: rename a file on a public share
-    Given user "user1" has shared folder "simple-folder" with link with "read, change, create, delete" permissions
+    Given user "user1" has shared folder "simple-folder" with link with "read, update, create, delete" permissions
     When the public uses the webUI to access the last public link created by user "user1"
     And the user renames file "lorem.txt" to "a-renamed-file.txt" using the webUI
     Then file "a-renamed-file.txt" should be listed on the webUI

--- a/tests/acceptance/features/webUIResharing/reshareUsers.feature
+++ b/tests/acceptance/features/webUIResharing/reshareUsers.feature
@@ -46,12 +46,12 @@ Feature: Resharing shared files with different permissions
     | item_type   | folder             |
     | permissions | <permissions>      |
     Examples:
-    | role        | displayed-role | collaborators-permissions     | displayed-permissions | permissions                         |
-    | Viewer      | Viewer         | share                         | share                 | read, share                         |
-    | Editor      | Editor         | share                         | share                 | all                                 |
-    | Custom Role | Custom role    | share, create                 | share, create         | read, share, create                 |
-    | Custom Role | Editor         | change, share                 | share                 | read, change, share                 |
-    | Custom Role | Editor         | delete, share, create, change | share                 | read, share, delete, change, create |
+    | role                 | displayed-role          | collaborators-permissions     | displayed-permissions | permissions                         |
+    | Viewer               | Viewer                  | share                         | share                 | read, share                         |
+    | Editor               | Editor                  | share                         | share                 | all                                 |
+    | Advanced permissions | Advanced permissions    | share, create                 | share, create         | read, share, create                 |
+    | Advanced permissions | Advanced permissions    | update, share                 | share, update         | read, update, share                 |
+    | Advanced permissions | Editor                  | delete, share, create, update | share                 | read, share, delete, update, create |
 
   Scenario Outline: share a received folder with another user with same permissions(including share permissions) and check if the user is displayed in collaborators list for original owner
     Given user "user2" has shared folder "simple-folder" with user "user1" with "<permissions>" permissions
@@ -77,12 +77,12 @@ Feature: Resharing shared files with different permissions
     | item_type   | folder             |
     | permissions | <permissions>      |
     Examples:
-    | role        | displayed-role | collaborators-permissions     | displayed-permissions | permissions                         |
-    | Viewer      | Viewer         | share                         | share                 | read, share                         |
-    | Editor      | Editor         | share                         | share                 | all                                 |
-    | Custom Role | Custom role    | share, create                 | share, create         | read, share, create                 |
-    | Custom Role | Editor         | change, share                 | share                 | read, change, share                 |
-    | Custom Role | Editor         | delete, share, create, change | share                 | read, share, delete, change, create |
+    | role                 | displayed-role          | collaborators-permissions     | displayed-permissions | permissions                         |
+    | Viewer               | Viewer                  | share                         | share                 | read, share                         |
+    | Editor               | Editor                  | share                         | share                 | all                                 |
+    | Advanced permissions | Advanced permissions    | share, create                 | share, create         | read, share, create                 |
+    | Advanced permissions | Advanced permissions    | update, share                 | share, update         | read, update, share                 |
+    | Advanced permissions | Editor                  | delete, share, create, update | share                 | read, share, delete, update, create |
 
   Scenario: share a folder with another user with share permissions and reshare without share permissions to different user, and check if user is displayed for original sharer
     Given user "user2" has shared folder "simple-folder" with user "user1" with "read, share" permissions
@@ -144,7 +144,7 @@ Feature: Resharing shared files with different permissions
   Scenario: User is allowed to reshare a file/folder with the equivalent received permissions, and collaborators should not be listed for the receiver
     Given user "user2" has shared folder "simple-folder" with user "user1" with "read, share, delete" permissions
     And user "user1" has logged in using the webUI
-    When the user shares folder "simple-folder (2)" with user "User Three" as "Custom role" with permissions "share, delete" using the webUI
+    When the user shares folder "simple-folder (2)" with user "User Three" as "Advanced permissions" with permissions "share, delete" using the webUI
     And the user re-logs in as "user3" using the webUI
     Then the collaborators list for folder "simple-folder (2)" should be empty
     And user "user3" should have received a share with these details:
@@ -158,11 +158,11 @@ Feature: Resharing shared files with different permissions
   Scenario: User is allowed to reshare a file/folder with the lesser permissions, and check if it is listed for original owner
     Given user "user2" has shared folder "simple-folder" with user "user1" with "read, share, delete" permissions
     And user "user1" has logged in using the webUI
-    When the user shares folder "simple-folder (2)" with user "User Three" as "Custom role" with permissions "delete" using the webUI
+    When the user shares folder "simple-folder (2)" with user "User Three" as "Advanced permissions" with permissions "delete" using the webUI
     And the user re-logs in as "user2" using the webUI
-    Then user "User One" should be listed as "Custom role" in the collaborators list for folder "simple-folder" on the webUI
+    Then user "User One" should be listed as "Advanced permissions" in the collaborators list for folder "simple-folder" on the webUI
     And custom permissions "share, delete" should be set for user "User One" for folder "simple-folder" on the webUI
-    And user "User Three" should be listed as "Custom role" in the collaborators list for folder "simple-folder" on the webUI
+    And user "User Three" should be listed as "Advanced permissions" in the collaborators list for folder "simple-folder" on the webUI
     And custom permissions "delete" should be set for user "User Three" for folder "simple-folder" on the webUI
     And user "user3" should have received a share with these details:
     | field       | value              |
@@ -175,7 +175,7 @@ Feature: Resharing shared files with different permissions
   Scenario: User is not allowed to reshare a file/folder with the higher permissions
     Given user "user2" has shared folder "simple-folder" with user "user1" with "read, share, delete" permissions
     And user "user1" has logged in using the webUI
-    When the user shares folder "simple-folder (2)" with user "User Three" as "Custom role" with permissions "share, delete, change" using the webUI
+    When the user shares folder "simple-folder (2)" with user "User Three" as "Advanced permissions" with permissions "share, delete, update" using the webUI
     Then the error message "Error while sharing." should be displayed on the webUI
     And as "user3" folder "simple-folder (2)" should not exist
 

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -49,10 +49,10 @@ Feature: Sharing files and folders with internal groups
     Then folder "simple-folder (2)" should be marked as shared by "User Three" on the webUI
     And file "testimage (2).jpg" should be marked as shared by "User Three" on the webUI
     Examples:
-      | set-role    | expected-role | permissions-folder         | permissions-file |
-      | Viewer      | Viewer        | read                       | read             |
-      | Editor      | Editor        | read,change,create, delete | read,change      |
-      | Custom Role | Viewer        | read                       | read             |
+      | set-role             | expected-role | permissions-folder         | permissions-file |
+      | Viewer               | Viewer        | read                       | read             |
+      | Editor               | Editor        | read,update,create, delete | read,update      |
+      | Advanced permissions | Viewer        | read                       | read             |
 
   Scenario: share a file with an internal group a member overwrites and unshares the file
     Given user "user3" has logged in using the webUI

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -45,10 +45,10 @@ Feature: Sharing files and folders with internal users
     #    And folder "simple-folder (2)" should be marked as shared by "User Two" on the webUI
     #    And file "testimage (2).jpg" should be marked as shared by "User Two" on the webUI
     Examples:
-      | set-role    | expected-role | permissions-folder        | permissions-file |
-      | Viewer      | Viewer        | read                      | read             |
-      | Editor      | Editor        | read,change,create,delete | read,change      |
-      | Custom Role | Viewer        | read                      | read             |
+      | set-role             | expected-role | permissions-folder        | permissions-file |
+      | Viewer               | Viewer        | read                      | read             |
+      | Editor               | Editor        | read,update,create,delete | read,update      |
+      | Advanced permissions | Viewer        | read                      | read             |
 
   Scenario Outline: change the collaborators of a file & folder
     Given user "user2" has logged in using the webUI
@@ -66,11 +66,11 @@ Feature: Sharing files and folders with internal users
       | item_type   | folder                 |
       | permissions | <expected-permissions> |
     Examples:
-      | initial-permissions | set-role    | expected-role | expected-permissions      |
-      | read,change,create  | Viewer      | Viewer        | read                      |
-      | read                | Editor      | Editor        | read,change,create,delete |
-      | read                | Custom role | Viewer        | read                      |
-      | all                 | Custom role | Editor        | all                       |
+      | initial-permissions | set-role             | expected-role | expected-permissions      |
+      | read,update,create  | Viewer               | Viewer        | read                      |
+      | read                | Editor               | Editor        | read,update,create,delete |
+      | read                | Advanced permissions | Viewer        | read                      |
+      | all                 | Advanced permissions | Editor        | all                       |
 
   Scenario: share a file with another internal user who overwrites and unshares the file
     Given user "user2" has logged in using the webUI

--- a/tests/acceptance/features/webUISharingPermissionMultipleUsers/shareWithMultipleUsers.feature
+++ b/tests/acceptance/features/webUISharingPermissionMultipleUsers/shareWithMultipleUsers.feature
@@ -50,32 +50,30 @@ Feature: Sharing files and folders with multiple internal users with different p
     And user "User Four" should not be listed in the collaborators list on the webUI
     And as "user4" folder "simple-folder (2)" should not exist
     Examples:
-      | role        | displayed-role | extra-permissions             | displayed-permissions | actual-permissions           |
-      | Viewer      | Viewer         | share                         | share                 | read, share                  |
-      | Viewer      | Viewer         | ,                             | ,                     | read                         |
-      | Editor      | Editor         | share                         | share                 | all                          |
-      | Editor      | Editor         | ,                             | ,                     | read, change, delete, create |
-      | Custom Role | Viewer         | ,                             | ,                     | read                         |
-      | Custom Role | Viewer         | share                         | share                 | read, share                  |
-      | Custom Role | Custom role    | delete                        | delete                | read, delete                 |
-      # issue-1897: Displayed role below should have been 'Custom role'
-      | Custom Role | Editor         | change                        | ,                     | read, change                 |
-      | Custom Role | Custom role    | create                        | create                | read, create                 |
-      | Custom Role | Custom role    | share, delete                 | share, delete         | read, share, delete          |
-      # issue-1897: Displayed role below should have been 'Custom role'
-      | Custom Role | Editor         | share, change                 | share                 | read, change, share          |
-      | Custom Role | Custom role    | share, create                 | share, create         | read, share, create          |
-      | Custom Role | Custom role    | delete, change                | delete, change        | read, delete, change         |
-      | Custom Role | Custom role    | delete, create                | delete, create        | read, delete, create         |
-      | Custom Role | Custom role    | change, create                | change, create        | read, change, create         |
-      # issue-1837: Displayed Permissions below should have been 'share, delete, change'
-      | Custom Role | Custom role    | share, delete, change         | ,                     | read, share, delete, change  |
+      | role                 | displayed-role          | extra-permissions             | displayed-permissions | actual-permissions           |
+      | Viewer               | Viewer                  | share                         | share                 | read, share                  |
+      | Viewer               | Viewer                  | ,                             | ,                     | read                         |
+      | Editor               | Editor                  | share                         | share                 | all                          |
+      | Editor               | Editor                  | ,                             | ,                     | read, update, delete, create |
+      | Advanced permissions | Viewer                  | ,                             | ,                     | read                         |
+      | Advanced permissions | Viewer                  | share                         | share                 | read, share                  |
+      | Advanced permissions | Advanced role           | delete                        | delete                | read, delete                 |
+      | Advanced permissions | Advanced permissions    | update                        | ,                     | read, update                 |
+      | Advanced permissions | Advanced permissions    | create                        | create                | read, create                 |
+      | Advanced permissions | Advanced permissions    | share, delete                 | share, delete         | read, share, delete          |
+      | Advanced permissions | Advanced permissions    | share, update                 | share                 | read, update, share          |
+      | Advanced permissions | Advanced permissions    | share, create                 | share, create         | read, share, create          |
+      | Advanced permissions | Advanced permissions    | delete, update                | delete, update        | read, delete, update         |
+      | Advanced permissions | Advanced permissions    | delete, create                | delete, create        | read, delete, create         |
+      | Advanced permissions | Advanced permissions    | update, create                | update, create        | read, update, create         |
+      # issue-1837: Displayed Permissions below should have been 'share, delete, update'
+      | Advanced permissions | Advanced permissions    | share, delete, update         | ,                     | read, share, delete, update  |
       # issue-1837: Displayed Permissions below should have been 'share, create, delete'.
-      | Custom Role | Custom role    | share, create, delete         | ,                     | read, share, delete, create  |
-      # issue-1837: Displayed Permissions below should have been 'share, change, create'.
-      | Custom Role | Custom role    | share, change, create         | ,                     | read, share, change, create  |
-      | Custom Role | Editor         | delete, change, create        | ,                     | read, delete, change, create |
-      | Custom Role | Editor         | share, delete, change, create | share                 | all                          |
+      | Advanced permissions | Advanced permissions    | share, create, delete         | ,                     | read, share, delete, create  |
+      # issue-1837: Displayed Permissions below should have been 'share, update, create'.
+      | Advanced permissions | Advanced permissions    | share, update, create         | ,                     | read, share, update, create  |
+      | Advanced permissions | Editor                  | delete, update, create        | ,                     | read, delete, update, create |
+      | Advanced permissions | Editor                  | share, delete, update, create | share                 | all                          |
 
   Scenario Outline: share a file with multiple users with different roles and permissions
     Given these users have been created with default attributes:
@@ -117,12 +115,12 @@ Feature: Sharing files and folders with multiple internal users with different p
     And user "User Four" should not be listed in the collaborators list on the webUI
     And as "user4" file "lorem(2).txt" should not exist
     Examples:
-      | role        | displayed-role | extra-permissions | displayed-permissions | actual-permissions  |
-      | Viewer      | Viewer         | share             | share                 | read, share         |
-      | Viewer      | Viewer         | ,                 | ,                     | read                |
-      | Editor      | Editor         | share             | share                 | share, read, change |
-      | Editor      | Editor         | ,                 | ,                     | read, change        |
-      | Custom Role | Viewer         | ,                 | ,                     | read                |
-      | Custom Role | Viewer         | share             | share                 | read, share         |
-      | Custom Role | Editor         | change            | ,                     | read, change        |
-      | Custom Role | Editor         | share, change     | share                 | read, change, share |
+      | role                 | displayed-role | extra-permissions | displayed-permissions | actual-permissions  |
+      | Viewer               | Viewer         | share             | share                 | read, share         |
+      | Viewer               | Viewer         | ,                 | ,                     | read                |
+      | Editor               | Editor         | share             | share                 | share, read, update |
+      | Editor               | Editor         | ,                 | ,                     | read, update        |
+      | Advanced permissions | Viewer         | ,                 | ,                     | read                |
+      | Advanced permissions | Viewer         | share             | share                 | read, share         |
+      | Advanced permissions | Editor         | update            | ,                     | read, update        |
+      | Advanced permissions | Editor         | share, update     | share                 | read, update, share |

--- a/tests/acceptance/features/webUISharingPermissionsGroups/sharePermissionsGroup.feature
+++ b/tests/acceptance/features/webUISharingPermissionsGroups/sharePermissionsGroup.feature
@@ -50,17 +50,17 @@ Feature: Sharing files and folders with internal groups with permissions
     And group "grp1" should not be listed in the collaborators list on the webUI
     And as "user1" file "lorem (2).txt" should not exist
     Examples:
-    | role        | displayed-role | extra-permissions | displayed-permissions | actual-permissions  |
-    | Viewer      | Viewer         | share             | share                 | read, share         |
-    | Viewer      | Viewer         | ,                 | ,                     | read                |
-    | Editor      | Editor         | share             | share                 | share, read, change |
-    | Editor      | Editor         | ,                 | ,                     | read, change        |
-    | Custom Role | Viewer         | ,                 | ,                     | read                |
-    | Custom Role | Viewer         | share             | share                 | read, share         |
-    | Custom Role | Editor         | change            | ,                     | read, change        |
-    | Custom Role | Editor         | share, change     | share                 | read, change, share |
+    | role                 | displayed-role | extra-permissions | displayed-permissions | actual-permissions  |
+    | Viewer               | Viewer         | share             | share                 | read, share         |
+    | Viewer               | Viewer         | ,                 | ,                     | read                |
+    | Editor               | Editor         | share             | share                 | share, read, update |
+    | Editor               | Editor         | ,                 | ,                     | read, update        |
+    | Advanced permissions | Viewer         | ,                 | ,                     | read                |
+    | Advanced permissions | Viewer         | share             | share                 | read, share         |
+    | Advanced permissions | Editor         | update            | ,                     | read, update        |
+    | Advanced permissions | Editor         | share, update     | share                 | read, update, share |
 
-  @issue-1837 @issue-1897
+  @issue-1837
   Scenario Outline: share a folder with multiple users with different roles and permissions
     Given group "grp2" has been created
     And user "user2" has been added to group "grp2"
@@ -96,29 +96,24 @@ Feature: Sharing files and folders with internal groups with permissions
     And group "grp1" should not be listed in the collaborators list on the webUI
     And as "user1" folder "simple-folder (2)" should not exist
     Examples:
-    | role        | displayed-role | extra-permissions             | displayed-permissions | actual-permissions           |
-    | Viewer      | Viewer         | share                         | share                 | read, share                  |
-    | Viewer      | Viewer         | ,                             | ,                     | read                         |
-    | Editor      | Editor         | share                         | share                 | all                          |
-    | Editor      | Editor         | ,                             | ,                     | read, change, delete, create |
-    | Custom Role | Viewer         | ,                             | ,                     | read                         |
-    | Custom Role | Viewer         | share                         | share                 | read, share                  |
-    | Custom Role | Custom role    | delete                        | delete                | read, delete                 |
-          # issue-1897: Displayed role below should have been 'Custom role'
-    | Custom Role | Editor         | change                        | ,                     | read, change                 |
-    | Custom Role | Custom role    | create                        | create                | read, create                 |
-    | Custom Role | Custom role    | share, delete                 | share, delete         | read, share, delete          |
-          # issue-1897: Displayed role below should have been 'Custom role'
-    | Custom Role | Editor         | share, change                 | share                 | read, change, share          |
-    | Custom Role | Custom role    | share, create                 | share, create         | read, share, create          |
-    | Custom Role | Custom role    | delete, change                | delete, change        | read, delete, change         |
-    | Custom Role | Custom role    | delete, create                | delete, create        | read, delete, create         |
-    | Custom Role | Custom role    | change, create                | change, create        | read, change, create         |
-          # issue-1837: Displayed Permissions below should have been 'share, delete, change'
-    | Custom Role | Custom role    | share, delete, change         | ,                     | read, share, delete, change  |
-          # issue-1837: Displayed Permissions below should have been 'share, create, delete'.
-    | Custom Role | Custom role    | share, create, delete         | ,                     | read, share, delete, create  |
-          # issue-1837: Displayed Permissions below should have been 'share, change, create'.
-    | Custom Role | Custom role    | share, change, create         | ,                     | read, share, change, create  |
-    | Custom Role | Editor         | delete, change, create        | ,                     | read, delete, change, create |
-    | Custom Role | Editor         | share, delete, change, create | share                 | all                          |
+    | role                 | displayed-role          | extra-permissions             | displayed-permissions | actual-permissions           |
+    | Viewer               | Viewer                  | share                         | share                 | read, share                  |
+    | Viewer               | Viewer                  | ,                             | ,                     | read                         |
+    | Editor               | Editor                  | share                         | share                 | all                          |
+    | Editor               | Editor                  | ,                             | ,                     | read, update, delete, create |
+    | Advanced permissions | Viewer                  | ,                             | ,                     | read                         |
+    | Advanced permissions | Viewer                  | share                         | share                 | read, share                  |
+    | Advanced permissions | Advanced permissions    | delete                        | delete                | read, delete                 |
+    | Advanced permissions | Advanced permissions    | update                        | update                | read, update                 |
+    | Advanced permissions | Advanced permissions    | create                        | create                | read, create                 |
+    | Advanced permissions | Advanced permissions    | share, delete                 | share, delete         | read, share, delete          |
+    | Advanced permissions | Advanced permissions    | share, update                 | share, update         | read, update, share          |
+    | Advanced permissions | Advanced permissions    | share, create                 | share, create         | read, share, create          |
+    | Advanced permissions | Advanced permissions    | delete, update                | delete, update        | read, delete, update         |
+    | Advanced permissions | Advanced permissions    | delete, create                | delete, create        | read, delete, create         |
+    | Advanced permissions | Advanced permissions    | update, create                | update, create        | read, update, create         |
+    | Advanced permissions | Advanced permissions    | share, delete, update         | share, delete, update | read, share, delete, update  |
+    | Advanced permissions | Advanced permissions    | share, create, delete         | share, create, delete | read, share, delete, create  |
+    | Advanced permissions | Advanced permissions    | share, update, create         | share, update, create | read, share, update, create  |
+    | Advanced permissions | Editor                  | delete, update, create        | ,                     | read, delete, update, create |
+    | Advanced permissions | Editor                  | share, delete, update, create | share                 | all                          |

--- a/tests/acceptance/features/webUISharingPermissionsUsers/sharePermissionsUsers.feature
+++ b/tests/acceptance/features/webUISharingPermissionsUsers/sharePermissionsUsers.feature
@@ -23,15 +23,13 @@ Feature: Sharing files and folders with internal users with different permission
       | item_type   | folder             |
       | permissions | read, share        |
 
-  @issue-1853 @issue-1837
+  @issue-1853
   Scenario: Change permissions of the previously shared folder
     Given user "user2" has shared folder "simple-folder" with user "user1" with "read, share, create, delete" permissions
     And user "user2" has logged in using the webUI
-    Then no custom permissions should be set for collaborator "User One" for folder "simple-folder" on the webUI
-    #    Then custom permissions "share, create, delete" should be set for user "User One" for folder "simple-folder" on the webUI
+    Then custom permissions "share, create, delete" should be set for user "User One" for folder "simple-folder" on the webUI
     When the user sets custom permission for current role of collaborator "User One" for folder "simple-folder" to "create, delete, share" using the webUI
-    Then no custom permissions should be set for collaborator "User One" for folder "simple-folder" on the webUI
-    #    Then custom permission "share, create, delete" should be set for user "User One" for folder "simple-folder" on the webUI
+    Then custom permission "share, create, delete" should be set for user "User One" for folder "simple-folder" on the webUI
     And user "user1" should have received a share with these details:
       | field       | value                       |
       | uid_owner   | user2                       |
@@ -40,21 +38,20 @@ Feature: Sharing files and folders with internal users with different permission
       | item_type   | folder                      |
       | permissions | read, share, create, delete |
 
-  @issue-1853 @issue-1837
+  @issue-1853
   Scenario: Change permissions of the previously shared folder
     Given user "user2" has shared folder "simple-folder" with user "user1" with "read, share, create" permissions
     And user "user2" has logged in using the webUI
     Then custom permissions "share, create" should be set for user "User One" for folder "simple-folder" on the webUI
-    When the user sets custom permission for current role of collaborator "User One" for folder "simple-folder" to "delete, change" using the webUI
-    Then no custom permissions should be set for collaborator "User One" for folder "simple-folder" on the webUI
-    #    Then custom permission "delete, change" should be set for user "User One" for folder "simple-folder" on the webUI
+    When the user sets custom permission for current role of collaborator "User One" for folder "simple-folder" to "delete, update" using the webUI
+    Then custom permission "delete, update" should be set for user "User One" for folder "simple-folder" on the webUI
     And user "user1" should have received a share with these details:
       | field       | value                |
       | uid_owner   | user2                |
       | share_with  | user1                |
       | file_target | /simple-folder (2)   |
       | item_type   | folder               |
-      | permissions | read, change, delete |
+      | permissions | read, update, delete |
 
   Scenario: Change permissions of the previously shared folder
     Given user "user2" has shared folder "simple-folder" with user "user1" with "read, delete" permissions
@@ -83,12 +80,12 @@ Feature: Sharing files and folders with internal users with different permission
       | item_type   | folder             |
       | permissions | <permissions>      |
     Examples:
-      | role        | displayed-role | extra-permissions             | displayed-permissions | permissions                         |
-      | Viewer      | Viewer         | share                         | share                 | read, share                         |
-      | Editor      | Editor         | share                         | share                 | all                                 |
-      | Custom Role | Custom role    | share, create                 | share, create         | read, share, create                 |
-      | Custom Role | Editor         | change, share                 | share                 | read, change, share                 |
-      | Custom Role | Editor         | delete, share, create, change | share                 | read, share, delete, change, create |
+      | role                 | displayed-role          | extra-permissions             | displayed-permissions | permissions                         |
+      | Viewer               | Viewer                  | share                         | share                 | read, share                         |
+      | Editor               | Editor                  | share                         | share                 | all                                 |
+      | Advanced permissions | Advanced permissions    | share, create                 | share, create         | read, share, create                 |
+      | Advanced permissions | Advanced permissions    | update, share                 | share, update         | read, update, share                 |
+      | Advanced permissions | Editor                  | delete, share, create, update | share                 | read, share, delete, update, create |
 
   Scenario Outline: Change permissions of the previously shared file
     Given user "user2" has shared file "lorem.txt" with user "user1" with "<initial-permissions>" permissions
@@ -105,7 +102,7 @@ Feature: Sharing files and folders with internal users with different permission
       | permissions | <permissions>  |
     Examples:
       | initial-permissions | permissions         |
-      | read, change        | read, share, change |
+      | read, update        | read, share, update |
       | read                | read, share         |
 
   Scenario: Delete all custom permissions of the previously shared file
@@ -135,10 +132,10 @@ Feature: Sharing files and folders with internal users with different permission
       | item_type   | file           |
       | permissions | <permissions>  |
     Examples:
-      | role        | displayed-role | collaborators-permissions | displayed-permissions | permissions         |
-      | Viewer      | Viewer         | share                     | share                 | read, share         |
-      | Editor      | Editor         | share                     | share                 | read, share, change |
-      | Custom Role | Editor         | share, change             | share                 | read, share, change |
+      | role                 | displayed-role | collaborators-permissions | displayed-permissions | permissions         |
+      | Viewer               | Viewer         | share                     | share                 | read, share         |
+      | Editor               | Editor         | share                     | share                 | read, share, update |
+      | Advanced permissions | Editor         | share, update             | share                 | read, share, update |
 
   Scenario: Share a folder without share permissions using API and check if it is listed on the collaborators list for original owner
     Given user "user2" has shared folder "simple-folder" with user "user1" with "read" permissions
@@ -152,32 +149,32 @@ Feature: Sharing files and folders with internal users with different permission
     And user "user2" has shared folder "simple-folder" with user "user1" with "read, share, delete" permissions
     And user "user1" has shared folder "simple-folder (2)" with user "user3" with "read, delete" permissions
     And user "user2" has logged in using the webUI
-    When the user sets custom permission for current role of collaborator "User Three" for folder "simple-folder" to "delete, change" using the webUI
-    Then custom permissions "delete, change" should be set for user "User Three" for folder "simple-folder" on the webUI
+    When the user sets custom permission for current role of collaborator "User Three" for folder "simple-folder" to "delete, update" using the webUI
+    Then custom permissions "delete, update" should be set for user "User Three" for folder "simple-folder" on the webUI
     And user "user3" should have received a share with these details:
       | field       | value                |
       | uid_owner   | user1                |
       | share_with  | user3                |
       | file_target | /simple-folder (2)   |
       | item_type   | folder               |
-      | permissions | delete, read, change |
+      | permissions | delete, read, update |
 
   Scenario: User is not allowed to reshare sub-folder with more permissions
     Given user "user3" has been created with default attributes
     And user "user2" has shared folder "simple-folder" with user "user1" with "read, share, delete" permissions
     And user "user1" has logged in using the webUI
     When the user browses to the folder "simple-folder (2)" on the files page
-    And the user shares folder "simple-empty-folder" with user "User Three" as "Custom role" with permissions "share, delete, change" using the webUI
+    And the user shares folder "simple-empty-folder" with user "User Three" as "Advanced permissions" with permissions "share, delete, update" using the webUI
     Then the error message "Error while sharing." should be displayed on the webUI
     And as "user3" folder "simple-empty-folder (2)" should not exist
 
   Scenario: User is not allowed to update permissions of a reshared sub-folder to higher permissions than what user has received
     Given user "user3" has been created with default attributes
-    And user "user2" has shared folder "simple-folder" with user "user1" with "read, share, delete, change" permissions
+    And user "user2" has shared folder "simple-folder" with user "user1" with "read, share, delete, update" permissions
     And user "user1" has shared folder "simple-folder (2)" with user "user3" with "share, delete" permissions
     And user "user1" has logged in using the webUI
     When the user browses to the folder "simple-folder (2)" on the files page
-    And the user shares folder "simple-empty-folder" with user "User Three" as "Custom role" with permissions "share, delete, change, create" using the webUI
+    And the user shares folder "simple-empty-folder" with user "User Three" as "Advanced permissions" with permissions "share, delete, update, create" using the webUI
     Then the error message "Error while sharing." should be displayed on the webUI
     And as "user3" folder "simple-empty-folder (2)" should not exist
 
@@ -187,7 +184,7 @@ Feature: Sharing files and folders with internal users with different permission
     And user "user1" has shared folder "simple-folder (2)" with user "user3" with "share, delete" permissions
     And user "user1" has logged in using the webUI
     When the user browses to the folder "simple-folder (2)" on the files page
-    And the user shares folder "simple-empty-folder" with user "User Three" as "Custom role" with permissions "share, delete, create, change" using the webUI
+    And the user shares folder "simple-empty-folder" with user "User Three" as "Advanced permissions" with permissions "share, delete, create, update" using the webUI
     Then user "user3" should have received a share with these details:
       | field       | value                    |
       | uid_owner   | user1                    |

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -48,7 +48,7 @@ Feature: Share by public link
     Examples:
       | role        | permissions                  |
       | Viewer      | read                         |
-      | Editor      | read, change, create, delete |
+      | Editor      | read, update, create, delete |
       | Contributor | read, create                 |
 
   Scenario: sharing by public link with "Uploader" role
@@ -74,7 +74,7 @@ Feature: Share by public link
     But file "data.zip" should not be listed on the webUI
 
   Scenario: creating a public link with "Editor" role makes it possible to delete files via the link
-    Given user "user1" has shared folder "simple-folder" with link with "read, change, create, delete" permissions
+    Given user "user1" has shared folder "simple-folder" with link with "read, update, create, delete" permissions
     When the public uses the webUI to access the last public link created by user "user1"
     And the user deletes the following elements using the webUI
       | name                                  |
@@ -86,7 +86,7 @@ Feature: Share by public link
     And the deleted elements should not be listed on the webUI after a page reload
 
   Scenario: creating a public link with "Editor" role makes it possible to delete files via the link even with password set
-    Given user "user1" has shared folder "simple-folder" with link with "read, change, create, delete" permissions and password "pass123"
+    Given user "user1" has shared folder "simple-folder" with link with "read, update, create, delete" permissions and password "pass123"
     When the public uses the webUI to access the last public link created by user "user1" with password "pass123"
     And the user deletes the following elements using the webUI
       | name                                  |
@@ -102,14 +102,14 @@ Feature: Share by public link
     Then it should not be possible to delete file "lorem.txt" using the webUI
 
   Scenario: creating a public link with "Editor" role makes it possible to upload a file
-    Given user "user1" has shared folder "simple-folder" with link with "read, change, create, delete" permissions
+    Given user "user1" has shared folder "simple-folder" with link with "read, update, create, delete" permissions
     When the public uses the webUI to access the last public link created by user "user1"
     And the user uploads file "new-lorem.txt" using the webUI
     Then file "new-lorem.txt" should be listed on the webUI
     And as "user1" file "simple-folder/new-lorem.txt" should exist
 
   Scenario: creating a public link with "Editor" role makes it possible to upload a file inside a subdirectory with password set
-    Given user "user1" has shared folder "simple-folder" with link with "read, change, create, delete" permissions and password "pass123"
+    Given user "user1" has shared folder "simple-folder" with link with "read, update, create, delete" permissions and password "pass123"
     When the public uses the webUI to access the last public link created by user "user1" with password "pass123"
     And the user opens folder "simple-empty-folder" using the webUI
     And the user uploads file "new-lorem.txt" using the webUI
@@ -117,7 +117,7 @@ Feature: Share by public link
     And as "user1" file "simple-folder/simple-empty-folder/new-lorem.txt" should exist
 
   Scenario: creating a public link with "Editor" role makes it possible to upload a folder
-    Given user "user1" has shared folder "simple-folder" with link with "read, change, create, delete" permissions
+    Given user "user1" has shared folder "simple-folder" with link with "read, update, create, delete" permissions
     When the public uses the webUI to access the last public link created by user "user1"
     And the user uploads folder "PARENT" using the webUI
     Then folder "PARENT" should be listed on the webUI
@@ -126,7 +126,7 @@ Feature: Share by public link
     And as "user1" file "simple-folder/PARENT/CHILD/child.txt" should exist
 
   Scenario: creating a public link with "Editor" role makes it possible to upload a folder inside a subdirectory
-    Given user "user1" has shared folder "simple-folder" with link with "read, change, create, delete" permissions
+    Given user "user1" has shared folder "simple-folder" with link with "read, update, create, delete" permissions
     When the public uses the webUI to access the last public link created by user "user1"
     And the user opens folder "simple-empty-folder" using the webUI
     And the user uploads folder "PARENT" using the webUI
@@ -136,14 +136,14 @@ Feature: Share by public link
     And as "user1" file "simple-folder/simple-empty-folder/PARENT/CHILD/child.txt" should exist
 
   Scenario: creating a public link with "Editor" role makes it possible to upload files via the link even with password set
-    Given user "user1" has shared folder "simple-folder" with link with "read, change, create, delete" permissions and password "pass123"
+    Given user "user1" has shared folder "simple-folder" with link with "read, update, create, delete" permissions and password "pass123"
     When the public uses the webUI to access the last public link created by user "user1" with password "pass123"
     And the user uploads file "new-lorem.txt" using the webUI
     Then file "new-lorem.txt" should be listed on the webUI
     And as "user1" file "simple-folder/new-lorem.txt" should exist
 
   Scenario: creating a public link with "Editor" role makes it possible to upload files inside a subdirectory
-    Given user "user1" has shared folder "simple-folder" with link with "read, change, create, delete" permissions
+    Given user "user1" has shared folder "simple-folder" with link with "read, update, create, delete" permissions
     When the public uses the webUI to access the last public link created by user "user1"
     And the user uploads folder "PARENT" using the webUI
     Then folder "PARENT" should be listed on the webUI
@@ -152,7 +152,7 @@ Feature: Share by public link
     And as "user1" file "simple-folder/PARENT/CHILD/child.txt" should exist
 
   Scenario: creating a public link with "Editor" role makes it possible to upload a folder even with password set
-    Given user "user1" has shared folder "simple-folder" with link with "read, change, create, delete" permissions and password "pass123"
+    Given user "user1" has shared folder "simple-folder" with link with "read, update, create, delete" permissions and password "pass123"
     When the public uses the webUI to access the last public link created by user "user1" with password "pass123"
     And the user uploads folder "PARENT" using the webUI
     Then folder "PARENT" should be listed on the webUI
@@ -161,7 +161,7 @@ Feature: Share by public link
     And as "user1" file "simple-folder/PARENT/CHILD/child.txt" should exist
 
   Scenario: creating a public link with "Editor" role makes it possible to upload a folder inside a sub-directory even with password set
-    Given user "user1" has shared folder "simple-folder" with link with "read, change, create, delete" permissions and password "pass123"
+    Given user "user1" has shared folder "simple-folder" with link with "read, update, create, delete" permissions and password "pass123"
     When the public uses the webUI to access the last public link created by user "user1" with password "pass123"
     And the user opens folder "simple-empty-folder" using the webUI
     And the user uploads folder "PARENT" using the webUI
@@ -285,7 +285,7 @@ Feature: Share by public link
     And the content of "lorem.txt" on the remote server should be the same as the local "lorem.txt"
 
   Scenario: public should be able to access a public link with correct password
-    Given user "user1" has shared folder "simple-folder" with link with "read, change, create, delete" permissions and password "pass123"
+    Given user "user1" has shared folder "simple-folder" with link with "read, update, create, delete" permissions and password "pass123"
     When the public uses the webUI to access the last public link created by user "user1" with password "pass123"
     Then file "lorem.txt" should be listed on the webUI
 

--- a/tests/acceptance/helpers/sharingHelper.js
+++ b/tests/acceptance/helpers/sharingHelper.js
@@ -12,7 +12,7 @@ module.exports = {
   }),
   PERMISSION_TYPES: Object.freeze({
     read: 1,
-    change: 2,
+    update: 2,
     create: 4,
     delete: 8,
     share: 16,

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -658,6 +658,9 @@ module.exports = {
     versionsElement: {
       selector: '//div//a[normalize-space(.)="Versions"]',
       locateStrategy: 'xpath'
+    },
+    collaboratorsList: {
+      selector: '.files-collaborators-lists'
     }
   }
 }

--- a/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
@@ -3,7 +3,7 @@ const userSharePostfix = '\nUser'
 const util = require('util')
 const _ = require('lodash')
 
-const collaboratorPermissionArray = ['share', 'change', 'create', 'delete']
+const collaboratorPermissionArray = ['share', 'update', 'create', 'delete']
 
 module.exports = {
   commands: {
@@ -19,8 +19,8 @@ module.exports = {
      *
      * @param {string} permission
      */
-    getPermissionSwitchXpath: function (permission) {
-      return util.format(this.elements.permissionButton.selector, permission)
+    getPermissionCheckbox: function (permission) {
+      return util.format(this.elements.permissionCheckbox.selector, permission)
     },
 
     assertSharingNotAllowed: function () {
@@ -125,10 +125,10 @@ module.exports = {
     selectPermissionsOnPendingShare: async function (permissions) {
       const permissionArray = this.getArrayFromPermissionString(permissions)
       for (const permission of permissionArray) {
-        const permissionSwitchXpath = this.getPermissionSwitchXpath(permission)
-        const elementID = await this.getVisibleElementID('xpath', permissionSwitchXpath)
+        const permissionCheckbox = this.getPermissionCheckbox(permission)
+        const elementID = await this.getVisibleElementID('xpath', permissionCheckbox)
         if (elementID === null) {
-          throw new Error('Button is not visible for permission:', permission)
+          throw new Error(`Checkbox is not visible for permission ${permission}`)
         }
         await this.api.elementIdClick(elementID)
       }
@@ -197,8 +197,8 @@ module.exports = {
      * @param {string} permission
      */
     toggleSinglePermission: async function (permission) {
-      const permissionXpath = this.getPermissionSwitchXpath(permission)
-      const elementID = await this.getVisibleElementID('xpath', permissionXpath)
+      const permissionCheckbox = this.getPermissionCheckbox(permission)
+      const elementID = await this.getVisibleElementID('xpath', permissionCheckbox)
       if (!elementID) {
         throw new Error(`permission ${permission} is not visible `)
       }
@@ -217,23 +217,23 @@ module.exports = {
     getSharePermissions: async function (collaborator) {
       const permissions = {}
       let collaboratorElementXpath
-      let permissionToggle
+      let permissionCheckbox
       for (let i = 0; i < collaboratorPermissionArray.length; i++) {
         collaboratorElementXpath = util.format(
           this.elements.collaboratorInformationByCollaboratorName.selector,
           collaborator
         )
-        permissionToggle = collaboratorElementXpath + util.format(
-          this.elements.permissionButton.selector,
+        permissionCheckbox = collaboratorElementXpath + util.format(
+          this.elements.permissionCheckbox.selector,
           collaboratorPermissionArray[i]
         )
 
-        await this.api.element('xpath', permissionToggle, result => {
+        await this.api.element('xpath', permissionCheckbox, result => {
           if (!result.value.ELEMENT) {
             return
           }
-          return this.api.elementIdAttribute(result.value.ELEMENT, 'data-state', result => {
-            permissions[collaboratorPermissionArray[i]] = result.value === 'on'
+          return this.api.elementIdSelected(result.value.ELEMENT, result => {
+            permissions[collaboratorPermissionArray[i]] = result.value
           })
         })
       }
@@ -267,16 +267,31 @@ module.exports = {
     /**
      * asserts that the permission is set to "off" or not displayed at all
      *
-     * @param {string} permissionXpath
+     * @param {string} permissionCheckbox
      */
-    assertPermissionDataStateIsOff: function (permissionXpath) {
-      return this.api.isVisible(permissionXpath, result => {
+    assertPermissionDataStateIsOff: async function (permissionCheckbox) {
+      // TODO: Improve performance. Permissions which are not displayed are slowing this function down
+      return this.isVisible(permissionCheckbox, result => {
         if (result.value === true) {
+          // TODO: Find if this causes some side effects or if there's a better solution
+          // eslint-disable-next-line no-unused-expressions
           this
-            .assert
-            .attributeEquals(permissionXpath, 'data-state', 'off', `data-state of xpath ${permissionXpath} is set `)
+            .expect
+            .element(permissionCheckbox)
+            .to.not.be.selected
         }
       })
+    },
+    /**
+     * asserts that the permission is set to "on" or not displayed at all
+     *
+     * @param {string} permissionCheckbox
+     */
+    assertPermissionDataStateIsOn: function (permissionCheckbox) {
+      return this
+        .expect
+        .element(permissionCheckbox)
+        .to.be.selected
     },
     /**
      *
@@ -291,22 +306,30 @@ module.exports = {
       this.expandInformationSelector(collaborator)
 
       for (let i = 0; i < collaboratorPermissionArray.length; i++) {
-        const permissionXpath = this.getPermissionSwitchXpath(collaboratorPermissionArray[i])
+        const collaboratorElement = util.format(
+          this.elements.collaboratorInformationByCollaboratorName.selector,
+          collaborator
+        )
+        const permissionCheckbox = collaboratorElement + util.format(
+          this.elements.permissionCheckbox.selector,
+          collaboratorPermissionArray[i]
+        )
+
         if (permissions !== undefined) {
           // check all the required permissions are set
           if (requiredPermissionArray.includes(collaboratorPermissionArray[i])) {
-            await this
-              .assert
-              .attributeEquals(permissionXpath, 'data-state', 'on', `data-state of xpath ${permissionXpath} is not set`)
+            await this.assertPermissionDataStateIsOn(permissionCheckbox)
           } else {
             // check unexpected permissions are not set
-            return this.assertPermissionDataStateIsOff(permissionXpath)
+            await this.assertPermissionDataStateIsOff(permissionCheckbox)
           }
         } else {
           // check all the permissions are not set
-          return this.assertPermissionDataStateIsOff(permissionXpath)
+          await this.assertPermissionDataStateIsOff(permissionCheckbox)
         }
       }
+
+      return this
     },
     /**
      *
@@ -517,8 +540,8 @@ module.exports = {
     newCollaboratorRemoveButton: {
       selector: "//span[contains(@class, 'oc-icon-danger')]"
     },
-    newCollaboratorRoleCustomRole: {
-      selector: '#files-collaborator-new-collaborator-role-custom'
+    newCollaboratorRoleAdvancedPermissions: {
+      selector: '#files-collaborator-new-collaborator-role-advancedRole'
     },
     selectRoleButtonInCollaboratorInformation: {
       selector: '//button[contains(@class, "files-collaborators-role-button")]',
@@ -533,12 +556,13 @@ module.exports = {
       selector: '//ul[contains(@class,"oc-autocomplete-suggestion-list")]//span[translate(.,"ABCDEFGHJIKLMNOPQRSTUVWXYZ","abcdefghjiklmnopqrstuvwxyz") ="%s"]',
       locateStrategy: 'xpath'
     },
-    permissionButton: {
-      selector: '//span[.="Can %s"]/parent::div/div',
+    permissionCheckbox: {
+      selector: '//input[@id="files-collaborators-permission-%s"]',
       locateStrategy: 'xpath'
     },
-    permissionButtons: {
-      selector: '//span[contains(., "Can")]/parent::div/div[contains(@class, "oc-switch")]'
+    permissionCheckboxes: {
+      selector: '//input[contains(@class, "files-collaborators-permission-checkbox")]',
+      locateStrategy: 'xpath'
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3789,6 +3789,11 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+filter-obj@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-2.0.1.tgz#34d9f0536786f072df7aeac3a8bda1c6e767aec6"
+  integrity sha512-yDEp513p7+iLdFHWBVdZFnRiOYwg8ZqmpaAiZCMjzqsbo7tCS4Qm4ulXOht337NGzkukKa9u3W4wqQ9tQPm3Ug==
+
 finalhandler@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.2.tgz#b7e7d000ffd11938d0fdb053506f6ebabe9f587d"


### PR DESCRIPTION
## Description
Introduced helper functions roleToBitmask and bitmaskToRole, separated collaborators into smaller components and small refactoring.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Refs #1897
- Fixes #1837 

## Motivation and Context
Cleaner code

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually
1. Share with user
2. Share with group
3. Edit existing share

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 