### PR TITLE
Don't re-filter autocomplete collaborators results for remote user

### DIFF
--- a/apps/files/src/components/Collaborators/NewCollaborator.vue
+++ b/apps/files/src/components/Collaborators/NewCollaborator.vue
@@ -185,14 +185,8 @@ export default {
     },
     filterRecipients (item, queryText) {
       if (item.value.shareType === 6) {
-        return (
-          item.label
-            .toLocaleLowerCase()
-            .indexOf(queryText.toLocaleLowerCase()) > -1 &&
-          item.label.indexOf('@') > -1 &&
-          item.label.indexOf('.') > -1 &&
-          item.label.lastIndexOf('.') + 1 !== item.label.length
-        )
+        // done on server side
+        return true
       }
       return (
         item.label.toLocaleLowerCase().indexOf(queryText.toLocaleLowerCase()) >

--- a/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletionSpecialChars.feature
+++ b/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletionSpecialChars.feature
@@ -15,6 +15,7 @@ Background:
     | groupname     |
     | finance1      |
     | finance2      |
+  And the setting "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "no"
 
 Scenario Outline: autocompletion of user having special characters in their usernames
   Given these users have been created but not initialized:


### PR DESCRIPTION
## Description
The autocomplete for adding collaborators was filtering results that
were already filtered on the server side.

This makes the filterRecipients function return true as no filtering is
necessary.

## Related Issue
Fixes https://github.com/owncloud/phoenix/issues/2509

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manual test with "user1", "user11" and "user2".
Typing "user1" properly filters out "user2" as it's done on the server already.

Also tested "user@x" to make sure a federated share appears in the list as expected in #2509 

Expecting that all autocomplete tests in CI will still pass.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
