### PR TITLE
Test Files drop without password

### DIFF
--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -108,7 +108,7 @@ Feature: Share by public link
     Then file "new-lorem.txt" should be listed on the webUI
     And as "user1" file "simple-folder/new-lorem.txt" should exist
 
-  Scenario: creating a public link with "Editor" role makes it possible to upload a file inside a subdirectory
+  Scenario: creating a public link with "Editor" role makes it possible to upload a file inside a subdirectory with password set
     Given user "user1" has shared folder "simple-folder" with link with "read, change, create, delete" permissions and password "pass123"
     When the public uses the webUI to access the last public link created by user "user1" with password "pass123"
     And the user opens folder "simple-empty-folder" using the webUI
@@ -142,7 +142,7 @@ Feature: Share by public link
     Then file "new-lorem.txt" should be listed on the webUI
     And as "user1" file "simple-folder/new-lorem.txt" should exist
 
-  Scenario: creating a public link with "Editor" role makes it possible to upload files inside a subdirectory even without password
+  Scenario: creating a public link with "Editor" role makes it possible to upload files inside a subdirectory
     Given user "user1" has shared folder "simple-folder" with link with "read, change, create, delete" permissions
     When the public uses the webUI to access the last public link created by user "user1"
     And the user uploads folder "PARENT" using the webUI
@@ -174,6 +174,20 @@ Feature: Share by public link
     Given user "user1" has shared folder "simple-folder" with link with "read" permissions and password "pass123"
     When the public uses the webUI to access the last public link created by user "user1" with password "pass123"
     Then it should not be possible to create files using the webUI
+
+  @issue-2414
+  Scenario: creating a public link with "Uploader" role makes it possible to upload a file
+    Given user "user1" has shared folder "simple-folder" with link with "create" permissions
+    When the public uses the webUI to access the last public link created by user "user1"
+    And the user uploads file "new-lorem.txt" using the webUI
+    Then as "user1" file "simple-folder/new-lorem.txt" should exist
+
+  @issue-2414
+  Scenario: creating a public link with "Uploader" role makes it possible to upload a folder
+    Given user "user1" has shared folder "simple-folder" with link with "create" permissions
+    When the public uses the webUI to access the last public link created by user "user1"
+    And the user uploads folder "PARENT" using the webUI
+    Then as "user1" file "simple-folder/PARENT/CHILD/child.txt" should exist
 
   @skip @yetToImplement
   Scenario: mount public link


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Adds a test for public link files and folder uploads without password

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Related to #2222 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally and CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...