### PR TITLE
Checks on resourceid (Public Links)

### DIFF
--- a/apps/files/src/components/FileLink.vue
+++ b/apps/files/src/components/FileLink.vue
@@ -93,9 +93,7 @@ export default {
     ...mapGetters(['getToken', 'capabilities']),
 
     $_links () {
-      return this.links.filter(link => {
-        return parseInt(link.itemSource) === parseInt(this.highlightedFile.id)
-      })
+      return this.links
     },
 
     $_expirationDate () {

--- a/apps/files/src/components/FileLink.vue
+++ b/apps/files/src/components/FileLink.vue
@@ -93,7 +93,9 @@ export default {
     ...mapGetters(['getToken', 'capabilities']),
 
     $_links () {
-      return this.links
+      return this.links.filter(link => {
+        return this.compareIds(link.itemSource, this.highlightedFile.id)
+      })
     },
 
     $_expirationDate () {

--- a/apps/files/src/mixins.js
+++ b/apps/files/src/mixins.js
@@ -100,6 +100,16 @@ export default {
         })
       })
     },
+    compareIds (x, y) {
+      if (!isNaN(x)) { // OC10 autoincrement id
+        return parseInt(x) === parseInt(y)
+      } else if (atob(y).split(':').length === 2) { // OC10: https://github.com/cs3org/reva/blob/e7830e2f752a05a081178ed26c384ced983b8fde/internal/http/services/owncloud/ocdav/ocdav.go#L169-L175
+        const opaqueid = atob(y).split(':')[1] // https://cs3org.github.io/cs3apis/#cs3.storageproviderv0alpha.ResourceId
+        return x === opaqueid
+      }
+
+      return false
+    },
     async $_ocUpload_addDropToQue (e) {
       const items = e.dataTransfer.items || e.dataTransfer.files
 

--- a/apps/files/src/mixins.js
+++ b/apps/files/src/mixins.js
@@ -102,7 +102,7 @@ export default {
     },
     compareIds (x, y) {
       if (!isNaN(x)) { // OC10 autoincrement id
-        return parseInt(x) === parseInt(y)
+        return parseInt(x, 10) === parseInt(y, 10)
       } else if (atob(y).split(':').length === 2) { // OC10: https://github.com/cs3org/reva/blob/e7830e2f752a05a081178ed26c384ced983b8fde/internal/http/services/owncloud/ocdav/ocdav.go#L169-L175
         const opaqueid = atob(y).split(':')[1] // https://cs3org.github.io/cs3apis/#cs3.storageproviderv0alpha.ResourceId
         return x === opaqueid

--- a/apps/files/src/mixins.js
+++ b/apps/files/src/mixins.js
@@ -100,15 +100,20 @@ export default {
         })
       })
     },
-    compareIds (x, y) {
-      if (!isNaN(x)) { // OC10 autoincrement id
-        return parseInt(x, 10) === parseInt(y, 10)
-      } else if (atob(y).split(':').length === 2) { // OC10: https://github.com/cs3org/reva/blob/e7830e2f752a05a081178ed26c384ced983b8fde/internal/http/services/owncloud/ocdav/ocdav.go#L169-L175
-        const opaqueid = atob(y).split(':')[1] // https://cs3org.github.io/cs3apis/#cs3.storageproviderv0alpha.ResourceId
-        return x === opaqueid
+    compareIds (a, b) {
+      if (!isNaN(a)) { // OC10 autoincrement id
+        return parseInt(a, 10) === parseInt(b, 10)
+      } else if (this.isOcisId(b)) {
+        return a === this.extractOpaqueId(b)
       }
 
       return false
+    },
+    isOcisId (id) {
+      return atob(id).split(':').length === 2
+    },
+    extractOpaqueId (id) {
+      return atob(id).split(':')[1]
     },
     async $_ocUpload_addDropToQue (e) {
       const items = e.dataTransfer.items || e.dataTransfer.files


### PR DESCRIPTION
## Description
Gets rid of share id type checking

## Motivation and Context
Reva id's are strings, therefore this guard is preventing them from being rendered.

## How Has This Been Tested?
✋ 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
