### PR TITLE
Fix failing createFoldersTest

### DIFF
--- a/tests/acceptance/pageObjects/filesPage.js
+++ b/tests/acceptance/pageObjects/filesPage.js
@@ -34,22 +34,22 @@ module.exports = {
      * @param {string} name to set or null to use default value from dialog
      * @param {boolean} expectToSucceed
      */
-    createFolder: function (name, expectToSucceed = true) {
-      this
+    createFolder: async function (name, expectToSucceed = true) {
+      await this
         .waitForElementVisible('@newFileMenuButton', 500000)
         .click('@newFileMenuButton')
         .waitForElementVisible('@newFolderButton')
         .click('@newFolderButton')
         .waitForElementVisible('@newFolderInput')
       if (name !== null) {
-        this.clearValueWithEvent('@newFolderInput')
-        this.setValueBySingleKeys('@newFolderInput', name)
+        await this.clearValueWithEvent('@newFolderInput')
+        await this.setValueBySingleKeys('@newFolderInput', name)
       }
-      this
+      await this
         .click('@newFolderOkButton')
         .waitForElementNotPresent('@createFolderLoadingIndicator')
       if (expectToSucceed) {
-        this.waitForElementNotVisible('@newFolderDialog')
+        await this.waitForElementNotVisible('@newFolderDialog')
           .waitForAnimationToFinish()
       }
       return this


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Acceptance test for createFolder feature is re-implemented because of some asynchronous commands issue. Some commands of the command queue were skipped due to asynchronous timing reasons which was causing CI failure.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
It's because CI was failing multiple times on same step.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
:robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...