### PR TITLE
Refactor filesPage page-object for assertion management

### DIFF
--- a/tests/acceptance/pageObjects/filesPage.js
+++ b/tests/acceptance/pageObjects/filesPage.js
@@ -1,7 +1,6 @@
 const util = require('util')
 const navigationHelper = require('../helpers/navigationHelper')
 const { join, normalize } = require('../helpers/path')
-const assert = require('assert')
 
 module.exports = {
   url: function () {
@@ -320,16 +319,15 @@ module.exports = {
     checkForButtonDisabled: function () {
       return this.waitForElementVisible('@createFileOkButtonDisabled')
     },
-    assertVersionsPresent: function (expectedNumber) {
-      if (expectedNumber !== 0) {
-        return this
-          .waitForElementVisible('@versionsList')
-          .api.elements('xpath', this.elements.versionsList.selector, function (result) {
-            assert.strictEqual(expectedNumber, result.value.length)
+    getVersionsCount: async function () {
+      let count = 0
+      await this
+        .api.elements(
+          '@versionsList',
+          function (result) {
+            count = result.value.length
           })
-      } else {
-        return this.waitForElementNotPresent('@versionsList')
-      }
+      return count
     },
     restoreToPreviousVersion: function () {
       return this

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -384,8 +384,11 @@ Then('the deleted elements should not be listed on the webUI after a page reload
   return assertDeletedElementsAreNotListed()
 })
 
-Then('the versions list should contain {int} entries', function (expectedNumber) {
-  return client.page.filesPage().assertVersionsPresent(expectedNumber)
+Then('the versions list should contain {int} entries', async function (expectedNumber) {
+  const count = await client.page.filesPage().getVersionsCount()
+  return assert.strictEqual(
+    expectedNumber, count
+  )
 })
 
 Then('the content of file {string} for user {string} should be {string}', async function (file, user, content) {


### PR DESCRIPTION
## Description
All the assertions from **filesPage** `page-objects` are moved to `respective contexts`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of #2508

## Motivation and Context
_Better Code = Life GooD_

## How Has This Been Tested?
CI

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 