### PR TITLE
Refactor ownCloudLoginPage for assertion management

### DIFF
--- a/tests/acceptance/pageObjects/ownCloudLoginPage.js
+++ b/tests/acceptance/pageObjects/ownCloudLoginPage.js
@@ -1,5 +1,3 @@
-const assert = require('assert')
-
 module.exports = {
   url: function () {
     return this.api.launchUrl
@@ -35,14 +33,18 @@ module.exports = {
           .setValue('@passwordInput', password)
           .click('@loginSubmitButton')
       },
-      assertLoginErrorMessage: async function (message) {
+      getLoginErrorMessage: async function () {
+        let errorMessage
         await this.api.assert.visible(this.elements.usernameInput.selector)
         await this.api.assert.visible(this.elements.passwordInput.selector)
         await this.api.assert.visible(this.elements.loginSubmitButton.selector)
-        return this.waitForElementVisible('@invalidCredentialsMessage')
-          .getText('@invalidCredentialsMessage', actualMessage => {
-            assert.strictEqual(message, actualMessage.value)
+        await this
+          .waitForElementVisible('@invalidCredentialsMessage')
+          .getText('@invalidCredentialsMessage', (result) => {
+            console.log(result)
+            errorMessage = result.value
           })
+        return errorMessage
       }
     }
   ]

--- a/tests/acceptance/pageObjects/ownCloudLoginPage.js
+++ b/tests/acceptance/pageObjects/ownCloudLoginPage.js
@@ -41,7 +41,6 @@ module.exports = {
         await this
           .waitForElementVisible('@invalidCredentialsMessage')
           .getText('@invalidCredentialsMessage', (result) => {
-            console.log(result)
             errorMessage = result.value
           })
         return errorMessage

--- a/tests/acceptance/stepDefinitions/loginContext.js
+++ b/tests/acceptance/stepDefinitions/loginContext.js
@@ -1,6 +1,7 @@
 const { client } = require('nightwatch-api')
 const { Given, Then, When } = require('cucumber')
 const loginHelper = require('../helpers/loginHelper')
+const assert = require('assert')
 
 Given(/^the user has browsed to the login page$/,
   () => {
@@ -40,8 +41,11 @@ Then('the files table should not be empty',
       .waitForElementVisible('@fileRows')
   })
 
-Then('the warning {string} should be displayed on the login page', function (message) {
-  return client.page.ownCloudLoginPage().assertLoginErrorMessage(message)
+Then('the warning {string} should be displayed on the login page', async function (expectedMessage) {
+  const actualMessage = await client.page.ownCloudLoginPage().getLoginErrorMessage()
+  return assert.strictEqual(
+    actualMessage, expectedMessage, `Error message miss-match, Expected: '${expectedMessage}', Found: '${actualMessage}'`
+  )
 })
 
 Then('the authentication page should be visible',


### PR DESCRIPTION
## Description
All the assertions from **ownCloudLoginPage** `page-objects` are moved to `respective contexts`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of #2508

## Motivation and Context
_Better Code = Life GooD_

## How Has This Been Tested?
CI

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 