### PR TITLE
Refactoring publicLinksDialog page-object for assertion management

### DIFF
--- a/tests/acceptance/pageObjects/FilesPageElement/publicLinksDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/publicLinksDialog.js
@@ -205,7 +205,7 @@ module.exports = {
     isExpiryDateDisabled: async function (linkName, pastDate) {
       await this.clickLinkEditBtn(linkName)
       const [year, month, day] = pastDate.split(/-/)
-      let disabled
+      let disabled = false
       const iDay = parseInt(day)
       const yearSelector = this.setExpiryDateYearSelectorXpath(year)
       const monthSelector = this.setExpiryDateMonthSelectorXpath(month)
@@ -248,9 +248,7 @@ module.exports = {
             disabled = true
           }
         })
-      if (disabled) {
-        return disabled
-      } else { return false }
+      return disabled
     },
     /**
      * sets up public link share edit form

--- a/tests/acceptance/pageObjects/FilesPageElement/publicLinksDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/publicLinksDialog.js
@@ -1,4 +1,3 @@
-const assert = require('assert')
 const util = require('util')
 const sharingHelper = require('../../helpers/sharingHelper')
 
@@ -195,18 +194,18 @@ module.exports = {
       return this
     },
     /**
-     * checks if the provided expiryDate is selectors are disabled or not
+     * checks if the given expiryDate is disabled or not
      *
-     * @param linkName name of the public link
-     * @param pastDate provided past date for inspection
+     * @param {string} linkName name of the public link
+     * @param {string} pastDate provided past date for inspection
      *  pastDate should be in form 2000-August-7 | 2000-Aug-7
      *  leading zeros before day are removed
-     * @returns {Promise<void>}
+     * @returns {Promise<boolean>}
      */
-    assertDisabledExpiryDate: async function (linkName, pastDate) {
+    isExpiryDateDisabled: async function (linkName, pastDate) {
       await this.clickLinkEditBtn(linkName)
       const [year, month, day] = pastDate.split(/-/)
-      let disabled = false
+      let disabled
       const iDay = parseInt(day)
       const yearSelector = this.setExpiryDateYearSelectorXpath(year)
       const monthSelector = this.setExpiryDateMonthSelectorXpath(month)
@@ -227,7 +226,7 @@ module.exports = {
             disabled = true
           }
         })
-      if (disabled) { return }
+      if (disabled) { return disabled }
       await this
         .click(yearSelector)
         .click('@dateTimeOkButton')
@@ -239,7 +238,7 @@ module.exports = {
             disabled = true
           }
         })
-      if (disabled) { return }
+      if (disabled) { return disabled }
       await this
         .click(monthSelector)
         .click('@dateTimeOkButton')
@@ -249,9 +248,9 @@ module.exports = {
             disabled = true
           }
         })
-      assert.strictEqual(
-        disabled, true, 'Provided date is not disabled'
-      )
+      if (disabled) {
+        return disabled
+      } else { return false }
     },
     /**
      * sets up public link share edit form
@@ -303,18 +302,23 @@ module.exports = {
         .waitForOutstandingAjaxCalls()
     },
     /**
-     * checks if public link share with provided name is present
+     * checks if public link share with given name is present
      *
      * @param {string} linkName - Name of the public link share to be asserted
-     * @returns {*}
+     * @returns {boolean}
      */
-    assertPublicLinkNotPresent: function (linkName) {
+    isPublicLinkPresent: async function (linkName) {
       const fileNameSelectorXpath = this.elements.publicLinkContainer.selector + this.elements.publicLinkName.selector
-      return this
-        .waitForElementNotPresent({
-          selector: util.format(fileNameSelectorXpath, linkName),
-          locateStrategy: this.elements.publicLinkName.locateStrategy
-        })
+      let isPresent
+      await this
+        .waitForAnimationToFinish()
+        .api.elements(
+          this.elements.publicLinkName.locateStrategy,
+          util.format(fileNameSelectorXpath, linkName),
+          (result) => {
+            isPresent = result.value.length > 0
+          })
+      return isPresent
     },
     /**
      * creates a new public link

--- a/tests/acceptance/stepDefinitions/publicLinkContext.js
+++ b/tests/acceptance/stepDefinitions/publicLinkContext.js
@@ -124,8 +124,13 @@ When('the user tries to edit expiration of the public link named {string} of fil
       .filesList()
       .closeSidebar(100)
       .openPublicLinkDialog(resource)
-    return client.page.FilesPageElement.publicLinksDialog()
-      .assertDisabledExpiryDate(linkName, pastDate)
+    const isDisabled = await client.page.FilesPageElement
+      .publicLinksDialog()
+      .isExpiryDateDisabled(linkName, pastDate)
+    return assert.ok(
+      isDisabled,
+      'Expected expiration date to be disabled but found not disabled'
+    )
   })
 
 When('the user {string} removes the public link named {string} of file/folder/resource {string} using the webUI',
@@ -139,9 +144,15 @@ When('the user {string} removes the public link named {string} of file/folder/re
       .removePublicLink(linkName)
   })
 
-Then('public link named {string} should not be listed on the public links list on the webUI', function (linkName) {
-  return client.page.FilesPageElement.publicLinksDialog()
-    .assertPublicLinkNotPresent(linkName)
+Then('public link named {string} should not be listed on the public links list on the webUI', async function (linkName) {
+  const isPresent = await client.page
+    .FilesPageElement
+    .publicLinksDialog()
+    .isPublicLinkPresent(linkName)
+  return assert.ok(
+    !isPresent,
+    `expected public-link '${linkName}' to be 'not listed' but got found`
+  )
 })
 
 Then(


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
All the assertions from `publicLinksDialog` of `page-objects` are moved to respective contexts.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of #2508

## Motivation and Context
Better management of code-base

## How Has This Been Tested?
:robot:

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 