### PR TITLE
Refactoring files-page page object for assertion management

### DIFF
--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -464,11 +464,31 @@ Then('no custom permissions should be set for collaborator {string} for file/fol
 
 When('the user shares file/folder/resource {string} with group {string} as {string} using the webUI', userSharesFileOrFolderWithGroup)
 
-Then('it should not be possible to share file/folder {string} using the webUI', function (resource) {
-  return client.page
+Then('it should not be possible to share file/folder {string} using the webUI', async function (resource) {
+  const state = await client.page
     .FilesPageElement
     .filesList()
-    .assertSharingIsDisabled(resource)
+    .isSharingBtnPresent(resource)
+  assert.ok(
+    !state,
+    `Error: Sharing button for resource ${resource} is not in disabled state`
+  )
+  const sidebarLinkTabState = await client.page
+    .FilesPageElement
+    .filesList()
+    .isSidebarLinksTabPresent(resource)
+  assert.ok(
+    !sidebarLinkTabState,
+    `Error: Sidebar 'Links' tab for resource ${resource} is present`
+  )
+  const sidebarCollaboratorsTabState = await client.page
+    .FilesPageElement
+    .filesList()
+    .isSidebarCollaboratorsTabPresent(resource)
+  assert.ok(
+    !sidebarCollaboratorsTabState,
+    `Error: Sidebar 'Collaborators' tab for resource ${resource} is present`
+  )
 })
 
 When('the user shares file/folder/resource {string} with user {string} as {string} using the webUI', userSharesFileOrFolderWithUser)


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
All the assertions from `filesPage` of `page-objects` are moved to respective contexts.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of #2508

## Motivation and Context
To make our code more powerful and managed!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
:robot:

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
