### PR TITLE
Acceptance test for multiple public links with same name for same file/folder

### DIFF
--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -810,3 +810,14 @@ Feature: Share by public link
     And the user navigates to the copied public link using the webUI
     Then file "lorem.txt" should be listed on the webUI
 
+  Scenario Outline: user creates multiple public links with same name for the same file/folder
+    Given user "user1" has logged in using the webUI
+    When the user creates a new public link for <element> "<name>" using the webUI with
+      | name | same_link_name |
+    And the user creates a new public link for <element> "<name>" using the webUI with
+      | name | same_link_name |
+    Then the tokens should be unique for each public links on the webUI
+    Examples:
+      | element | name          |
+      | folder  | simple-folder |
+      | file    | lorem.txt     |

--- a/tests/acceptance/stepDefinitions/publicLinkContext.js
+++ b/tests/acceptance/stepDefinitions/publicLinkContext.js
@@ -191,3 +191,14 @@ When('the user copies the url of public link named {string} of file/folder/resou
   return client.page.FilesPageElement.publicLinksDialog()
     .copyPublicLinkURI(linkName)
 })
+Then('the tokens should be unique for each public links on the webUI', async function () {
+  const tokens = []
+  const publicLinkList = await client.page.FilesPageElement.publicLinksDialog().getPublicLinkList()
+  for (let element of publicLinkList) {
+    element = element.substring(0, element.lastIndexOf('|'))
+    element = element.substring(element.lastIndexOf('\n') + 1)
+    tokens.push(element)
+  }
+  const isUnique = tokens.length === (new Set(tokens).size)
+  return assert.ok(isUnique)
+})


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Acceptance test for multiple public links with same name for same file/folder

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes issue #2526

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
-


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...