### PR TITLE
test password enforcement when changing public links

### DIFF
--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -346,6 +346,66 @@ Feature: Share by public link
       | path        | /simple-folder |
       | name        | Public link    |
 
+  Scenario Outline: user tries to change the role of an existing public link role without entering share password while enforce password for that role is enforced
+    Given the setting "<setting-name>" of app "core" has been set to "yes"
+    And user "user1" has shared folder "simple-folder" with link with "<initial-permissions>" permissions
+    And user "user1" has logged in using the webUI
+    When the user edits the public link named "{}" of folder "simple-folder" changing following
+      | role | <role> |
+    Then the user should see an error message on the public link share dialog saying "Passwords are enforced for link shares"
+    And user "user1" should have a share with these details:
+      | field       | value                 |
+      | share_type  | public_link           |
+      | uid_owner   | user1                 |
+      | permissions | <initial-permissions> |
+      | path        | /simple-folder        |
+    Examples:
+      | initial-permissions | role        | setting-name                                      |
+      | read, create        | Viewer      | shareapi_enforce_links_password_read_only         |
+      | read                | Contributor | shareapi_enforce_links_password_read_write        |
+      | read                | Editor      | shareapi_enforce_links_password_read_write_delete |
+      | read, create        | Uploader    | shareapi_enforce_links_password_write_only        |
+
+  Scenario Outline: user tries to delete the password of an existing public link role while enforce password for that role is enforced
+    Given the setting "<setting-name>" of app "core" has been set to "yes"
+    And user "user1" has shared folder "simple-folder" with link with "<initial-permissions>" permissions and password "123"
+    And user "user1" has logged in using the webUI
+    When the user edits the public link named "{}" of folder "simple-folder" changing following
+      | password | |
+    Then the user should see an error message on the public link share dialog saying "Passwords are enforced for link shares"
+    And user "user1" should have a share with these details:
+      | field       | value                 |
+      | share_type  | public_link           |
+      | uid_owner   | user1                 |
+      | permissions | <initial-permissions> |
+      | path        | /simple-folder        |
+    Examples:
+      | initial-permissions          | setting-name                                      |
+      | read                         | shareapi_enforce_links_password_read_only         |
+      | read, create                 | shareapi_enforce_links_password_read_write        |
+      | read, update, create, delete | shareapi_enforce_links_password_read_write_delete |
+      | create                       | shareapi_enforce_links_password_write_only        |
+
+  Scenario Outline: user changes the role of an existing public link role without entering share password while enforce password for the original role is enforced
+    Given the setting "<setting-name>" of app "core" has been set to "yes"
+    And user "user1" has shared folder "simple-folder" with link with "<initial-permissions>" permissions and password "123"
+    And user "user1" has logged in using the webUI
+    When the user edits the public link named "{}" of folder "simple-folder" changing following
+      | role     | <role> |
+      | password |        |
+    Then user "user1" should have a share with these details:
+      | field       | value                  |
+      | share_type  | public_link            |
+      | uid_owner   | user1                  |
+      | permissions | <expected-permissions> |
+      | path        | /simple-folder         |
+    Examples:
+      | initial-permissions          | role        | setting-name                                      | expected-permissions         |
+      | read                         | Contributor | shareapi_enforce_links_password_read_only         | read, create                 |
+      | read, create                 | Viewer      | shareapi_enforce_links_password_read_write        | read                         |
+      | read, update, create, delete | Uploader    | shareapi_enforce_links_password_read_write_delete | create                       |
+      | create                       | Editor      | shareapi_enforce_links_password_write_only        | read, update, create, delete |
+
   @yetToImplement
   Scenario: public should be able to access the shared file through public link
     Given user "user1" has logged in using the webUI

--- a/tests/acceptance/pageObjects/FilesPageElement/publicLinksDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/publicLinksDialog.js
@@ -145,8 +145,11 @@ module.exports = {
      * @returns {Promise<void>}
      */
     setPublicLinkPassword: function (linkPassword) {
+      this.waitForElementVisible('@publicLinkPasswordField')
+      if (linkPassword === '') {
+        return this.click('@publicLinkDeletePasswordButton')
+      }
       return this
-        .waitForElementVisible('@publicLinkPasswordField')
         .clearValue('@publicLinkPasswordField')
         .setValue('@publicLinkPasswordField', linkPassword)
     },
@@ -426,6 +429,10 @@ module.exports = {
     },
     publicLinkPasswordField: {
       selector: '//input[@type="password"]',
+      locateStrategy: 'xpath'
+    },
+    publicLinkDeletePasswordButton: {
+      selector: '//*[@uk-tooltip="Remove password"]',
       locateStrategy: 'xpath'
     },
     publicLinkSaveButton: {


### PR DESCRIPTION
## Description
test if password enforcement on public links works correctly when editing an existing public link

## Related Issue
part of https://github.com/owncloud/phoenix/issues/2075

## Motivation and Context
when editing a public link the password should be enforced if the enforcement setting for the selected role is enabled but if the enforcement setting is set for other roles the password should not be enforced

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...