### PR TITLE
Acceptance tests: search from trashbin page and favorites page does search in the global scope

### DIFF
--- a/tests/acceptance/features/webUIFiles/search.feature
+++ b/tests/acceptance/features/webUIFiles/search.feature
@@ -131,3 +131,25 @@ Feature: Search
     When the user searches for "strängéनेपाली" using the webUI
     Then file "strängéनेपालीloremfile.txt" with path "/" should be listed in the search results in the other folders section on the webUI
     And file "strängéनेपालीloremfile.txt" with path "/strängé नेपाली folder" should be listed in the search results in the other folders section on the webUI
+
+  @issue-1726
+  Scenario: Search for deleted folder in trashbin
+    Given user "user1" has created folder "deleted folder"
+    And user "user1" has created folder "not deleted folder"
+    And the following files have been deleted by user "user1"
+      | name               |
+      | deleted folder     |
+    When the user browses to the trashbin page
+    And the user searches for "folder" using the webUI
+    Then folder "not deleted folder" should be listed on the webUI
+    And folder "deleted folder" should not be listed on the webUI
+
+  @issue-1726
+  Scenario: Search for favorited folder in favorites page
+    Given user "user1" has created folder "favorite folder"
+    And user "user1" has created folder "not favorite folder"
+    And user "user1" has favorited element "favorite folder"
+    When the user browses to the favorites page
+    And the user searches for "favorite" using the webUI
+    Then folder "favorite folder" should be listed on the webUI
+    And folder "not favorite folder" should be listed on the webUI


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Adds acceptance test to verify that search from trashbin page and favorites page does the search in global scope
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/phoenix/issues/1726
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI
- Manual

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
