### PR TITLE
pin selenium container version to 3.141.59-xenon

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -391,7 +391,7 @@ def browserService(alternateSuiteName, browser):
 	if browser == 'chrome':
 		return [{
 			'name': 'selenium',
-			'image': 'selenium/standalone-chrome-debug:latest',
+			'image': 'selenium/standalone-chrome-debug:3.141.59-xenon',
 			'pull': 'always',
 			'volumes': [{
 				'name': 'uploads',
@@ -402,7 +402,7 @@ def browserService(alternateSuiteName, browser):
 	if browser == 'firefox':
 		return [{
 			'name': 'selenium',
-			'image': 'selenium/standalone-firefox-debug:latest',
+			'image': 'selenium/standalone-firefox-debug:3.141.59-xenon',
 			'pull': 'always',
 			'volumes': [{
 				'name': 'uploads',

--- a/.drone.yml
+++ b/.drone.yml
@@ -212,7 +212,7 @@ services:
 
 - name: selenium
   pull: always
-  image: selenium/standalone-chrome-debug:latest
+  image: selenium/standalone-chrome-debug:3.141.59-xenon
   volumes:
   - name: uploads
     path: /uploads
@@ -421,7 +421,7 @@ services:
 
 - name: selenium
   pull: always
-  image: selenium/standalone-chrome-debug:latest
+  image: selenium/standalone-chrome-debug:3.141.59-xenon
   volumes:
   - name: uploads
     path: /uploads
@@ -630,7 +630,7 @@ services:
 
 - name: selenium
   pull: always
-  image: selenium/standalone-chrome-debug:latest
+  image: selenium/standalone-chrome-debug:3.141.59-xenon
   volumes:
   - name: uploads
     path: /uploads
@@ -839,7 +839,7 @@ services:
 
 - name: selenium
   pull: always
-  image: selenium/standalone-chrome-debug:latest
+  image: selenium/standalone-chrome-debug:3.141.59-xenon
   volumes:
   - name: uploads
     path: /uploads
@@ -1048,7 +1048,7 @@ services:
 
 - name: selenium
   pull: always
-  image: selenium/standalone-chrome-debug:latest
+  image: selenium/standalone-chrome-debug:3.141.59-xenon
   volumes:
   - name: uploads
     path: /uploads
@@ -1257,7 +1257,7 @@ services:
 
 - name: selenium
   pull: always
-  image: selenium/standalone-chrome-debug:latest
+  image: selenium/standalone-chrome-debug:3.141.59-xenon
   volumes:
   - name: uploads
     path: /uploads
@@ -1466,7 +1466,7 @@ services:
 
 - name: selenium
   pull: always
-  image: selenium/standalone-chrome-debug:latest
+  image: selenium/standalone-chrome-debug:3.141.59-xenon
   volumes:
   - name: uploads
     path: /uploads
@@ -1675,7 +1675,7 @@ services:
 
 - name: selenium
   pull: always
-  image: selenium/standalone-chrome-debug:latest
+  image: selenium/standalone-chrome-debug:3.141.59-xenon
   volumes:
   - name: uploads
     path: /uploads
@@ -1884,7 +1884,7 @@ services:
 
 - name: selenium
   pull: always
-  image: selenium/standalone-chrome-debug:latest
+  image: selenium/standalone-chrome-debug:3.141.59-xenon
   volumes:
   - name: uploads
     path: /uploads
@@ -2093,7 +2093,7 @@ services:
 
 - name: selenium
   pull: always
-  image: selenium/standalone-chrome-debug:latest
+  image: selenium/standalone-chrome-debug:3.141.59-xenon
   volumes:
   - name: uploads
     path: /uploads
@@ -2302,7 +2302,7 @@ services:
 
 - name: selenium
   pull: always
-  image: selenium/standalone-chrome-debug:latest
+  image: selenium/standalone-chrome-debug:3.141.59-xenon
   volumes:
   - name: uploads
     path: /uploads
@@ -2511,7 +2511,7 @@ services:
 
 - name: selenium
   pull: always
-  image: selenium/standalone-chrome-debug:latest
+  image: selenium/standalone-chrome-debug:3.141.59-xenon
   volumes:
   - name: uploads
     path: /uploads
@@ -2720,7 +2720,7 @@ services:
 
 - name: selenium
   pull: always
-  image: selenium/standalone-chrome-debug:latest
+  image: selenium/standalone-chrome-debug:3.141.59-xenon
   volumes:
   - name: uploads
     path: /uploads
@@ -2929,7 +2929,7 @@ services:
 
 - name: selenium
   pull: always
-  image: selenium/standalone-chrome-debug:latest
+  image: selenium/standalone-chrome-debug:3.141.59-xenon
   volumes:
   - name: uploads
     path: /uploads
@@ -3138,7 +3138,7 @@ services:
 
 - name: selenium
   pull: always
-  image: selenium/standalone-chrome-debug:latest
+  image: selenium/standalone-chrome-debug:3.141.59-xenon
   volumes:
   - name: uploads
     path: /uploads
@@ -3347,7 +3347,7 @@ services:
 
 - name: selenium
   pull: always
-  image: selenium/standalone-chrome-debug:latest
+  image: selenium/standalone-chrome-debug:3.141.59-xenon
   volumes:
   - name: uploads
     path: /uploads
@@ -3556,7 +3556,7 @@ services:
 
 - name: selenium
   pull: always
-  image: selenium/standalone-chrome-debug:latest
+  image: selenium/standalone-chrome-debug:3.141.59-xenon
   volumes:
   - name: uploads
     path: /uploads
@@ -3765,7 +3765,7 @@ services:
 
 - name: selenium
   pull: always
-  image: selenium/standalone-chrome-debug:latest
+  image: selenium/standalone-chrome-debug:3.141.59-xenon
   volumes:
   - name: uploads
     path: /uploads
@@ -3974,7 +3974,7 @@ services:
 
 - name: selenium
   pull: always
-  image: selenium/standalone-chrome-debug:latest
+  image: selenium/standalone-chrome-debug:3.141.59-xenon
   volumes:
   - name: uploads
     path: /uploads
@@ -4183,7 +4183,7 @@ services:
 
 - name: selenium
   pull: always
-  image: selenium/standalone-chrome-debug:latest
+  image: selenium/standalone-chrome-debug:3.141.59-xenon
   volumes:
   - name: uploads
     path: /uploads
@@ -4392,7 +4392,7 @@ services:
 
 - name: selenium
   pull: always
-  image: selenium/standalone-chrome-debug:latest
+  image: selenium/standalone-chrome-debug:3.141.59-xenon
   volumes:
   - name: uploads
     path: /uploads
@@ -4601,7 +4601,7 @@ services:
 
 - name: selenium
   pull: always
-  image: selenium/standalone-chrome-debug:latest
+  image: selenium/standalone-chrome-debug:3.141.59-xenon
   volumes:
   - name: uploads
     path: /uploads
@@ -4849,7 +4849,7 @@ services:
 
 - name: selenium
   pull: always
-  image: selenium/standalone-chrome-debug:latest
+  image: selenium/standalone-chrome-debug:3.141.59-xenon
   volumes:
   - name: uploads
     path: /uploads
@@ -5058,7 +5058,7 @@ services:
 
 - name: selenium
   pull: always
-  image: selenium/standalone-chrome-debug:latest
+  image: selenium/standalone-chrome-debug:3.141.59-xenon
   volumes:
   - name: uploads
     path: /uploads
@@ -5267,7 +5267,7 @@ services:
 
 - name: selenium
   pull: always
-  image: selenium/standalone-chrome-debug:latest
+  image: selenium/standalone-chrome-debug:3.141.59-xenon
   volumes:
   - name: uploads
     path: /uploads


### PR DESCRIPTION
## Description
pin the selenium container to a version known to work

## Motivation and Context
the latest version of the selenium container has a problem to create screenshots and crashes

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...