### PR TITLE
Separate app switcher from app navigation sidebar

### DIFF
--- a/config.json.dist
+++ b/config.json.dist
@@ -9,5 +9,6 @@
   },
   "apps" : [
     "files"
-  ]
+  ],
+  "applications" : []
 }

--- a/config.json.sample
+++ b/config.json.sample
@@ -7,5 +7,15 @@
     "url": "https://demo.owncloud.com/index.php/apps/oauth2/api/v1/token",
     "authUrl": "https://demo.owncloud.com/index.php/apps/oauth2/authorize"
   },
-  "apps" : ["files"]
+  "apps" : ["files"],
+  "applications": [{
+    "title": {
+      "en": "Files",
+      "de": "Dateien",
+      "fr": "Fichiers",
+	  "zh_CN": "文件"
+    },
+    "icon": "folder",
+    "url": "http://demo.owncloud.com/index.html#/files/list"
+  }]
 }

--- a/src/Phoenix.vue
+++ b/src/Phoenix.vue
@@ -6,9 +6,9 @@
         <router-view name="fullscreen"></router-view>
       </template>
       <template v-else>
-        <message-bar />
-        <top-bar></top-bar>
-        <side-menu></side-menu>
+        <message-bar :active-messages="activeMessages" @deleteMessage="$_deleteMessage" />
+        <top-bar :applicationsList="$_applicationsList" :activeNotifications="activeNotifications" :user-id="user.id" :user-display-name="user.displayname" :hasAppNavigation="!!appNavigationEntries.length" @toggleAppNavigation="$_toggleAppNavigation(!appNavigationVisible)"></top-bar>
+        <side-menu :visible="appNavigationVisible" :entries="appNavigationEntries" @closed="$_toggleAppNavigation(false)"></side-menu>
         <main id="main">
           <router-view id="oc-app-container" name="app" class="uk-height-1-1"></router-view>
         </main>
@@ -31,6 +31,17 @@ export default {
     TopBar,
     SkipTo
   },
+  data () {
+    return {
+      appNavigationVisible: false,
+      $_notificationsInterval: null
+    }
+  },
+  destroyed () {
+    if (this.$_notificationsInterval) {
+      clearInterval(this.$_notificationsInterval)
+    }
+  },
   metaInfo () {
     const metaInfo = {
       title: this.configuration.theme.general.name
@@ -46,8 +57,28 @@ export default {
     this.initAuth()
   },
   computed: {
-    ...mapState(['route']),
-    ...mapGetters(['configuration']),
+    ...mapState(['route', 'user']),
+    ...mapGetters(['configuration', 'activeNotifications', 'activeMessages', 'capabilities']),
+    $_applicationsList () {
+      return this.configuration.applications
+    },
+
+    appNavigationEntries () {
+      if (this.publicPage()) {
+        return []
+      }
+      // FIXME: use store or other ways, not $root
+      return this.$root.navItems.filter(item => {
+        // FIXME: filter to only show current app
+        if (item.enabled === undefined) {
+          return true
+        }
+        if (this.capabilities === undefined) {
+          return false
+        }
+        return item.enabled(this.capabilities)
+      })
+    },
     showHeader () {
       return this.$route.meta.hideHeadbar !== true
     },
@@ -56,7 +87,40 @@ export default {
     }
   },
   methods: {
-    ...mapActions(['initAuth'])
+    ...mapActions(['initAuth', 'fetchNotifications', 'deleteMessage']),
+    $_toggleAppNavigation (state) {
+      this.appNavigationVisible = state
+    },
+    $_updateNotifications () {
+      this.fetchNotifications(this.$client).catch((error) => {
+        console.error('Error while loading notifications: ', error)
+        clearInterval(this.$_notificationsInterval)
+      })
+    },
+    $_deleteMessage (item) {
+      this.deleteMessage(item)
+    }
+  },
+  watch: {
+    $route () {
+      this.appNavigationVisible = false
+    },
+    capabilities (caps) {
+      if (!caps) {
+        // capabilities not loaded yet
+        return
+      }
+
+      // setup periodic loading of notifications if the server supports them
+      if (caps.notifications) {
+        this.$nextTick(() => {
+          this.$_updateNotifications()
+        })
+        this.$_notificationsInterval = setInterval(() => {
+          this.$_updateNotifications()
+        }, 30000)
+      }
+    }
   }
 }
 </script>

--- a/src/components/ApplicationsMenu.vue
+++ b/src/components/ApplicationsMenu.vue
@@ -1,0 +1,88 @@
+<template>
+  <div v-if="!!applicationsList.length">
+    <oc-button id="_appSwitcherButton" icon="apps" variation="primary" class="oc-topbar-menu-burger uk-height-1-1"  aria-label="$gettext('Application Switcher')" ref="menubutton" />
+    <oc-drop toggle="#_appSwitcherButton" mode="click" :options="{pos:'bottom-right'}" class="uk-width-large" ref="menu">
+      <div class="uk-grid-small uk-text-center" uk-grid>
+        <div class="uk-width-1-3" v-for="(n, nid) in $_applicationsList" :key="nid">
+          <a target="_blank" :href="n.url">
+            <oc-icon v-if="n.iconMaterial" :name="n.iconMaterial" size="large" />
+            <oc-icon v-if="n.iconUrl" :url="n.iconUrl" size="large" />
+            <div>{{ n.title }}</div>
+          </a>
+        </div>
+      </div>
+    </oc-drop>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    visible: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    applicationsList: {
+      type: Array,
+      required: false,
+      default: () => null
+    }
+  },
+  watch: {
+    visible (val) {
+      if (val) {
+        this.focusFirstLink()
+      } else {
+        this.$emit('closed')
+      }
+    }
+  },
+  computed: {
+    $_applicationsList () {
+      return this.applicationsList.map((item) => {
+        const lang = this.$language.current
+        // TODO: move language resolution to a common function
+        // FIXME: need to handle logic for variants like en_US vs en_GB
+        let title = item.title.en
+        let iconMaterial
+        let iconUrl
+        if (item.title[lang]) {
+          title = item.title[lang]
+        }
+
+        if (!item.icon) {
+          iconMaterial = 'deprecated' // broken icon
+        } else if (item.icon.indexOf('.') < 0) {
+          // not a file name or URL, treat as a material icon name instead
+          iconMaterial = item.icon
+        } else {
+          iconUrl = item.icon
+        }
+        return {
+          iconMaterial: iconMaterial,
+          iconUrl: iconUrl,
+          title: title,
+          url: item.url
+        }
+      })
+    }
+  },
+  methods: {
+    logout () {
+      this.visible = false
+      this.$store.dispatch('logout')
+    },
+    focusFirstLink () {
+      /*
+      * Delay for two reasons:
+      * - for screen readers Virtual buffer
+      * - to outsmart uikit's focus management
+      */
+      setTimeout(() => {
+        this.$refs.menu.$el.querySelector('a:first-of-type').focus()
+      }, 500)
+    }
+  }
+}
+</script>

--- a/src/components/Avatar.vue
+++ b/src/components/Avatar.vue
@@ -1,7 +1,7 @@
 <template>
-  <div v-if="enabled">
-    <oc-avatar :width=42 :height=42 :loading="loading" :src="avatarSource" />
-  </div>
+  <component :is="type" v-if="enabled">
+    <oc-avatar :width="width" :height="width" :loading="loading" :src="avatarSource" />
+  </component>
 </template>
 <script>
 import { mapGetters } from 'vuex'
@@ -73,11 +73,27 @@ export default {
     }
   },
   props: {
+    /**
+     * The html element used for the avatar container.
+     * `div, span`
+     */
+    type: {
+      type: String,
+      default: 'div',
+      validator: value => {
+        return value.match(/(div|span)/)
+      }
+    },
     userid: {
       /**
        * Allow empty string to show placeholder
        */
       default: ''
+    },
+    width: {
+      type: Number,
+      required: false,
+      default: 42
     }
   }
 }

--- a/src/components/MessageBar.vue
+++ b/src/components/MessageBar.vue
@@ -15,15 +15,20 @@
 </template>
 
 <script>
-import { mapGetters, mapActions } from 'vuex'
-
 export default {
+  props: {
+    activeMessages: {
+      type: Array,
+      required: false,
+      default: () => []
+    }
+  },
   methods: {
-    ...mapActions(['deleteMessage'])
+    deleteMessage (item) {
+      this.$emit('deleteMessage', item)
+    }
   },
   computed: {
-    ...mapGetters(['activeMessages']),
-
     $_ocMessages_limited () {
       return this.activeMessages ? this.activeMessages.slice(0, 5) : []
     }

--- a/src/components/UserMenu.vue
+++ b/src/components/UserMenu.vue
@@ -1,0 +1,88 @@
+<template>
+  <div>
+    <oc-button id="_userMenuButton" class="oc-topbar-personal uk-height-1-1" variation="primary" aria-label="$gettext('User Menu')" ref="menuButton">
+      <avatar type="span" class="oc-topbar-personal-avatar" :userid="userId" />
+      <span class="oc-topbar-personal-label">{{ userDisplayName }}</span>
+    </oc-button>
+    <oc-drop toggle="#_userMenuButton" mode="click" :options="{pos:'bottom-right'}" class="uk-width-large" ref="menu">
+      <div class="uk-card-body uk-flex uk-flex-middle uk-flex-column">
+        <avatar
+          :userid="userId"
+          :width="128"
+        />
+        <h3 class="uk-card-title">{{ userDisplayName }}</h3>
+        <span v-if="userEmail">{{ userEmail }}</span>
+        <router-link to="/account" target="_blank"><translate>Manage your account</translate></router-link>
+        <br/>
+        <oc-button id="logoutMenuItem" type="a" @click="logout()"><translate>Log out</translate></oc-button>
+      </div>
+      <div class="uk-card-footer uk-flex uk-flex-middle uk-flex-column">
+        <span>Version: {{appVersion.version}}-{{appVersion.hash}} ({{appVersion.buildDate}})</span>
+      </div>
+    </oc-drop>
+  </div>
+</template>
+
+<script>
+import appVersionJson from '../../build/version.json'
+import Avatar from './Avatar.vue'
+
+export default {
+  components: {
+    Avatar
+  },
+  props: {
+    userId: {
+      type: String,
+      required: true
+    },
+    userDisplayName: {
+      type: String,
+      required: true
+    },
+    userEmail: {
+      type: String,
+      required: false,
+      default: null
+    }
+  },
+  data () {
+    return {
+      appVersion: appVersionJson
+    }
+  },
+  watch: {
+    visible (val) {
+      if (val) {
+        this.focusFirstLink()
+      } else {
+        this.$emit('closed')
+      }
+    }
+  },
+  methods: {
+    logout () {
+      this.visible = false
+      this.$store.dispatch('logout')
+    },
+    openItem (url) {
+      if (url) {
+        const win = window.open(url, '_blank')
+        if (win) {
+          win.focus()
+        }
+      }
+    },
+    focusFirstLink () {
+      /*
+      * Delay for two reasons:
+      * - for screen readers Virtual buffer
+      * - to outsmart uikit's focus management
+      */
+      setTimeout(() => {
+        this.$refs.menuButton.$el.querySelector('a:first-of-type').focus()
+      }, 500)
+    }
+  }
+}
+</script>

--- a/src/phoenix.js
+++ b/src/phoenix.js
@@ -152,12 +152,7 @@ function loadApps () {
     silent: true
   })
 
-  // add menu items from config,json
   navItems = navItems.flat()
-  if (config.menu && config.menu.items) {
-    navItems= navItems.concat(config.menu.items)
-  }
-
   const OC = new Vue({
     el: '#owncloud',
     data: {

--- a/src/store/app.js
+++ b/src/store/app.js
@@ -1,5 +1,4 @@
 const state = {
-  sidebarVisible: false,
   messages: [],
   notifications: {
     loading: true,
@@ -61,9 +60,6 @@ const actions = {
 }
 
 const mutations = {
-  TOGGLE_SIDEBAR (state, visible) {
-    state.sidebarVisible = visible
-  },
   ENQUEUE_MESSAGE (state, message) {
     // set random id to improve iteration in v-for & lodash
     if (!message.id) message.id = Math.random().toString(36).slice(2, -1)
@@ -90,9 +86,6 @@ const mutations = {
 }
 
 const getters = {
-  isSidebarVisible: state => {
-    return state.sidebarVisible
-  },
   activeMessages: state => {
     return state.messages
   },

--- a/src/store/config.js
+++ b/src/store/config.js
@@ -43,6 +43,7 @@ const mutations = {
     state.openIdConnect = config.openIdConnect
     state.rootFolder = config.rootFolder === undefined ? '/' : config.rootFolder
     state.state = config.state === undefined ? 'working' : config.state
+    state.applications = config.applications === undefined ? [] : config.applications
     if (config.corrupted) state.corrupted = config.corrupted
   },
   LOAD_THEME (state, theme) {

--- a/tests/acceptance/helpers/loginHelper.js
+++ b/tests/acceptance/helpers/loginHelper.js
@@ -43,8 +43,8 @@ module.exports = {
     const phoenixPage = client.page.phoenixPage()
     return phoenixPage
       .navigate()
-      .waitForElementVisible('@menuButton')
-      .click('@menuButton')
+      .waitForElementVisible('@userMenuButton')
+      .click('@userMenuButton')
       .waitForElementVisible('@logoutMenuItem')
       .waitForAnimationToFinish()
       .click('@logoutMenuItem')

--- a/tests/acceptance/pageObjects/phoenixPage.js
+++ b/tests/acceptance/pageObjects/phoenixPage.js
@@ -195,6 +195,9 @@ module.exports = {
     searchLoadingIndicator: {
       selector: '.oc-app-bar .uk-spinner'
     },
+    userMenuButton: {
+      selector: '#_userMenuButton'
+    },
     menuButton: {
       selector: '//button[@aria-label="Menu"]',
       locateStrategy: 'xpath'


### PR DESCRIPTION
## Description
- App switcher now appears on the top right, items need to be configured in config.json's "menu/items" section
- Account + Logout now appear in the new User menu on the top right under the user's avatar
- Left sidebar now only contains the current apps' menu items

## Related Issue
Fixes https://github.com/owncloud/phoenix/issues/2650

## Motivation and Context
See ticket

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [x] Fix styles, it currently looks ugly
- [x] Align config format for application menu with spec: https://github.com/owncloud/phoenix/issues/2650#issuecomment-564126465
- [x] Proper icon for the app switcher (need icon in design system first)
- [x] Solve l10n for menu entries
- [x] Properly wire up the "/account" route
- [x] Issues when toggling multiple dropdowns / sidebar. Need proper exclusion
- [x] Clicking sidebar entry must close it
- [ ] Optional: Filter sidebar entries to only contain entries from the currently visible app
- [ ] Optional: better way for passing in attributes from outside like the current user ?! Or access global store directly ? We need to keep encapsulation to be able to use those as web components later on
- [ ] top left menu label should state the name of the current app instead of just "Menu". keep the label there even if there is no menu
- [x] See other TODOs