### PR TITLE
switched to sessionStorage

### DIFF
--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -3,7 +3,8 @@ import { Log, User, UserManager, WebStorageStateStore } from 'oidc-client'
 export function initVueAuthenticate (config) {
   if (config) {
     const store = new WebStorageStateStore({
-      prefix: 'oc_oAuth'
+      prefix: 'oc_oAuth',
+      store: sessionStorage
     })
     let baseUrl = window.location.href.split('#')[0]
     if (baseUrl.endsWith('/index.html')) {
@@ -67,7 +68,7 @@ export function initVueAuthenticate (config) {
         return mgr.signinRedirect()
       },
       getToken () {
-        const storageString = localStorage.getItem('oc_oAuth' + mgr._userStoreKey)
+        const storageString = sessionStorage.getItem('oc_oAuth' + mgr._userStoreKey)
         if (storageString) {
           const user = User.fromStorageString(storageString)
           if (user) {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -31,7 +31,7 @@ export const Store = new Vuex.Store({
   // state: {
   //   someModulelessState: 0
   // },
-  plugins: [vuexPersist.plugin, vuexPersistInSession.plugin],
+  plugins: [vuexPersistInSession.plugin],
   modules: {
     app,
     apps,

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -12,23 +12,17 @@ import router from './router'
 
 Vue.use(Vuex)
 
-const vuexPersist = new VuexPersistence({
-  key: 'phoenixState',
-  storage: window.localStorage,
-  filter: (mutation) => ([
-    'SET_USER',
-    'SET_TOKEN',
-    'SET_CAPABILITIES'
-  ].indexOf(mutation.type) > -1),
-  modules: ['user']
-})
-
 const vuexPersistInSession = new VuexPersistence({
   key: 'phoenixStateInSessionStorage',
   // Browser tab independent storage which gets deleted after the tab is closed
   storage: window.sessionStorage,
-  filter: (mutation) => (['SAVE_URL_BEFORE_LOGIN'].indexOf(mutation.type) > -1),
-  modules: ['router']
+  filter: (mutation) => ([
+    'SAVE_URL_BEFORE_LOGIN',
+    'SET_USER',
+    'SET_TOKEN',
+    'SET_CAPABILITIES'
+  ].indexOf(mutation.type) > -1),
+  modules: ['router', 'user']
 })
 
 const strict = process.env.NODE_ENV === 'development'


### PR DESCRIPTION
## Description
Switched the storage of the auth service from local to session storage.

## Related Issue
- Fixes https://github.com/owncloud/phoenix/issues/2407

## Motivation and Context
If the browser will be closed and therefore the session ends the user should start a new auth flow.

## Open tasks:
- [ ] Check if there are some more places where the tokens are stored in the local storage