### PR TITLE
Acceptance test to share a folder or file with group and a member performs actions on received share

### DIFF
--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -15,7 +15,6 @@ Feature: Sharing files and folders with internal groups
     And user "user1" has been added to group "grp1"
     And user "user2" has been added to group "grp1"
 
-  @smokeTest @yetToImplement
   Scenario Outline: share a file & folder with another internal user
     Given user "user3" has logged in using the webUI
     When the user shares folder "simple-folder" with group "grp1" as "<set-role>" using the webUI
@@ -46,67 +45,65 @@ Feature: Sharing files and folders with internal groups
     But these resources should not be listed in the folder "simple-folder (2)" on the webUI
       | entry_name        |
       | simple-folder (2) |
-    #    And folder "simple-folder (2)" should be marked as shared by "User Two" on the webUI
-    #    And file "testimage (2).jpg" should be marked as shared by "User Two" on the webUI
+    When the user browses to the shared-with-me page using the webUI
+    Then folder "simple-folder (2)" should be marked as shared by "User Three" on the webUI
+    And file "testimage (2).jpg" should be marked as shared by "User Three" on the webUI
     Examples:
       | set-role    | expected-role | permissions-folder         | permissions-file |
       | Viewer      | Viewer        | read                       | read             |
       | Editor      | Editor        | read,change,create, delete | read,change      |
       | Custom Role | Viewer        | read                       | read             |
 
-  @skip @yetToImplement
   Scenario: share a file with an internal group a member overwrites and unshares the file
     Given user "user3" has logged in using the webUI
     When the user renames file "lorem.txt" to "new-lorem.txt" using the webUI
-    And the user shares file "new-lorem.txt" with group "grp1" using the webUI
+    And the user shares file "new-lorem.txt" with group "grp1" as "Editor" using the webUI
     And the user re-logs in as "user1" using the webUI
-    Then the content of "new-lorem.txt" should not be the same as the local "new-lorem.txt"
+    Then as "user1" the content of "new-lorem.txt" should not be the same as the local "new-lorem.txt"
     # overwrite the received shared file
-    When the user uploads overwriting file "new-lorem.txt" using the webUI and retries if the file is locked
+    When the user uploads overwriting file "new-lorem.txt" using the webUI
     Then file "new-lorem.txt" should be listed on the webUI
-    And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
+    And as "user1" the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
     # unshare the received shared file
     When the user unshares file "new-lorem.txt" using the webUI
     Then file "new-lorem.txt" should not be listed on the webUI
     # check that another group member can still see the file
     When the user re-logs in as "user2" using the webUI
-    Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
+    Then as "user2" the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
     # check that the original file owner can still see the file
     When the user re-logs in as "user3" using the webUI
-    Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
+    Then as "user3" the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 
-  @skip @yetToImplement
   Scenario: share a folder with an internal group and a member uploads, overwrites and deletes files
     Given user "user3" has logged in using the webUI
     When the user renames folder "simple-folder" to "new-simple-folder" using the webUI
-    And the user shares folder "new-simple-folder" with group "grp1" using the webUI
+    And the user shares folder "new-simple-folder" with group "grp1" as "Editor" using the webUI
     And the user re-logs in as "user1" using the webUI
     And the user opens folder "new-simple-folder" using the webUI
-    Then the content of "lorem.txt" should not be the same as the local "lorem.txt"
+    Then as "user1" the content of "new-simple-folder/lorem.txt" should not be the same as the local "lorem.txt"
     # overwrite an existing file in the received share
-    When the user uploads overwriting file "lorem.txt" using the webUI and retries if the file is locked
+    When the user uploads overwriting file "lorem.txt" using the webUI
     Then file "lorem.txt" should be listed on the webUI
-    And the content of "lorem.txt" should be the same as the local "lorem.txt"
+    And as "user1" the content of "new-simple-folder/lorem.txt" should be the same as the local "lorem.txt"
     # upload a new file into the received share
     When the user uploads file "new-lorem.txt" using the webUI
-    Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
+    Then as "user1" the content of "new-simple-folder/new-lorem.txt" should be the same as the local "new-lorem.txt"
     # delete a file in the received share
     When the user deletes file "data.zip" using the webUI
     Then file "data.zip" should not be listed on the webUI
     # check that the file actions by the sharee are visible to another group member
     When the user re-logs in as "user2" using the webUI
     And the user opens folder "new-simple-folder" using the webUI
-    Then the content of "lorem.txt" should be the same as the local "lorem.txt"
-    And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
+    Then as "user2" the content of "new-simple-folder/lorem.txt" should be the same as the local "lorem.txt"
+    And as "user2" the content of "new-simple-folder/new-lorem.txt" should be the same as the local "new-lorem.txt"
     And file "data.zip" should not be listed on the webUI
     # check that the file actions by the sharee are visible for the share owner
     When the user re-logs in as "user3" using the webUI
     And the user opens folder "new-simple-folder" using the webUI
-    Then the content of "lorem.txt" should be the same as the local "lorem.txt"
-    And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
+    Then as "user3" the content of "new-simple-folder/lorem.txt" should be the same as the local "lorem.txt"
+    And as "user3" the content of "new-simple-folder/new-lorem.txt" should be the same as the local "new-lorem.txt"
     And file "data.zip" should not be listed on the webUI
 
-  @smokeTest
   Scenario: share a folder with an internal group and a member unshares the folder
     Given user "user3" has logged in using the webUI
     When the user renames folder "simple-folder" to "new-simple-folder" using the webUI
@@ -142,18 +139,6 @@ Feature: Sharing files and folders with internal groups
     When the administrator excludes group "system-group" from receiving shares using the webUI
     Then user "user1" should not be able to share folder "simple-folder" with group "system-group" using the sharing API
 
-  @skip @yetToImplement
-  Scenario: autocompletion for a group that is excluded from receiving shares
-    Given group "system-group" has been created
-    And the administrator has browsed to the admin sharing settings page
-    When the administrator excludes group "system-group" from receiving shares using the webUI
-    And the user re-logs in as "user1" using the webUI
-    And the user browses to the files page
-    And the user opens the share dialog for folder "simple-folder" using the webUI
-    And the user types "system-group" in the share-with-field
-    Then a tooltip with the text "No users or groups found for system-group" should be shown near the share-with-field on the webUI
-    And the autocomplete list should not be displayed on the webUI
-
   Scenario: user shares the file/folder with a group and delete the share with group
     Given user "user1" has logged in using the webUI
     And user "user1" has shared file "lorem.txt" with group "grp1"
@@ -179,3 +164,12 @@ Feature: Sharing files and folders with internal groups
     And file "lorem.txt" should be listed in shared-with-others page on the webUI
     And as "user2" file "lorem (2).txt" should not exist
     But as "user3" file "lorem (2).txt" should exist
+
+  Scenario: Auto-completion for a group that is excluded from receiving shares
+    Given group "system-group" has been created
+    And the administrator has excluded group "system-group" from receiving shares
+    When the user re-logs in as "user1" using the webUI
+    And the user browses to the files page
+    And the user opens the share dialog for folder "simple-folder" using the webUI
+    And the user types "system-group" in the share-with-field
+    Then the autocomplete list should not be displayed on the webUI

--- a/tests/acceptance/pageObjects/sharedWithMePage.js
+++ b/tests/acceptance/pageObjects/sharedWithMePage.js
@@ -68,6 +68,20 @@ module.exports = {
         .waitForElementVisible(actionLocatorButton)
         .click(actionLocatorButton)
         .waitForOutstandingAjaxCalls()
+    },
+    /**
+     * Asserts that the element(file/folder/resource) on the shared-with-me page is shared by the desired user
+     *
+     * @param {string} element
+     * @param {string} sharer
+     */
+    assertSharedByUser: function (element, sharer) {
+      const requiredXpath = this.api.page.FilesPageElement.filesList().getFileRowSelectorByFileName(element) +
+                          util.format(this.elements.getSharedFromUserName.selector, sharer)
+      return this.waitForElementVisible({
+        locateStrategy: this.elements.getSharedFromUserName.locateStrategy,
+        selector: requiredXpath
+      })
     }
   },
   elements: {

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -237,6 +237,10 @@ Then('the following files should be listed on the files-drop page:', async funct
   )
 })
 
+When('the user unshares file/folder {string} using the webUI', function (element) {
+  return client.page.FilesPageElement.filesList().deleteFile(element)
+})
+
 When('the user uploads folder {string} using the webUI', function (element) {
   const rootUploadDir = client.globals.mountedUploadDir
   const name = path.join(rootUploadDir, element)
@@ -653,6 +657,7 @@ Then('file/folder {string} should be listed in shared-with-others page on the we
 Given('the user has created file {string}', function (fileName) {
   return webdav.createFile(client.globals.currentUser, fileName, '')
 })
+
 Given('user {string} has created file {string}', function (userId, fileName) {
   return webdav.createFile(userId, fileName, '')
 })


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Acceptance test to share a folder or file with group and a member performs actions on received share.The test to assert auto-completion is not present for a  group that is excluded from receiving shares is also added.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...