### PR TITLE
Refactor publicLinkPasswordPage for assertion management

### DIFF
--- a/tests/acceptance/pageObjects/publicLinkPasswordPage.js
+++ b/tests/acceptance/pageObjects/publicLinkPasswordPage.js
@@ -36,21 +36,33 @@ module.exports = {
           .waitForElementPresent({ selector: '@filesListProgressBar', abortOnFailure: false }) // don't fail if we are too late
           .waitForElementNotPresent('@filesListProgressBar')
       },
-      assertResourceAccessDenied: function () {
+      /**
+       * submits the public link password input form
+       * this is made for those scenarios where we submit wrong password in previous steps and webUI doesn't navigate to files-page
+       */
+      submitLinkPasswordForm: function () {
         return this
-          .waitForElementPresent('@passwordSubmitButton')
+          .initAjaxCounters()
+          .waitForElementVisible('@passwordInput')
           .click('@passwordSubmitButton')
-          .waitForElementVisible('@loadingPublicLink')
-          .waitForElementPresent('@passwordInput')
+          .waitForOutstandingAjaxCalls()
+      },
+      /**
+       * gets resource access denied message after clicking submit password button for a public link share
+       *
+       * @return {Promise<string>}
+       */
+      getResourceAccessDeniedMsg: async function () {
+        let message
+        await this
+          .waitForElementVisible('@passwordSubmitButton')
           .getText(
-            this.elements.resourceProtectedText.locateStrategy,
-            this.elements.resourceProtectedText.selector,
+            '@resourceProtectedText',
             (result) => {
-              if (result.value !== 'This resource is password-protected.') {
-                throw new Error('Resource Protected Message Invalid', result)
-              }
+              message = result.value
             }
           )
+        return message
       }
     }
   ]

--- a/tests/acceptance/stepDefinitions/publicLinkContext.js
+++ b/tests/acceptance/stepDefinitions/publicLinkContext.js
@@ -86,11 +86,17 @@ Then('as user {string} the folder {string} should not have any public link', asy
   return this
 })
 
-Then('the public should not get access to the publicly shared file', function () {
-  return client
+Then('the public should not get access to the publicly shared file', async function () {
+  const message = await client
     .page
     .publicLinkPasswordPage()
-    .assertResourceAccessDenied()
+    .submitLinkPasswordForm() // form is submitted as password input is filled in the step before this particular step in 'when' part
+    .getResourceAccessDeniedMsg()
+  return assert.strictEqual(
+    'This resource is password-protected.',
+    message,
+    'Resource protected message invalid, Found: ', message
+  )
 })
 
 When('the user edits the public link named {string} of file/folder/resource {string} changing following but not saving',


### PR DESCRIPTION
## Description
All the assertions from **publicLinkPasswordPage** `page-objects` are moved to `respective contexts`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of #2508

## Motivation and Context
_Better Code = Life GooD_

## How Has This Been Tested?
CI

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 