### PR TITLE
tests for creating public links when the expiry date is enforced

### DIFF
--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -604,7 +604,7 @@ Feature: Share by public link
       | expireDate | 2038-10-14       |
     And user "user1" has logged in using the webUI
     When the user edits the public link named "Public link" of file "lorem.txt" changing following
-      | expireDate  | 2038-July-21  |
+      | expireDate  | 2038 July 21  |
     Then the fields of the last public link share response of user "user1" should include
       | expireDate | 2038-07-21 |
 
@@ -652,6 +652,69 @@ Feature: Share by public link
       | shared-resource |
       | lorem.txt       |
       | simple-folder   |
+
+  Scenario: user cannot set an expiry date when creating a public link to a date that is past the enforced max expiry date
+    Given the setting "shareapi_default_expire_date" of app "core" has been set to "yes"
+    And the setting "shareapi_enforce_expire_date" of app "core" has been set to "yes"
+    And user "user1" has logged in using the webUI
+    When the user tries to create a new public link for resource "simple-folder" using the webUI with
+      | expireDate | +8 |
+    Then the user should see an error message on the public link share dialog saying "Cannot set expiration date more than 7 days in the future"
+    And the user "user1" should not have created any shares
+
+  Scenario: user cannot change the expiry date of an existing public link to a date that is past the enforced max expiry date
+    Given the setting "shareapi_default_expire_date" of app "core" has been set to "yes"
+    And the setting "shareapi_enforce_expire_date" of app "core" has been set to "yes"
+    And user "user1" has created a public link with following settings
+      | path       | lorem.txt   |
+      | name       | Public link |
+      | expireDate | +6          |
+    And user "user1" has logged in using the webUI
+    When the user edits the public link named "Public link" of file "lorem.txt" changing following
+      | expireDate | +8 |
+    Then the user should see an error message on the public link share dialog saying "Cannot set expiration date more than 7 days in the future"
+    And user "user1" should have a share with these details:
+      | field       | value       |
+      | share_type  | public_link |
+      | uid_owner   | user1       |
+      | permissions | read        |
+      | path        | /lorem.txt  |
+      | name        | Public link |
+      | expiration  | +6          |
+
+  Scenario: user can set an expiry date when creating a public link to a date that is before the enforced max expiry date
+    Given the setting "shareapi_default_expire_date" of app "core" has been set to "yes"
+    And the setting "shareapi_enforce_expire_date" of app "core" has been set to "yes"
+    And user "user1" has logged in using the webUI
+    When the user creates a new public link for resource "lorem.txt" using the webUI with
+      | expireDate | +7 |
+    Then user "user1" should have a share with these details:
+      | field       | value       |
+      | share_type  | public_link |
+      | uid_owner   | user1       |
+      | permissions | read        |
+      | path        | /lorem.txt  |
+      | name        | Public link |
+      | expiration  | +7          |
+
+  Scenario: user can change the expiry date of an existing public link to a date that is before the enforced max expiry date
+    Given the setting "shareapi_default_expire_date" of app "core" has been set to "yes"
+    And the setting "shareapi_enforce_expire_date" of app "core" has been set to "yes"
+    And user "user1" has created a public link with following settings
+      | path       | lorem.txt   |
+      | name       | Public link |
+      | expireDate | +5          |
+    And user "user1" has logged in using the webUI
+    When the user edits the public link named "Public link" of file "lorem.txt" changing following
+      | expireDate | +7 |
+    Then user "user1" should have a share with these details:
+      | field       | value       |
+      | share_type  | public_link |
+      | uid_owner   | user1       |
+      | permissions | read        |
+      | path        | /lorem.txt  |
+      | name        | Public link |
+      | expiration  | +7          |
 
   @skip @yetToImplement
   Scenario: share two file with same name but different paths by public link

--- a/tests/acceptance/pageObjects/FilesPageElement/publicLinksDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/publicLinksDialog.js
@@ -1,5 +1,6 @@
 const assert = require('assert')
 const util = require('util')
+const sharingHelper = require('../../helpers/sharingHelper')
 
 module.exports = {
   commands: {
@@ -160,7 +161,12 @@ module.exports = {
      * @returns {Promise}
      */
     setPublicLinkExpiryDate: function (value) {
-      const [year, month, day] = value.split('-')
+      value = sharingHelper.calculateDate(value)
+      const dateToSet = new Date(Date.parse(value))
+      const year = dateToSet.getFullYear()
+      const month = dateToSet.toLocaleString('en-GB', { month: 'long' })
+      const day = dateToSet.getDate()
+
       return this
         .initAjaxCounters()
         .waitForElementVisible('@linkExpirationDateField')

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -105,7 +105,12 @@ const shareFileFolder = function (
  * @param {string} data.expireDate Expiry date of the share
  */
 const createPublicLink = function (sharer, data) {
-  const { path, permissions = 'read', name, password, expireDate } = data
+  let { path, permissions = 'read', name, password, expireDate } = data
+
+  if (typeof expireDate !== 'undefined') {
+    expireDate = sharingHelper.calculateDate(expireDate)
+  }
+
   return shareFileFolder(
     path,
     sharer,


### PR DESCRIPTION
## Description
test if public link creation / edit works correctly when the expiration date is enforced
on top of #2529 (review only the second commit)

## Related Issue
part of #2075

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...