### PR TITLE
Add focus management for uploads

### DIFF
--- a/apps/files/src/components/FileUpload.vue
+++ b/apps/files/src/components/FileUpload.vue
@@ -2,7 +2,7 @@
   <oc-nav-item icon="file_upload" @click="triggerUpload">
     <span id="files-file-upload-button" v-translate>Upload File</span>
     <div slot="outer-content">
-      <input id="fileUploadInput" type="file" name="file" @change="$_ocUpload_addFileToQue" multiple ref="input" />
+      <input id="fileUploadInput" type="file" aria-labelledby="files-file-upload-button" name="file" @change="$_ocUpload_addFileToQue" multiple ref="input" />
     </div>
   </oc-nav-item>
 </template>

--- a/apps/files/src/components/FilesApp.vue
+++ b/apps/files/src/components/FilesApp.vue
@@ -3,7 +3,7 @@
       <files-app-bar />
       <upload-progress v-show="inProgress.length" class="uk-padding-small uk-background-muted" />
       <oc-grid class="uk-height-1-1 uk-flex-1 uk-overflow-auto">
-        <div class="uk-width-expand uk-overflow-auto uk-height-1-1" @dragover="$_ocApp_dragOver" :class="{ 'uk-visible@m' : _sidebarOpen }">
+        <div ref="filesListWrapper" tabindex="-1" class="uk-width-expand uk-overflow-auto uk-height-1-1" @dragover="$_ocApp_dragOver" :class="{ 'uk-visible@m' : _sidebarOpen }">
           <oc-loader id="files-list-progress" v-if="loadingFolder"></oc-loader>
           <trash-bin v-if="$route.name === 'files-trashbin'" :fileData="activeFiles" />
           <shared-files-list v-else-if="sharedList" :fileData="activeFiles" @sideBarOpen="openSideBar" />
@@ -142,7 +142,11 @@ export default {
       this.renameDialogErrorMessage = this.validateFileName(value)
     }
   },
-
+  created () {
+    this.$root.$on('upload-end', () => {
+      this.delayForScreenreader(() => this.$refs.filesListWrapper.focus())
+    })
+  },
   computed: {
     ...mapGetters('Files', [
       'selectedFiles', 'activeFiles', 'dropzone', 'loadingFolder', 'highlightedFile', 'currentFolder', 'inProgress',

--- a/apps/files/src/components/UploadProgress.vue
+++ b/apps/files/src/components/UploadProgress.vue
@@ -10,6 +10,7 @@
         icon="expand_more"
       />
       <translate
+        id="upload-label"
         :translate-n="count"
         translate-plural="Uploading %{ count } items"
       >
@@ -21,13 +22,16 @@
         class="uk-width-1-1 uk-width-medium@s"
       >
         <oc-progress
+          ref="progressbar"
           :value="totalUploadProgress"
           :max="100"
+          aria-labelledby="upload-label"
           class="uk-width-expand uk-margin-remove-bottom"
         />
         <span>
           {{ totalUploadProgress | roundNumber}} %
         </span>
+        <oc-hidden-announcer level="assertive" :announcement="announcement" />
       </oc-grid>
     </oc-grid>
     <oc-drop
@@ -47,15 +51,25 @@ import Mixins from '../mixins'
 
 export default {
   name: 'UploadProgress',
-
+  data () {
+    return {
+      announcement: '',
+      announcementOnComplete: this.$gettext('Upload complete')
+    }
+  },
   components: {
     UploadMenu
   },
-
   mixins: [
     Mixins
   ],
-
+  created () {
+    this.$root.$on('upload-start', () => {
+      this.$nextTick(() => {
+        this.delayForScreenreader(() => this.$refs.progressbar.$el.focus())
+      })
+    })
+  },
   computed: {
     ...mapGetters('Files', ['inProgress', 'uploaded']),
 
@@ -81,6 +95,13 @@ export default {
       }
 
       return progressTotal
+    }
+  },
+  watch: {
+    totalUploadProgress (value) {
+      if (value === 100) {
+        this.announcement = this.announcementOnComplete
+      }
     }
   }
 }

--- a/apps/files/src/mixins.js
+++ b/apps/files/src/mixins.js
@@ -45,6 +45,12 @@ export default {
     formDateFromNow (date) {
       return moment(date).locale(this.$language.current).fromNow()
     },
+    delayForScreenreader (func, delay = 500) {
+      /*
+      * Delay for screen readers Virtual buffers
+      */
+      setTimeout(() => func(), delay)
+    },
     fileTypeIcon (file) {
       if (file) {
         if (file.type === 'folder') {
@@ -287,6 +293,7 @@ export default {
     },
 
     $_ocUpload (file, path, overwrite = null, emitSuccess = true, addToProgress = true) {
+      this.$root.$emit('upload-start')
       let basePath = this.path || ''
       let relativePath = path
       if (addToProgress) {
@@ -318,6 +325,7 @@ export default {
       }
 
       promise.then(e => {
+        this.$root.$emit('upload-end')
         this.removeFileFromProgress(file)
         if (emitSuccess) {
           this.$emit('success', e, file)


### PR DESCRIPTION
Regarding: progressbar, to listwrapper on complete

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Improves upload user flow for screen reader users by making them programmatically aware of 
* the interstitial interface state of an upload in progress
* the end of mentioned upload progress

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/owncloud-design-system/issues/536
- Hard dependency on https://github.com/owncloud/owncloud-design-system/pull/556

## Motivation and Context
While visual users can comprehend that an (larger) upload is running and get visual clues about its end, screen readers stay silent during the progress. This PR tackles this issue by adding two steps:
1. When the upload starts programmatic focus will be sent to the progressbar. In the related ODS PR `OcProgress` is improved with aria states/information about the upload so screen reader can pick its state up. In order to do so the progressbar has to have focus.
2. Once the upload has finished screen reader will be informed about the completion via a live region and focus will be sent to the container that wraps the file lists (where the newly uploaded files then will recide).

## How Has This Been Tested?
- No automatic tests (related to my issues with the overall test setup)
- Manual tests with two tools
  - Tracking of the focus in the browser's console via the following JavaScript `document.addEventListener('focusin', () => {console.log(document.activeElement);});`
  - [NerdeRegion Chrome extension for a visible output of live regions](https://chrome.google.com/webstore/detail/nerderegion/lkcampbojgmgobcfinlkgkodlnlpjieb)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes


## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] https://github.com/owncloud/owncloud-design-system/pull/556 has to be merged prior to this PR