### PR TITLE
Acceptance test: check for the tabs displayed in details of public share page

### DIFF
--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -821,3 +821,20 @@ Feature: Share by public link
       | element | name          |
       | folder  | simple-folder |
       | file    | lorem.txt     |
+
+  @issue-2090
+  Scenario: access details dialog of public share and check the tabs displayed
+    Given user "user1" has logged in using the webUI
+    When the user creates a new public link for folder "simple-folder" using the webUI with
+      | role | Editor |
+    And the public uses the webUI to access the last public link created by user "user1"
+    And the user picks the row of file "lorem.txt" in the webUI
+    Then the following tabs should be visible in the details dialog
+      | name          |
+      | versions      |
+      | links         |
+      | collaborators |
+#    Then the following tabs should not be visible in the details dialog
+#      | name          |
+#      | links         |
+#      | collaborators |

--- a/tests/acceptance/pageObjects/filesPage.js
+++ b/tests/acceptance/pageObjects/filesPage.js
@@ -246,6 +246,19 @@ module.exports = {
           callback(result.value)
         })
     },
+    getVisibleTabs: async function () {
+      const tabs = []
+      let elements
+      await this.api.elements('@tabsInSideBar', function (result) {
+        elements = result.value
+      })
+      for (const { ELEMENT } of elements) {
+        await this.api.elementIdText(ELEMENT, function (result) {
+          tabs.push(result.value.toLowerCase())
+        })
+      }
+      return tabs
+    },
     copyPermalinkFromFilesAppBar: function () {
       return this
         .waitForElementVisible('@permalinkCopyButton')
@@ -453,6 +466,10 @@ module.exports = {
     },
     restorePreviousVersion: {
       selector: '(//div[contains(@id,"oc-file-versions")]//tbody/tr[@class="file-row"])[1]//button[1]',
+      locateStrategy: 'xpath'
+    },
+    tabsInSideBar: {
+      selector: '//div[@class="sidebar-container"]//li/a',
       locateStrategy: 'xpath'
     }
   }

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -618,6 +618,15 @@ Then('the {string} details panel should be visible', function (panel) {
   })
 })
 
+Then('the following tabs should be visible in the details dialog', async function (table) {
+  const visibleTabs = await client.page.filesPage().getVisibleTabs()
+  const expectedVisibleTabs = table.rows()
+  const difference = _.difference(expectedVisibleTabs.flat(), visibleTabs)
+  if (difference.length !== 0) {
+    throw new Error(`${difference} tabs was expected to be visible but not found.`)
+  }
+})
+
 Then('no {string} tab should be available in the details panel', function (tab) {
   const tabSelector = client.page.filesPage().getXpathOfLinkToTabInSidePanel()
   return client.page.filesPage()


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
When public link share is accessed, ```collaborators```, ```links``` and ```versions``` tabs are visible. This PR adds an acceptance test to verify this scenario, which is a bug as addressed in this issue: https://github.com/owncloud/phoenix/issues/2090
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/phoenix/issues/2090

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
