### PR TITLE
Test public link uploads with/without password

### DIFF
--- a/apps/files/src/mixins.js
+++ b/apps/files/src/mixins.js
@@ -226,7 +226,7 @@ export default {
           let p
 
           if (this.publicPage()) {
-            p = this.queue.add(() => this.$client.publicFiles.createFolder(this.rootPath + directory))
+            p = this.queue.add(() => this.$client.publicFiles.createFolder(this.rootPath, directory, this.publicLinkPassword))
           } else {
             p = this.queue.add(() => this.$client.files.createFolder(this.rootPath + directory))
           }

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -101,12 +101,74 @@ Feature: Share by public link
     When the public uses the webUI to access the last public link created by user "user1"
     Then it should not be possible to delete file "lorem.txt" using the webUI
 
+  Scenario: creating a public link with "Editor" role makes it possible to upload a file
+    Given user "user1" has shared folder "simple-folder" with link with "read, change, create, delete" permissions
+    When the public uses the webUI to access the last public link created by user "user1"
+    And the user uploads file "new-lorem.txt" using the webUI
+    Then file "new-lorem.txt" should be listed on the webUI
+    And as "user1" file "simple-folder/new-lorem.txt" should exist
+
+  Scenario: creating a public link with "Editor" role makes it possible to upload a file inside a subdirectory
+    Given user "user1" has shared folder "simple-folder" with link with "read, change, create, delete" permissions and password "pass123"
+    When the public uses the webUI to access the last public link created by user "user1" with password "pass123"
+    And the user opens folder "simple-empty-folder" using the webUI
+    And the user uploads file "new-lorem.txt" using the webUI
+    Then file "new-lorem.txt" should be listed on the webUI
+    And as "user1" file "simple-folder/simple-empty-folder/new-lorem.txt" should exist
+
+  Scenario: creating a public link with "Editor" role makes it possible to upload a folder
+    Given user "user1" has shared folder "simple-folder" with link with "read, change, create, delete" permissions
+    When the public uses the webUI to access the last public link created by user "user1"
+    And the user uploads folder "PARENT" using the webUI
+    Then folder "PARENT" should be listed on the webUI
+    And folder "CHILD" should be listed in the folder "PARENT" on the webUI
+    And file "child.txt" should be listed in the folder "CHILD" on the webUI
+    And as "user1" file "simple-folder/PARENT/CHILD/child.txt" should exist
+
+  Scenario: creating a public link with "Editor" role makes it possible to upload a folder inside a subdirectory
+    Given user "user1" has shared folder "simple-folder" with link with "read, change, create, delete" permissions
+    When the public uses the webUI to access the last public link created by user "user1"
+    And the user opens folder "simple-empty-folder" using the webUI
+    And the user uploads folder "PARENT" using the webUI
+    Then folder "PARENT" should be listed on the webUI
+    And folder "CHILD" should be listed in the folder "PARENT" on the webUI
+    And file "child.txt" should be listed in the folder "CHILD" on the webUI
+    And as "user1" file "simple-folder/simple-empty-folder/PARENT/CHILD/child.txt" should exist
+
   Scenario: creating a public link with "Editor" role makes it possible to upload files via the link even with password set
     Given user "user1" has shared folder "simple-folder" with link with "read, change, create, delete" permissions and password "pass123"
     When the public uses the webUI to access the last public link created by user "user1" with password "pass123"
     And the user uploads file "new-lorem.txt" using the webUI
     Then file "new-lorem.txt" should be listed on the webUI
     And as "user1" file "simple-folder/new-lorem.txt" should exist
+
+  Scenario: creating a public link with "Editor" role makes it possible to upload files inside a subdirectory even without password
+    Given user "user1" has shared folder "simple-folder" with link with "read, change, create, delete" permissions
+    When the public uses the webUI to access the last public link created by user "user1"
+    And the user uploads folder "PARENT" using the webUI
+    Then folder "PARENT" should be listed on the webUI
+    And folder "CHILD" should be listed in the folder "PARENT" on the webUI
+    And file "child.txt" should be listed in the folder "CHILD" on the webUI
+    And as "user1" file "simple-folder/PARENT/CHILD/child.txt" should exist
+
+  Scenario: creating a public link with "Editor" role makes it possible to upload a folder even with password set
+    Given user "user1" has shared folder "simple-folder" with link with "read, change, create, delete" permissions and password "pass123"
+    When the public uses the webUI to access the last public link created by user "user1" with password "pass123"
+    And the user uploads folder "PARENT" using the webUI
+    Then folder "PARENT" should be listed on the webUI
+    And folder "CHILD" should be listed in the folder "PARENT" on the webUI
+    And file "child.txt" should be listed in the folder "CHILD" on the webUI
+    And as "user1" file "simple-folder/PARENT/CHILD/child.txt" should exist
+
+  Scenario: creating a public link with "Editor" role makes it possible to upload a folder inside a sub-directory even with password set
+    Given user "user1" has shared folder "simple-folder" with link with "read, change, create, delete" permissions and password "pass123"
+    When the public uses the webUI to access the last public link created by user "user1" with password "pass123"
+    And the user opens folder "simple-empty-folder" using the webUI
+    And the user uploads folder "PARENT" using the webUI
+    Then folder "PARENT" should be listed on the webUI
+    And folder "CHILD" should be listed in the folder "PARENT" on the webUI
+    And file "child.txt" should be listed in the folder "CHILD" on the webUI
+    And as "user1" file "simple-folder/simple-empty-folder/PARENT/CHILD/child.txt" should exist
 
   Scenario: creating a public link with "Viewer" role makes it possible to create files via the link even with password set
     Given user "user1" has shared folder "simple-folder" with link with "read" permissions and password "pass123"

--- a/tests/acceptance/features/webUIUpload/upload.feature
+++ b/tests/acceptance/features/webUIUpload/upload.feature
@@ -60,7 +60,7 @@ Feature: File Upload
   @smokeTest
   Scenario: uploading a big file (when chunking is implemented this upload should be chunked)
     Given a file with the size of "30000000" bytes and the name "big-video.mp4" has been created locally
-    When the user uploads file "big-video.mp4" using the webUI
+    When the user uploads a created file "big-video.mp4" using the webUI
     Then no message should be displayed on the webUI
     And file "big-video.mp4" should be listed on the webUI
     And as "user1" the content of "big-video.mp4" should be the same as the local "big-video.mp4"

--- a/tests/acceptance/features/webUIUpload/uploadEdgecases.feature
+++ b/tests/acceptance/features/webUIUpload/uploadEdgecases.feature
@@ -28,7 +28,7 @@ Feature: File Upload
   Scenario Outline: upload a new file into a sub folder
     Given a file with the size of "3000" bytes and the name "0" has been created locally
     When the user opens folder "<folder-to-upload-to>" using the webUI
-    And the user uploads file "0" using the webUI
+    And the user uploads a created file "0" using the webUI
     Then file "0" should be listed on the webUI
     And as "user1" the content of "<folder-to-upload-to>/0" should be the same as the local "0"
 
@@ -85,7 +85,7 @@ Feature: File Upload
 
   Scenario Outline: upload a big file using difficult names (when chunking in implemented that upload should be chunked)
     Given a file with the size of "30000000" bytes and the name <file-name> has been created locally
-    When the user uploads file <file-name> using the webUI
+    When the user uploads a created file <file-name> using the webUI
     Then file <file-name> should be listed on the webUI
     And as "user1" the content of <file-name> should be the same as the local <file-name>
     Examples:
@@ -97,6 +97,6 @@ Feature: File Upload
   Scenario: Upload a big file called "0" (when chunking in implemented that upload should be chunked)
     Given a file with the size of "30000000" bytes and the name "0" has been created locally
     When the user opens folder "simple-folder" using the webUI
-    And the user uploads file "0" using the webUI
+    And the user uploads a created file "0" using the webUI
     Then file "0" should be listed on the webUI
     And as "user1" the content of "simple-folder/0" should be the same as the local "0"

--- a/tests/acceptance/features/webUIUpload/uploadFileGreaterThanQuotaSize.feature
+++ b/tests/acceptance/features/webUIUpload/uploadFileGreaterThanQuotaSize.feature
@@ -15,7 +15,7 @@ Feature: Upload a file
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
     And a file with the size of "30000000" bytes and the name "big-video.mp4" has been created locally
-    When the user uploads file "big-video.mp4" using the webUI
+    When the user uploads a created file "big-video.mp4" using the webUI
     Then file "big-video.mp4" should not be listed on the webUI
     Then the error message 'File upload failed…' should be displayed on the webUI
     #And a error message should be displayed on the webUI with the text matching

--- a/tests/acceptance/pageObjects/filesPage.js
+++ b/tests/acceptance/pageObjects/filesPage.js
@@ -80,25 +80,20 @@ module.exports = {
       }
       return this
     },
-    selectFileForUpload: function (localFileName) {
+    selectFileForUpload: function (filePath) {
       return this
         .waitForElementVisible('@newFileMenuButton')
         .click('@newFileMenuButton')
         .waitForElementVisible('@fileUploadButton')
-        .uploadRemote(
-          require('path').join(this.api.globals.filesForUpload, localFileName),
-          filePath => {
-            this.api.setValue(this.elements.fileUploadInput.selector, filePath)
-          }
-        )
+        .setValue('@fileUploadInput', filePath)
     },
     /**
      *
-     * @param {string} localFileName
+     * @param {string} filePath
      */
-    uploadFile: function (localFileName) {
+    uploadFile: function (filePath) {
       return this
-        .selectFileForUpload(localFileName)
+        .selectFileForUpload(filePath)
         .waitForElementVisible(
           '@fileUploadProgress',
           this.api.globals.waitForConditionTimeout,

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -193,7 +193,15 @@ Given('the following files have been deleted by user {string}', async function (
 })
 
 When('the user uploads file {string} using the webUI', function (element) {
-  return client.page.filesPage().uploadFile(element)
+  const uploadPath = path.join(client.globals.mountedUploadDir, element)
+  return client.page.filesPage().uploadFile(uploadPath)
+})
+
+When('the user uploads a created file {string} using the webUI', function (element) {
+  const filePath = path.join(client.globals.filesForUpload, element)
+  return client.uploadRemote(filePath, function (uploadPath) {
+    client.page.filesPage().uploadFile(uploadPath)
+  })
 })
 
 When('the user uploads folder {string} using the webUI', function (element) {
@@ -558,7 +566,7 @@ Then('the following files/folders/resources should be listed on the webUI', func
   return assertElementsAreListed([].concat.apply([], table.rows()))
 })
 
-Then('file {string} should be listed in the folder {string} on the webUI', function (file, folder) {
+Then('file/folder {string} should be listed in the folder {string} on the webUI', function (file, folder) {
   return client
     .page
     .FilesPageElement
@@ -653,7 +661,8 @@ Then('it should not be possible to delete file/folder {string} using the webUI',
 })
 
 When('the user uploads overwriting file {string} using the webUI', function (file) {
-  return client.page.filesPage().selectFileForUpload(file)
+  const uploadPath = path.join(client.globals.mountedUploadDir, file)
+  return client.page.filesPage().selectFileForUpload(uploadPath)
     .then(() => client.page.filesPage().confirmFileOverwrite())
 })
 

--- a/tests/acceptance/stepDefinitions/publicLinkContext.js
+++ b/tests/acceptance/stepDefinitions/publicLinkContext.js
@@ -34,7 +34,6 @@ When('the public uses the webUI to access the last public link created by user {
 
 When('the public uses the webUI to access the last public link created by user {string} with password {string}', async function (linkCreator, password) {
   const lastShareToken = await sharingHelper.fetchLastPublicLinkShare(linkCreator)
-
   await client.page.publicLinkFilesPage().navigateAndWaitForPasswordPage(lastShareToken)
 
   return client.page.publicLinkPasswordPage().submitPublicLinkPassword(password)


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This adds tests for files and folder uploads in root and inside subdirectory, with a password, and without a password. This also fixes bug when a folder is uploaded via a public link when the password is set. (ref: #2402 ).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Related to #2222

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally and CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...