### PR TITLE
Change oc-search-bar implementation, see ODS PR #512

### DIFF
--- a/apps/files/src/components/FilesAppBar.vue
+++ b/apps/files/src/components/FilesAppBar.vue
@@ -17,6 +17,7 @@
           :value="searchTerm"
           :label="searchLabel"
           :loading="isLoadingSearch"
+          buttonHidden="true"
           :button="false"
           @clear="onSearchClear"
           :key="searchBarKey"


### PR DESCRIPTION
Usage of `buttonHidden` prop in `oc-search-bar`, context: https://github.com/owncloud/owncloud-design-system/pull/512/files#diff-5f4324b6a0a736af3ec6c1a6a5388987R102