### PR TITLE
Acceptance test: breadcrumb is not seen one level below root directory when rootFolder is set

### DIFF
--- a/tests/acceptance/features/webUIFiles/breadcrumb.feature
+++ b/tests/acceptance/features/webUIFiles/breadcrumb.feature
@@ -1,0 +1,25 @@
+Feature: access breadcrumb
+  As a user
+  I want to browse to parent folders using breadcrumb
+  So that I can access resources with ease
+
+  Background:
+    Given user "user1" has been created with default attributes
+
+  @issue-2538
+  Scenario: Check breadCrumb for folder one level below the root folder when rootFolder is set
+    Given the rootFolder has been set to "" in phoenix config file
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    #    Then breadcrumb for folder "simple-folder" should be displayed on the webUI
+    Then there should be no breadcrumb displayed on the webUI
+    When the user opens folder "simple-empty-folder" using the webUI
+    Then breadcrumb for folder "simple-empty-folder" should be displayed on the webUI
+
+  Scenario: Change rootFolder to simple-folder and check for the displayed files
+    Given the rootFolder has been set to "simple-folder" in phoenix config file
+    And user "user1" has logged in using the webUI
+    When the user browses to the files page
+    Then folder "0" should not be listed on the webUI
+    But as "user1" folder "0" should exist
+    And file "lorem.txt" should be listed on the webUI

--- a/tests/acceptance/pageObjects/filesPage.js
+++ b/tests/acceptance/pageObjects/filesPage.js
@@ -358,6 +358,10 @@ module.exports = {
     breadcrumb: {
       selector: '#files-breadcrumb li:nth-of-type(2)'
     },
+    resourceBreadcrumb: {
+      selector: '//div[@id="files-breadcrumb"]//a[contains(text(),"%s")]',
+      locateStrategy: 'xpath'
+    },
     filterListButton: {
       selector: '#oc-filter-list-btn'
     },

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -6,6 +6,7 @@ const _ = require('lodash')
 const loginHelper = require('../helpers/loginHelper')
 const { move } = require('../helpers/webdavHelper')
 const path = require('../helpers/path')
+const util = require('util')
 let deletedElements
 let timeOfLastDeleteOperation = Date.now()
 let timeOfLastUploadOperation = Date.now()
@@ -169,6 +170,14 @@ When('the user deletes the following elements using the webUI', async function (
     deletedElements.push(line[0])
   }
   return client.page.filesPage()
+})
+
+Then('there should be no breadcrumb displayed on the webUI', function () {
+  return assertBreadCrumbIsNotDisplayed()
+})
+
+Then('breadcrumb for folder {string} should be displayed on the webUI', function (resource) {
+  return assertBreadcrumbIsDisplayedFor(resource)
 })
 
 /**
@@ -502,6 +511,25 @@ const theseResourcesShouldBeListed = function (entryList) {
     client.page.FilesPageElement.filesList().waitForFileVisible(entry[0])
   })
   return client
+}
+
+const assertBreadCrumbIsNotDisplayed = function () {
+  const breadcrumbXpath = client.page.filesPage().elements.breadcrumb.selector
+  return client.expect.element(breadcrumbXpath).to.not.be.present
+}
+
+/**
+ *
+ * @param {string} resource
+ */
+const assertBreadcrumbIsDisplayedFor = function (resource) {
+  const breadcrumbElement = client.page.filesPage().elements.resourceBreadcrumb
+  const resourceBreadcrumbXpath = util.format(breadcrumbElement.selector, resource)
+  return client
+    .useStrategy(breadcrumbElement)
+    .assert
+    .visible(resourceBreadcrumbXpath,
+      `Resource ${resourceBreadcrumbXpath} expected to be visible but is not visible .`)
 }
 
 /**


### PR DESCRIPTION


<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
When ```rootFolder``` is set in ```dist/config.json```, then breadcrumb is not seen one level below the root directory. For more info check this issue: https://github.com/owncloud/phoenix/issues/2538
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/phoenix/issues/2538

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI
- Manual
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
