### PR TITLE
Limit concurrent uploads to one

### DIFF
--- a/apps/files/src/components/PublicLinks/FilesDrop.vue
+++ b/apps/files/src/components/PublicLinks/FilesDrop.vue
@@ -145,14 +145,14 @@ export default {
       this.uploadedFilesChangeTracker++
       this.uploadedFiles.set(uploadId, { name: event.name, size: event.size, status: 'init' })
 
-      this.$client.publicFiles.putFileContents(this.publicLinkToken, event.name, this.publicLinkPassword, event, {
+      this.uploadQueue.add(() => this.$client.publicFiles.putFileContents(this.publicLinkToken, event.name, this.publicLinkPassword, event, {
         // automatically rename in case of duplicates
         headers: { 'OC-Autorename': 1 },
         onProgress: (progressEvent) => {
           this.uploadedFilesChangeTracker++
           this.uploadedFiles.set(uploadId, { name: event.name, size: event.size, status: 'uploading' })
         }
-      }).then(e => {
+      })).then(e => {
         this.uploadedFilesChangeTracker++
         this.uploadedFiles.set(uploadId, { name: event.name, size: event.size, status: 'done' })
       }).catch(e => {


### PR DESCRIPTION
## Description
Limit concurrent uploads to one to avoid clogging the network queue of the browser.
The progress bar is still added before the upload actually starts, but the SDK upload method is called only once the p-queue triggers it when it's its turn.

## Related Issue
Fixes https://github.com/owncloud/phoenix/issues/2594

## Motivation and Context
Unclog the browser network queue

## How Has This Been Tested?
- Test case 1: upload many files in regular files view and observe the network console:
    - before the fix: a lot of pending entries, laptop fan going crazy
    - after the fix: only one pending upload network call at a time
- Test case 2: like test case 1 but using the "upload-only" public link share (aka files-drop) because this has another code path

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

