### PR TITLE
Add acceptance test for copying public link URL and assert shared resource

### DIFF
--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -739,3 +739,11 @@ Feature: Share by public link
     When the user uploads file "lorem.txt" keeping both new and existing files using the webUI
     Then file "lorem.txt" should be listed on the webUI
     And file "lorem (2).txt" should be listed on the webUI
+
+  Scenario: user browses to public link share using copy link button
+    Given user "user1" has shared folder "simple-folder" with link with "read" permissions
+    And user "user1" has logged in using the webUI
+    When the user copies the url of public link named "{}" of folder "simple-folder" using the webUI
+    And the user navigates to the copied public link using the webUI
+    Then file "lorem.txt" should be listed on the webUI
+

--- a/tests/acceptance/pageObjects/FilesPageElement/publicLinksDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/publicLinksDialog.js
@@ -384,6 +384,21 @@ module.exports = {
         message = result.value
       })
       return message
+    },
+    /**
+     * clicks the 'copy-public-link-uri' button of a public link
+     *
+     * @param {string} linkName Name of the public link whose URL is to be copied
+     */
+    copyPublicLinkURI: function (linkName) {
+      const copyBtnXpath = util.format(this.elements.publicLinkURLCopyButton.selector, linkName)
+      const copyBtnSelector = {
+        selector: copyBtnXpath,
+        locateStrategy: this.elements.publicLinkURLCopyButton.locateStrategy
+      }
+      return this
+        .waitForElementVisible(copyBtnSelector)
+        .click(copyBtnSelector)
     }
   },
   elements: {
@@ -425,6 +440,10 @@ module.exports = {
     },
     publicLinkDeleteButton: {
       selector: '//span[.="%s"]/../..//button[@aria-label="Delete public link"]',
+      locateStrategy: 'xpath'
+    },
+    publicLinkURLCopyButton: {
+      selector: '//span[.="%s"]/../..//button[@aria-label="Copy link url"]',
       locateStrategy: 'xpath'
     },
     publicLinkPasswordField: {

--- a/tests/acceptance/stepDefinitions/privateLinksContext.js
+++ b/tests/acceptance/stepDefinitions/privateLinksContext.js
@@ -9,7 +9,7 @@ When('the user copies the private link of the file/folder {string} using the web
     .copyPrivateLink()
 })
 
-When('the user navigates to the copied private link using the webUI', function () {
+When('the user navigates to the copied private/public link using the webUI', function () {
   return client.getClipBoardContent(function (url) {
     // If the redirect happens immediately we receive an error
     // Cannot read property 'parentNode' of null

--- a/tests/acceptance/stepDefinitions/publicLinkContext.js
+++ b/tests/acceptance/stepDefinitions/publicLinkContext.js
@@ -182,3 +182,12 @@ When('the user closes the public link details sidebar', function () {
     .filesList()
     .closeSidebar(100)
 })
+
+When('the user copies the url of public link named {string} of file/folder/resource {string} using the webUI', async function (linkName, resource) {
+  await client.page.FilesPageElement
+    .filesList()
+    .closeSidebar(100)
+    .openPublicLinkDialog(resource)
+  return client.page.FilesPageElement.publicLinksDialog()
+    .copyPublicLinkURI(linkName)
+})


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
In phoenix, when we create a public link for some resource, we get a button that copies the public link uri in clipboard and then we can paste it on browser and view shared items. WebUI acceptance test for this scenario has been added.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #2525

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
:robot: 
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...