### PR TITLE
Assertion refactor shared with me page

### DIFF
--- a/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
+++ b/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
@@ -207,7 +207,7 @@ Feature: accept/decline shares coming from internal users
     Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
     And user "user1" has shared file "lorem.txt" with user "user2"
     When the user browses to the shared-with-me page using the webUI
-    Then the file "lorem.txt" should be in "Pending" state on the webUI
+    Then file "lorem.txt" shared by "User One" should be in "Pending" state on the webUI
     When the user browses to the files page
     Then file "lorem (2).txt" should not be listed on the webUI
 
@@ -215,7 +215,7 @@ Feature: accept/decline shares coming from internal users
     Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
     And user "user1" has shared file "lorem.txt" with user "user2"
     When the user browses to the shared-with-me page using the webUI
-    Then the file "lorem.txt" should be in "Pending" state on the webUI
+    Then file "lorem.txt" shared by "User One" should be in "Pending" state on the webUI
     When the user browses to the files page
     Then file "lorem (2).txt" should not be listed on the webUI
 
@@ -234,8 +234,8 @@ Feature: accept/decline shares coming from internal users
     And user "user1" has shared file "testimage.jpg" with user "user2"
     And the user has browsed to the shared-with-me page
     When the user declines share "lorem.txt" offered by user "User One" using the webUI
-    Then the file "lorem.txt" should be in "Declined" state on the webUI
-    And the file "testimage.jpg" should be in "Pending" state on the webUI
+    Then file "lorem.txt" shared by "User One" should be in "Declined" state on the webUI
+    And file "testimage.jpg" shared by "User One" should be in "Pending" state on the webUI
     When the user browses to the files page
     Then file "lorem (2).txt" should not be listed on the webUI
     And file "testimage (2).jpg" should not be listed on the webUI
@@ -246,10 +246,10 @@ Feature: accept/decline shares coming from internal users
     And user "user1" has shared file "testimage.jpg" with user "user2"
     And the user has browsed to the shared-with-me page
     When the user accepts share "lorem.txt" offered by user "User One" using the webUI
-    Then the file "lorem (2).txt" should be in "Accepted" state on the webUI
-    And the file "testimage.jpg" should be in "Pending" state on the webUI
-    And the file "lorem (2).txt" should be in "Accepted" state on the webUI after a page reload
-    And the file "testimage.jpg" should be in "Pending" state on the webUI after a page reload
+    Then file "lorem (2).txt" shared by "User One" should be in "Accepted" state on the webUI
+    And file "testimage.jpg" shared by "User One" should be in "Pending" state on the webUI
+    And the file "lorem (2).txt" shared by "User One" should be in "Accepted" state on the webUI after a page reload
+    And the file "testimage.jpg" shared by "User One" should be in "Pending" state on the webUI after a page reload
     When the user browses to the files page
     Then file "lorem (2).txt" should be listed on the webUI
     And file "testimage (2).jpg" should not be listed on the webUI
@@ -261,8 +261,8 @@ Feature: accept/decline shares coming from internal users
     And user "user2" has declined the share "lorem.txt" offered by user "user1"
     And the user has browsed to the shared-with-me page
     When the user accepts share "lorem.txt" offered by user "User One" using the webUI
-    Then the file "lorem (2).txt" should be in "Accepted" state on the webUI
-    And the file "testimage.jpg" should be in "Pending" state on the webUI
+    Then file "lorem (2).txt" shared by "User One" should be in "Accepted" state on the webUI
+    And file "testimage.jpg" shared by "User One" should be in "Pending" state on the webUI
     When the user browses to the files page
     Then file "lorem (2).txt" should be listed on the webUI
     And file "testimage (2).jpg" should not be listed on the webUI
@@ -278,8 +278,8 @@ Feature: accept/decline shares coming from internal users
     Then file "lorem (2).txt" should not be listed on the webUI
     And file "testimage (2).jpg" should not be listed on the webUI
     When the user browses to the shared-with-me page using the webUI
-    Then the file "lorem.txt" should be in "Declined" state on the webUI
-    And the file "testimage.jpg" should be in "Pending" state on the webUI
+    Then file "lorem.txt" shared by "User One" should be in "Declined" state on the webUI
+    And file "testimage.jpg" shared by "User One" should be in "Pending" state on the webUI
 
   Scenario:  shared file status is changed to declined when user deletes the file
     Given user "user1" has shared file "lorem.txt" with user "user2"

--- a/tests/acceptance/features/webUISharingNotifications/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingNotifications/shareWithUsers.feature
@@ -42,8 +42,8 @@ Feature: Sharing files and folders with internal users
     Then folder "simple-folder (2)" should be listed on the webUI
     And folder "simple-empty-folder (2)" should be listed on the webUI
     When the user browses to the shared-with-me page using the webUI
-    Then the folder "simple-folder (2)" should be in "Accepted" state on the webUI
-    And the folder "simple-empty-folder (2)" should be in "Accepted" state on the webUI
+    Then folder "simple-folder (2)" shared by "User One" should be in "Accepted" state on the webUI
+    And folder "simple-empty-folder (2)" shared by "User One" should be in "Accepted" state on the webUI
 
   @smokeTest
   Scenario: reject an offered share
@@ -55,6 +55,6 @@ Feature: Sharing files and folders with internal users
     Then folder "simple-folder (2)" should not be listed on the webUI
     And folder "simple-empty-folder (2)" should not be listed on the webUI
     When the user browses to the shared-with-me page using the webUI
-    Then the folder "simple-folder" should be in "Declined" state on the webUI
-    And the folder "simple-empty-folder" should be in "Declined" state on the webUI
+    Then folder "simple-folder" shared by "User One" should be in "Declined" state on the webUI
+    And folder "simple-empty-folder" shared by "User One" should be in "Declined" state on the webUI
 

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -760,15 +760,16 @@ Then('the collaborators list for file/folder/resource {string} should be empty',
   assert.strictEqual(count, 0, `Expected to have no collaborators for '${resource}', Found: ${count}`)
 })
 
-Then('the file/folder/resource {string} should be in {string} state on the webUI', function (filename, status) {
-  status = status === 'Accepted' ? '' : status
-  return client.page.sharedWithMePage().assertDesiredStatusIsPresent(filename, status)
-})
-
-Then('file/folder {string} shared by {string} should be in {string} state on the webUI', function (element, user, status) {
-  status = status === 'Accepted' ? '' : status
-  return client.page.sharedWithMePage().assertDesiredStatusIsPresent(element, status, user)
-})
+Then('file/folder {string} shared by {string} should be in {string} state on the webUI',
+  async function (resource, sharer, expectedStatus) {
+    const currentStatus = await client.page.sharedWithMePage().getShareStatusOfResource(resource, sharer)
+    return assert.strictEqual(
+      currentStatus,
+      expectedStatus,
+      `Expected resource '${resource}' shared by '${sharer}' to be
+      in state '${expectedStatus}' but it is in state: '${currentStatus}'!`
+    )
+  })
 
 When('the user declines share {string} offered by user {string} using the webUI', function (filename, user) {
   return client.page.sharedWithMePage().declineAcceptFile('Decline', filename, user)
@@ -778,11 +779,17 @@ When('the user accepts share {string} offered by user {string} using the webUI',
   return client.page.sharedWithMePage().declineAcceptFile('Accept', filename, user)
 })
 
-Then('the file {string} should be in {string} state on the webUI after a page reload', async function (filename, status) {
-  status = status === 'Accepted' ? '' : status
-  await client.refresh()
-  return client.page.sharedWithMePage().assertDesiredStatusIsPresent(filename, status)
-})
+Then('the file {string} shared by {string} should be in {string} state on the webUI after a page reload',
+  async function (filename, sharer, expectedStatus) {
+    await client.refresh()
+    const currentStatus = await client.page.sharedWithMePage().getShareStatusOfResource(filename, sharer)
+    return assert.strictEqual(
+      currentStatus,
+      expectedStatus,
+      `Expected resource '${filename}'  shared by '${sharer}' to
+       be in state '${expectedStatus}' but it is in state: '${currentStatus}'!`
+    )
+  })
 
 Then('the autocomplete list should not be displayed on the webUI', function () {
   return client.page.FilesPageElement.sharingDialog().assertAutocompleteListIsNotVisible()
@@ -796,13 +803,26 @@ Given('user {string} has accepted the share {string} offered by user {string}', 
   return sharingHelper.acceptShare(filename, user, sharer)
 })
 
-Then('the file {string} shared by {string} should not be in {string} state', function (filename, sharer, status) {
-  return client.page.sharedWithMePage().assertDesiredStatusIsAbsent(filename, sharer, status)
-})
+Then('the file {string} shared by {string} should not be in {string} state',
+  async function (filename, sharer, expectedStatus) {
+    const currentStatus = await client.page.sharedWithMePage().getShareStatusOfResource(filename, sharer)
+    return assert.notStrictEqual(
+      currentStatus,
+      expectedStatus,
+      `Expected resource '${filename}' shared by '${sharer}' not to be
+      present with status '${expectedStatus}' but got found: '${currentStatus}'!`
+    )
+  })
 
-Then('file/folder {string} should be marked as shared by {string} on the webUI', function (element, sharer) {
-  return client.page.sharedWithMePage().assertSharedByUser(element, sharer)
-})
+Then('file/folder {string} should be marked as shared by {string} on the webUI',
+  async function (element, sharer) {
+    const username = await client.page.sharedWithMePage().getSharedByUser(element)
+    return assert.strictEqual(
+      username,
+      sharer,
+      `Expected username: '${sharer}', but found '${username}'`
+    )
+  })
 
 Then('user {string} should not have created any shares', async function (user) {
   const shares = await sharingHelper.getAllSharesSharedByUser(user)


### PR DESCRIPTION
## Description
All the assertions from **sharedWithMePage** `page-objects` are moved to `respective contexts`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of #2508

## Motivation and Context
_Better Code = Life GooD_

## How Has This Been Tested?
CI

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 