### PR TITLE
Refactor phoenixPage for assertion management

### DIFF
--- a/tests/acceptance/pageObjects/phoenixPage.js
+++ b/tests/acceptance/pageObjects/phoenixPage.js
@@ -1,6 +1,4 @@
-const assert = require('assert')
 const util = require('util')
-const userSettings = require('../helpers/userSettings')
 
 module.exports = {
   url: function () {
@@ -59,6 +57,11 @@ module.exports = {
     toggleNotificationDrawer: async function () {
       return this.waitForElementVisible('@notificationBell').click('@notificationBell')
     },
+    /**
+     * gets list of notifications
+     *
+     * @return {Promise<array>}
+     */
     getNotifications: async function () {
       const notifications = []
       await this.toggleNotificationDrawer()
@@ -73,20 +76,6 @@ module.exports = {
       return notifications
     },
     /**
-     * Checks if the notifications consists of all the expected notifications
-     * @param {string} expectedNotifications
-     */
-    assertNotificationIsPresent: async function (numberOfNotifications, expectedNotifications) {
-      const notifications = await this.getNotifications()
-      assert.strictEqual(notifications.length, numberOfNotifications)
-      const promises = []
-      for (const element of expectedNotifications) {
-        const isPresent = notifications.includes(userSettings.replaceInlineCode(element.title))
-        promises.push(this.assert.ok(isPresent))
-      }
-      return Promise.all(promises)
-    },
-    /**
      * Perform accept action on the offered shares in the notifications
      */
     acceptAllSharesInNotification: async function () {
@@ -99,14 +88,26 @@ module.exports = {
           .waitForElementVisible(acceptShareButton)
           .click(acceptShareButton)
           .waitForAjaxCallsToStartAndFinish()
+          .useCss()
       }
     },
     /**
-     * Checks to assert the notification bell is not present as well as no notifications are present
+     * notification bell is present only when the user have got some notifications to show
+     * after clicking the notification bell then only user can see notifications received
+     * So,there would be no notifications when the notification bell on the top-bar of webUI is not visible
+     *
+     * @return boolean
      */
-    assertNoNotifications: function () {
-      return this.waitForElementNotPresent('@notificationBell')
-        .assert.elementNotPresent(this.elements.notificationElement)
+    isNotificationBellVisible: async function () {
+      let isVisible = false
+      await this
+        .api.element(
+          '@notificationBell',
+          result => {
+            isVisible = result.value === 0
+          }
+        )
+      return isVisible
     },
     /**
      * Perform decline action on the offered shares in the notifications

--- a/tests/acceptance/stepDefinitions/notificationsContext.js
+++ b/tests/acceptance/stepDefinitions/notificationsContext.js
@@ -1,7 +1,9 @@
 const { client } = require('nightwatch-api')
 const { Given, When, Then } = require('cucumber')
 const httpHelper = require('../helpers/httpHelper')
+const userSettings = require('../helpers/userSettings')
 const fetch = require('node-fetch')
+const assert = require('assert')
 
 When('user {string} is sent a notification', function (user) {
   const body = new URLSearchParams()
@@ -51,11 +53,24 @@ Then('the notification bell should disappear on the webUI', function () {
   return client.page.phoenixPage().waitForElementNotPresent('@notificationBell')
 })
 
-Then('the user should see {int} notifications on the webUI with these details', function (numberOfNotifications, dataTable) {
-  const dataTableHashed = dataTable.hashes()
-  return client.page.phoenixPage().assertNotificationIsPresent(numberOfNotifications, dataTableHashed)
-})
+Then('the user should see {int} notifications on the webUI with these details',
+  async function (numberOfNotifications, dataTable) {
+    const expectedNotifications = dataTable.hashes()
+    const notifications = await client.page.phoenixPage().getNotifications()
+    assert.strictEqual(
+      notifications.length,
+      numberOfNotifications,
+      'Notification count miss-match!'
+    )
+    for (const element of expectedNotifications) {
+      const isPresent = notifications.includes(userSettings.replaceInlineCode(element.title))
+      assert.ok(
+        isPresent,
+        `Expected: '${element.title}' to be present but found: not present in ${notifications}`)
+    }
+  })
 
-Then('the user should have no notifications', function () {
-  return client.page.phoenixPage().assertNoNotifications()
+Then('the user should have no notifications', async function () {
+  const status = await client.page.phoenixPage().isNotificationBellVisible()
+  assert.ok(!status, 'Expected: notification bell to be absent but found: visible')
 })


### PR DESCRIPTION
## Description
All the assertions from **phoenixPage** `page-objects` are moved to `respective contexts`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of #2508

## Motivation and Context
_Better Code = Life GooD_

## How Has This Been Tested?
CI

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 