### PR TITLE
Implement all (except one) federation sharing tests

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -237,6 +237,10 @@ def acceptance():
 				for browser in params['browsers']:
 					for db in params['databases']:
 						federatedServerVersion = params['federatedServerVersion']
+						federationDbSuffix = '-federated'
+
+						if params['federatedServerNeeded'] and getDbName(db) not in ['mariadb', 'mysql']:
+							errorFound = True
 
 						browserString = '' if browser == '' else '-' + browser
 						name = '%s%s' % (alternateSuiteName, browserString)
@@ -262,7 +266,7 @@ def acceptance():
 								owncloudLog() +
 								fixPermissions() +
 								(
-									installFederatedServer(federatedServerVersion, db) +
+									installFederatedServer(federatedServerVersion, db, federationDbSuffix) +
 									setupFedServerAndApp(params['logLevel']) +
 									fixPermissionsFederated() +
 									owncloudLogFederated() if params['federatedServerNeeded'] else []
@@ -273,7 +277,9 @@ def acceptance():
 								phoenixService() +
 								owncloudService() +
 								(
-									owncloudFederatedService() if params['federatedServerNeeded'] else []
+									owncloudFederatedService() +
+									databaseServiceForFederation(db, federationDbSuffix)
+									if params['federatedServerNeeded'] else []
 								) +
 								browserService(alternateSuiteName, browser) +
 								databaseService(db),
@@ -342,6 +348,26 @@ def notify():
 		result['trigger']['ref'].append('refs/heads/%s' % branch)
 
 	return result
+
+def databaseServiceForFederation(db, suffix):
+	dbName = getDbName(db)
+
+	# only support mariadb, for phoenix, it's not important to support others
+	if dbName not in ['mariadb', 'mysql']:
+		print('Not implemented federated database for', dbName)
+		return []
+
+	return [{
+		'name': dbName + suffix,
+		'image': db,
+		'pull': 'always',
+		'environment': {
+			'MYSQL_USER': getDbUsername(db),
+			'MYSQL_PASSWORD': getDbPassword(db),
+			'MYSQL_DATABASE': getDbDatabase(db) + suffix,
+			'MYSQL_ROOT_PASSWORD': getDbRootPassword()
+		}
+	}]
 
 def databaseService(db):
 	dbName = getDbName(db)
@@ -553,7 +579,21 @@ def installCore(version, db):
 
 	return [stepDefinition]
 
-def installFederatedServer(version, db):
+def installFederatedServer(version, db, dbSuffix = '-federated'):
+	host = getDbName(db)
+	dbType = host
+
+	username = getDbUsername(db)
+	password = getDbPassword(db)
+	database = getDbDatabase(db) + dbSuffix
+
+	if host == 'mariadb':
+		dbType = 'mysql'
+	elif host == 'postgres':
+		dbType = 'pgsql'
+	elif host == 'oracle':
+		dbType = 'oci'
+
 	stepDefinition = {
 		'name': 'install-federated',
 		'image': 'owncloudci/core',
@@ -561,6 +601,11 @@ def installFederatedServer(version, db):
 		'settings': {
 			'version': version,
 			'core_path': '/var/www/owncloud/federated/',
+			'db_type': dbType,
+			'db_name': database,
+			'db_host': host + dbSuffix,
+			'db_username': username,
+			'db_password': password
 		}
 	}
 	return [stepDefinition]

--- a/.drone.yml
+++ b/.drone.yml
@@ -3593,6 +3593,11 @@ steps:
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated/
+    db_host: mysql-federated
+    db_name: owncloud-federated
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
     version: daily-master-qa
 
 - name: setup-fed-server-phoenix
@@ -3681,6 +3686,15 @@ services:
   - FOREGROUND
   environment:
     APACHE_WEBROOT: /var/www/owncloud/federated/
+
+- name: mysql-federated
+  pull: always
+  image: mysql:5.5
+  environment:
+    MYSQL_DATABASE: owncloud-federated
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
 
 - name: selenium
   pull: always

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -8,7 +8,9 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes" on remote server
     And the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "no"
     And server "%remote_backend_url%" has been added as trusted server
+    And server "%backend_url%" has been added as trusted server
     And server "%backend_url%" has been added as trusted server on remote server
+    And server "%remote_backend_url%" has been added as trusted server on remote server
     And user "user1" has been created with default attributes on remote server
     And user "user1" has been created with default attributes
     And user "user1" has logged in using the webUI
@@ -20,7 +22,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And as "user1" file "/simple-folder (2)/lorem.txt" should exist on remote server
     And as "user1" folder "/simple-empty-folder (2)" should exist on remote server
 
-  @yetToImplement
+  @issue-2510 @yetToImplement
   Scenario: test the single steps of receiving a federation share
     Given user "user2" has been created with default attributes on remote server
     And user "user3" has been created with default attributes on remote server
@@ -47,211 +49,83 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     #    And folder "simple-folder (2)" should be listed on the webUI
     #    And folder "simple-empty-folder (2)" should be listed on the webUI
 
-  @skip @yetToImplement
   Scenario: declining a federation share on the webUI
-    Given user "user1" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
+    Given user "user1" from remote server has shared "/lorem.txt" with user "user1" from local server
     And the user has reloaded the current page of the webUI
-    When the user declines the offered remote shares using the webUI
+    When the user declines all shares displayed in the notifications on the webUI
     Then file "lorem (2).txt" should not be listed on the webUI
-    And file "lorem (2).txt" should not be listed in the shared-with-you page on the webUI
+    When the user browses to the shared-with-me page
+    And the user reloads the current page of the webUI
+    Then file "lorem (2).txt" should not be listed on the webUI
 
-  @skip @yetToImplement
+  @issue-2510 @yetToImplement
   Scenario: automatically accept a federation share when it is allowed by the config
-    Given parameter "autoAddServers" of app "federation" has been set to "1"
-    And user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
-    And user "user1" from server "LOCAL" has accepted the last pending share
-    And the user has reloaded the current page of the webUI
-    And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
-    And parameter "autoAddServers" of app "federation" has been set to "0"
-    When user "user1" from server "REMOTE" shares "/lorem.txt" with user "user1" from server "LOCAL" using the sharing API
-    And the user has reloaded the current page of the webUI
-    Then file "lorem (2).txt" should be listed on the webUI
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "user1" from remote server has shared "simple-folder" with user "user1" from local server
+    When the user reloads the current page of the webUI
+    Then folder "simple-folder" should be listed on the webUI
+    When the user opens folder "simple-folder" directly on the webUI
+    Then file "lorem.txt" should be listed on the webUI
+    When the user browses to the shared-with-me page
+    And the user reloads the current page of the webUI
+    Then folder "simple-folder" should not be listed on the webUI
 
-  @skip @yetToImplement
-  Scenario: User-based auto accepting is disabled while global is enabled
-    Given parameter "autoAddServers" of app "federation" has been set to "1"
-    And user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
-    And user "user1" from server "LOCAL" has accepted the last pending share
-    And the user has reloaded the current page of the webUI
-    And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
-    And parameter "autoAddServers" of app "federation" has been set to "0"
-    And the user has browsed to the personal sharing settings page
-    When the user disables automatically accepting remote shares from trusted servers
-    And user "user1" from server "REMOTE" shares "/lorem.txt" with user "user1" from server "LOCAL" using the sharing API
-    Then user "user1" should not see the following elements
-      | /lorem%20(2).txt |
+  Scenario: share a folder with an remote user with "Viewer" role
+    When the user shares folder "simple-empty-folder" with remote user "user1" as "Viewer" using the webUI
+    Then user "user1" should have shared a folder "simple-empty-folder" with these details:
+      | field       | value                      |
+      | uid_owner   | user1                      |
+      | share_with  | user1@%remote_backend_url% |
+      | item_type   | folder                     |
+      | permissions | read                       |
+    And as "user1" folder "simple-empty-folder" should exist on remote server
 
-  @skip @yetToImplement
-  Scenario: one user disabling user-based auto accepting while global is enabled has no effect on other users
-    Given user "user2" has been created with default attributes
-    And parameter "autoAddServers" of app "federation" has been set to "1"
-    And user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
-    And user "user1" from server "LOCAL" has accepted the last pending share
-    And the user has reloaded the current page of the webUI
-    And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
-    And parameter "autoAddServers" of app "federation" has been set to "0"
-    And the user has browsed to the personal sharing settings page
-    When the user disables automatically accepting remote shares from trusted servers
-    And user "user1" from server "REMOTE" shares "/lorem.txt" with user "user2" from server "LOCAL" using the sharing API
-    Then user "user2" should see the following elements
-      | /lorem%20(2).txt |
-
-  @skip @yetToImplement
-  Scenario: User-based accepting from trusted server checkbox is not visible while global is disabled
-    Given parameter "autoAddServers" of app "federation" has been set to "1"
-    And user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
-    And user "user1" from server "LOCAL" has accepted the last pending share
-    And the user has reloaded the current page of the webUI
-    And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "no"
-    And parameter "autoAddServers" of app "federation" has been set to "0"
-    And the user has browsed to the personal sharing settings page
-    Then User-based auto accepting from trusted servers checkbox should not be displayed on the personal sharing settings page in the webUI
-
-  @skip @yetToImplement
-  Scenario: User-based & global auto accepting is enabled but remote server is not trusted
-    Given parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
-    And parameter "autoAddServers" of app "federation" has been set to "0"
-    And the user has browsed to the personal sharing settings page
-    When the user disables automatically accepting remote shares from trusted servers
-    And the user enables automatically accepting remote shares from trusted servers
-    And user "user1" from server "REMOTE" shares "/lorem.txt" with user "user1" from server "LOCAL" using the sharing API
-    Then user "user1" should not see the following elements
-      | /lorem%20(2).txt |
-
-  @skip @yetToImplement
-  Scenario: share a folder with an remote user and prohibit deleting - local server shares - remote server receives
-    When the user shares folder "simple-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI
-    And the user sets the sharing permissions of "user1@%remote_server_without_scheme% (federated)" for "simple-folder" using the webUI to
-      | delete | no |
-    And user "user1" re-logs in to "%remote_server%" using the webUI
-    And the user accepts the offered remote shares using the webUI
-    And the user opens folder "simple-folder (2)" using the webUI
-    Then it should not be possible to delete file "lorem.txt" using the webUI
-
-  @skip @yetToImplement
   Scenario: share a folder with an remote user and prohibit deleting - remote server shares - local server receives
-    When user "user1" re-logs in to "%remote_server%" using the webUI
-    And the user shares folder "simple-folder" with remote user "user1@%local_server_without_scheme%" using the webUI
-    And the user sets the sharing permissions of "user1@%local_server_without_scheme% (federated)" for "simple-folder" using the webUI to
-      | delete | no |
-    And user "user1" re-logs in to "%local_server%" using the webUI
-    And the user accepts the offered remote shares using the webUI
-    And the user opens folder "simple-folder (2)" using the webUI
+    Given user "user1" from remote server has shared "simple-folder" with user "user1" from local server with "read" permissions
+    When the user reloads the current page of the webUI
+    And the user accepts all shares displayed in the notifications on the webUI
+    And the user opens folder "simple-folder (2)" directly on the webUI
     Then it should not be possible to delete file "lorem.txt" using the webUI
 
-  @skip @yetToImplement
-  Scenario: overwrite a file in a received share - local server shares - remote server receives
-    Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
-    And user "user1" from server "REMOTE" has accepted the last pending share
-    When user "user1" on "REMOTE" uploads file "filesForUpload/lorem.txt" to "simple-folder (2)/lorem.txt" using the WebDAV API
-    And user "user1" re-logs in to "%local_server%" using the webUI
-    And the user opens folder "simple-folder" using the webUI
-    Then file "lorem.txt" should be listed on the webUI
-    And the content of "lorem.txt" on the local server should be the same as the local "lorem.txt"
-
-  @skip @yetToImplement
   Scenario: overwrite a file in a received share - remote server shares - local server receives
-    Given user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
-    And the user has reloaded the current page of the webUI
-    When the user accepts the offered remote shares using the webUI
-    And the user opens folder "simple-folder (2)" using the webUI
-    And the user uploads overwriting file "lorem.txt" using the webUI and retries if the file is locked
-    And user "user1" re-logs in to "%remote_server%" using the webUI
-    And the user opens folder "simple-folder" using the webUI
-    Then file "lorem.txt" should be listed on the webUI
-    And the content of "lorem.txt" on the remote server should be the same as the local "lorem.txt"
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "user1" from remote server has shared "simple-folder" with user "user1" from local server
+    And the user opens folder "simple-folder (2)" directly on the webUI
+    When the user uploads overwriting file "lorem.txt" using the webUI
+    Then as "user1" the content of "simple-folder (2)/lorem.txt" should be the same as the local "lorem.txt"
 
-  @skip
-  Scenario: upload a new file in a received share - local server shares - remote server receives
-    Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
-    And user "user1" from server "REMOTE" has accepted the last pending share
-    When user "user1" on "REMOTE" uploads file "filesForUpload/new-lorem.txt" to "simple-folder (2)/new-lorem.txt" using the WebDAV API
-    And user "user1" re-logs in to "%local_server%" using the webUI
-    And the user opens folder "simple-folder" using the webUI
-    Then file "new-lorem.txt" should be listed on the webUI
-    And the content of "new-lorem.txt" on the local server should be the same as the local "new-lorem.txt"
-
-  @skip
   Scenario: upload a new file in a received share - remote server shares - local server receives
-    Given user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
-    And the user has reloaded the current page of the webUI
-    When the user accepts the offered remote shares using the webUI
-    And the user opens folder "simple-folder (2)" using the webUI
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "user1" from remote server has shared "simple-folder" with user "user1" from local server
+    When the user opens folder "simple-folder (2)" directly on the webUI
     And the user uploads file "new-lorem.txt" using the webUI
-    And user "user1" re-logs in to "%remote_server%" using the webUI
-    And the user opens folder "simple-folder" using the webUI
-    Then file "new-lorem.txt" should be listed on the webUI
-    And the content of "new-lorem.txt" on the remote server should be the same as the local "new-lorem.txt"
+    Then as "user1" file "simple-folder/new-lorem.txt" should exist on remote server
 
-  @skip
-  Scenario: rename a file in a received share - local server shares - remote server receives
-    Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
-    And user "user1" from server "REMOTE" has accepted the last pending share
-    When user "user1" on "REMOTE" moves file "/simple-folder%20(2)/lorem-big.txt" to "/simple-folder%20(2)/renamed%20file.txt" using the WebDAV API
-    And user "user1" re-logs in to "%local_server%" using the webUI
-    And the user opens folder "simple-folder" using the webUI
-    Then file "renamed file.txt" should be listed on the webUI
-    But file "lorem-big.txt" should not be listed on the webUI
-    And the content of "renamed file.txt" on the local server should be the same as the original "simple-folder/lorem-big.txt"
-
-  @skip @yetToImplement
   Scenario: rename a file in a received share - remote server shares - local server receives
-    Given user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
-    And the user has reloaded the current page of the webUI
-    When the user accepts the offered remote shares using the webUI
-    When the user opens folder "simple-folder (2)" using the webUI
-    And the user renames file "lorem-big.txt" to "renamed file.txt" using the webUI
-    And user "user1" re-logs in to "%remote_server%" using the webUI
-    And the user opens folder "simple-folder" using the webUI
-    Then file "renamed file.txt" should be listed on the webUI
-    And the content of "renamed file.txt" on the remote server should be the same as the original "simple-folder/lorem-big.txt"
-    But file "lorem-big.txt" should not be listed on the webUI
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "user1" from remote server has shared "simple-folder" with user "user1" from local server
+    When the user opens folder "simple-folder (2)" directly on the webUI
+    And the user renames file "lorem.txt" to "new-lorem.txt" using the webUI
+    Then as "user1" file "simple-folder/new-lorem.txt" should exist on remote server
+    But as "user1" file "simple-folder/lorem.txt" should not exist on remote server
 
-  @skip
-  Scenario: delete a file in a received share - local server shares - remote server receives
-    Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
-    And user "user1" from server "REMOTE" has accepted the last pending share
-    When user "user1" on "REMOTE" deletes file "simple-folder (2)/data.zip" using the WebDAV API
-    And user "user1" re-logs in to "%local_server%" using the webUI
-    And the user opens folder "simple-folder" using the webUI
-    Then file "data.zip" should not be listed on the webUI
-
-  @skip
   Scenario: delete a file in a received share - remote server shares - local server receives
-    Given user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
-    And the user has reloaded the current page of the webUI
-    When the user accepts the offered remote shares using the webUI
-    And the user opens folder "simple-folder (2)" using the webUI
-    And the user deletes file "data.zip" using the webUI
-    And user "user1" re-logs in to "%remote_server%" using the webUI
-    And the user opens folder "simple-folder" using the webUI
-    Then file "data.zip" should not be listed on the webUI
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "user1" from remote server has shared "simple-folder" with user "user1" from local server
+    When the user opens folder "simple-folder (2)" directly on the webUI
+    And the user deletes file "lorem.txt" using the webUI
+    Then as "user1" file "simple-folder/lorem.txt" should not exist on remote server
 
-  @skip @yetToImplement
-  Scenario: receive same name federation share from two users
-    Given using server "REMOTE"
-    And user "user2" has been created with default attributes
-    And user "user1" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
-    And user "user2" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
-    And the user has reloaded the current page of the webUI
-    When the user accepts the offered remote shares using the webUI
-    Then file "lorem (2).txt" should be listed on the webUI
-    And file "lorem (3).txt" should be listed on the webUI
-    And file "lorem (2).txt" should be listed in the shared-with-you page on the webUI
-    And file "lorem (3).txt" should be listed in the shared-with-you page on the webUI
-
-  @skip @yetToImplement
   Scenario: unshare a federation share
-    Given user "user1" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
-    And user "user1" from server "LOCAL" has accepted the last pending share
-    And the user has reloaded the current page of the webUI
-    When the user unshares file "lorem (2).txt" using the webUI
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "user1" from remote server has shared "lorem.txt" with user "user1" from local server
+    When the user reloads the current page of the webUI
+    And the user deletes file "lorem (2).txt" using the webUI
     Then file "lorem (2).txt" should not be listed on the webUI
-    When the user has reloaded the current page of the webUI
-    Then file "lorem (2).txt" should not be listed on the webUI
-    And file "lorem (2).txt" should not be listed in the shared-with-you page on the webUI
+    And as "user1" file "lorem (2).txt" should not exist
+    And as "user1" file "lorem.txt" should exist on remote server
 
-  @skip @yetToImplement
+  @issue-2510 @skip @yetToImplement
   Scenario: unshare a federation share from "share-with-you" page
     Given user "user1" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
     And user "user1" from server "LOCAL" has accepted the last pending share
@@ -260,113 +134,91 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Then file "lorem (2).txt" should not be listed on the webUI
     And file "lorem (2).txt" should not be listed in the files page on the webUI
 
-  @skip @yetToImplement
-  Scenario: test sharing folder to a remote server and resharing it back to the local
-    Given using server "LOCAL"
-    And these users have been created:
-      | username |
-      | user2    |
-    When the user shares folder "simple-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI
-    And user "user1" re-logs in to "%remote_server%" using the webUI
-    And the user accepts the offered remote shares using the webUI
-    And user "user1" from server "REMOTE" shares "/simple-folder (2)" with user "user2" from server "LOCAL" using the sharing API
-    And user "user2" re-logs in to "%local_server%" using the webUI
-    And the user accepts the offered remote shares using the webUI
-    Then as "user2" folder "/simple-folder (2)" should exist
-    And as "user2" file "/simple-folder (2)/lorem.txt" should exist
-
-  @skip @yetToImplement
-  Scenario: test resharing folder as readonly and set it as readonly by resharer
-    Given using server "LOCAL"
-    And these users have been created:
-      | username |
-      | user2    |
-    When the user shares folder "simple-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI
-    And user "user1" re-logs in to "%remote_server%" using the webUI
-    And the user accepts the offered remote shares using the webUI
-    And user "user1" from server "REMOTE" shares "/simple-folder (2)" with user "user2" from server "LOCAL" using the sharing API
-    And the user sets the sharing permissions of "user2@%local_server%/ (federated)" for "simple-folder (2)" using the webUI to
-      | edit | no |
-    And user "user2" re-logs in to "%local_server%" using the webUI
-    And the user accepts the offered remote shares using the webUI
-    Then as "user2" folder "/simple-folder (2)" should exist
-    And as "user2" file "/simple-folder (2)/lorem.txt" should exist
-    When the user opens folder "simple-folder (2)" using the webUI
-    Then it should not be possible to delete file "lorem.txt" using the webUI
-
-  @skip @yetToImplement
-  Scenario: test resharing folder and set it as readonly by owner
-    Given using server "LOCAL"
-    And these users have been created:
-      | username |
-      | user2    |
-    When the user shares folder "simple-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI
-    And user "user1" re-logs in to "%remote_server%" using the webUI
-    And the user accepts the offered remote shares using the webUI
-    And user "user1" from server "REMOTE" shares "/simple-folder (2)" with user "user2" from server "LOCAL" using the sharing API
-    And user "user1" re-logs in to "%local_server%" using the webUI
-    And the user opens the share dialog for folder "simple-folder" using the webUI
-    And the user sets the sharing permissions of "user2@%local_server% (federated)" for "simple-folder" using the webUI to
-      | edit | no |
-    And user "user2" re-logs in to "%local_server%" using the webUI
-    And the user accepts the offered remote shares using the webUI
-    Then as "user2" folder "/simple-folder (2)" should exist
-    And as "user2" file "/simple-folder (2)/lorem.txt" should exist
-    When the user opens folder "simple-folder (2)" using the webUI
-    Then it should not be possible to delete file "lorem.txt" using the webUI
-
-  @skip @yetToImplement
-  Scenario: test sharing long file names with federation share
-    When user "user1" moves file "/lorem.txt" to "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" using the WebDAV API
+  Scenario: test resharing folder with "Viewer" role
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "user2" has been created with default attributes
+    And user "user1" from remote server has shared "simple-folder" with user "user1" from local server
     And the user has reloaded the current page of the webUI
-    And the user shares file "averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" with remote user "user1@%remote_server_without_scheme%" using the webUI
-    And user "user1" re-logs in to "%remote_server%" using the webUI
-    And the user accepts the offered remote shares using the webUI
-    And using server "REMOTE"
-    Then as "user1" file "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" should exist
+    When the user shares folder "simple-folder (2)" with user "User Two" as "Viewer" using the webUI
+    Then as "user2" folder "simple-folder (2)/lorem.txt" should exist
+    And user "user2" should have received a share with these details:
+      | field       | value                      |
+      | uid_owner   | user1                      |
+      | share_with  | user2                      |
+      | item_type   | folder                     |
+      | permissions | read                       |
 
-  @skip @yetToImplement
+  Scenario: test resharing a federated server to remote again
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "user2" has been created with default attributes on remote server
+    And user "user1" from remote server has shared "simple-folder" with user "user1" from local server with "read, share" permissions
+    And the user has reloaded the current page of the webUI
+    When the user shares folder "simple-folder (2)" with remote user "user2" as "Viewer" using the webUI
+    Then user "user1" should have shared a folder "simple-folder (2)" with these details:
+      | field       | value                      |
+      | uid_owner   | user1                      |
+      | share_with  | user2@%remote_backend_url% |
+      | item_type   | folder                     |
+      | permissions | read                       |
+    And as "user2" folder "simple-folder (2)" should exist on remote server
+
+  Scenario: try resharing a folder with read-only permissions
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "user1" from remote server has shared "simple-folder" with user "user1" from local server with "read" permissions
+    When the user reloads the current page of the webUI
+    Then the user should not be able to share folder "simple-folder (2)" using the webUI
+
+  Scenario: test sharing long file names with federation share
+    When user "user1" has uploaded file with content "secret" to "averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt"
+    And the user has reloaded the current page of the webUI
+    When the user shares file "averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" with remote user "user1" as "Viewer" using the webUI
+    Then as "user1" file "averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" should exist on remote server
+
   Scenario: sharee should be able to access the files/folders inside other folder
-    Given user "user1" has created folder "simple-folder/simple-empty-folder/finalfolder"
-    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/simple-empty-folder/textfile.txt"
-    And user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
-    And user "user1" from server "REMOTE" has accepted the last pending share
-    And user "user1" re-logs in to "%remote_server%" using the webUI
-    When the user opens folder "simple-folder (2)" using the webUI
-    Then file "lorem.txt" should be listed on the webUI
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "user1" from remote server has shared "'single'quotes" with user "user1" from local server
+    And the user has reloaded the current page of the webUI
+    When the user opens folder "'single'quotes (2)" using the webUI
+    Then as "user1" these resources should be listed on the webUI
+     | entry_name          |
+     | simple-empty-folder |
+     | for-git-commit      |
+     | lorem.txt           |
     When the user opens folder "simple-empty-folder" using the webUI
-    Then file "textfile.txt" should be listed on the webUI
-    And folder "finalfolder" should be listed on the webUI
+    Then as "user1" these resources should be listed on the webUI
+     | entry_name     |
+     | for-git-commit |
+    When the user downloads file "for-git-commit" using the webUI
+    Then no message should be displayed on the webUI
+    And as "user1" the content of "'single'quotes (2)/lorem.txt" should be the same as the original "'single'quotes/lorem.txt"
+    And as "user1" the content of "'single'quotes (2)/simple-empty-folder/for-git-commit" should be the same as the original "'single'quotes/simple-empty-folder/for-git-commit"
 
-  @skip
-  Scenario: sharee uploads a file inside a folder of a folder
-    Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
-    And user "user1" from server "REMOTE" has accepted the last pending share
-    When user "user1" re-logs in to "%remote_server%" using the webUI
-    And the user opens folder "simple-folder (2)/simple-empty-folder" using the webUI
-    And the user uploads file "lorem.txt" using the webUI
-    And using server "LOCAL"
-    Then as "user1" file "simple-folder/simple-empty-folder/lorem.txt" should exist
+  Scenario: uploading a file inside a folder of a folder
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "user1" from remote server has shared "simple-folder" with user "user1" from local server
+    When the user opens folder "simple-folder (2)/simple-empty-folder" directly on the webUI
+    And the user uploads file "new-lorem.txt" using the webUI
+    Then file "new-lorem.txt" should be listed on the webUI
+    And as "user1" file "simple-folder/simple-empty-folder/new-lorem.txt" should exist on remote server
+    And as "user1" file "simple-folder (2)/simple-empty-folder/new-lorem.txt" should exist
 
-  @skip
   Scenario: rename a file in a folder inside a shared folder
-    Given user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/simple-empty-folder/textfile.txt"
-    And user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
-    And user "user1" from server "REMOTE" has accepted the last pending share
-    And user "user1" re-logs in to "%remote_server%" using the webUI
-    And the user opens folder "simple-folder (2)/simple-empty-folder" using the webUI
-    When the user renames file "textfile.txt" to "new-lorem.txt" using the webUI
-    And using server "LOCAL"
-    Then as "user1" file "simple-folder/simple-empty-folder/new-lorem.txt" should exist
-    But as "user1" file "simple-folder/simple-empty-folder/textfile.txt" should not exist
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "user1" from remote server has shared "'single'quotes" with user "user1" from local server
+    When the user opens folder "/'single'quotes (2)/simple-empty-folder" directly on the webUI
+    And the user renames file "for-git-commit" to "not-for-git-commit" using the webUI
+    Then file "for-git-commit" should not be listed on the webUI
+    And as "user1" file "'single'quotes (2)/simple-empty-folder/for-git-commit" should not exist
+    And as "user1" file "'single'quotes/simple-empty-folder/for-git-commit" should not exist on remote server
+    But file "not-for-git-commit" should be listed on the webUI
+    And as "user1" file "'single'quotes (2)/simple-empty-folder/not-for-git-commit" should exist
+    And as "user1" file "'single'quotes/simple-empty-folder/not-for-git-commit" should exist on remote server
 
-  @skip
   Scenario: delete a file in a folder inside a shared folder
-    Given user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/simple-empty-folder/textfile.txt"
-    And user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
-    And user "user1" from server "REMOTE" has accepted the last pending share
-    And user "user1" re-logs in to "%remote_server%" using the webUI
-    And the user opens folder "/simple-folder (2)/simple-empty-folder" using the webUI
-    When the user deletes file "textfile.txt" using the webUI
-    And using server "LOCAL"
-    Then as "user1" file "/simple-folder/simple-empty-folder/textfile.txt" should not exist
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "user1" from remote server has shared "'single'quotes" with user "user1" from local server
+    When the user opens folder "/'single'quotes (2)/simple-empty-folder" directly on the webUI
+    And the user deletes file "for-git-commit" using the webUI
+    Then file "for-git-commit" should not be listed on the webUI
+    And as "user1" file "'single'quotes (2)/simple-empty-folder/for-git-commit" should not exist
+    And as "user1" file "'single'quotes/simple-empty-folder/for-git-commit" should not exist on remote server

--- a/tests/acceptance/features/webUITrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinRestore.feature
@@ -115,4 +115,3 @@ Feature: Restore deleted files/folders
     And as "user1" file "simple-folder-renamed/file-to-delete-and-restore" should not exist
     #And as "user1" file "simple-folder-renamed/file-to-delete-and-restore" should exist
     And as "user1" file "simple-folder/file-to-delete-and-restore" should not exist
-

--- a/tests/acceptance/helpers/webdavHelper.js
+++ b/tests/acceptance/helpers/webdavHelper.js
@@ -80,7 +80,7 @@ exports.move = function (userId, fromName, toName) {
 exports.propfind = function (path, userId, properties, folderDepth = 1) {
   const headers = httpHelper.createAuthHeader(userId)
   headers.Depth = folderDepth
-  const davPath = client.globals.backend_url + '/remote.php/dav' + resolve(path)
+  const davPath = backendHelper.getCurrentBackendUrl() + '/remote.php/dav' + resolve(path)
   let propertyBody = ''
   properties.map(prop => {
     propertyBody += `<${prop}/>`
@@ -221,7 +221,7 @@ exports.getSkeletonFile = function (filename) {
 
 exports.uploadFileWithContent = function (user, content, filename) {
   const headers = httpHelper.createAuthHeader(user)
-  return fetch(client.globals.backend_url +
+  return fetch(backendHelper.getCurrentBackendUrl() +
     '/remote.php/webdav/' + filename, {
     headers: {
       'Content-Type': 'text/plain',

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -123,6 +123,12 @@ Given('the user has browsed to the files page', function () {
     .page.filesPage()
     .navigateAndWaitTillLoaded()
 })
+
+When('the user opens folder {string} directly on the webUI', function (folder) {
+  folder = encodeURIComponent(path.normalize(folder))
+  return client.page.filesPage().navigateAndWaitTillLoaded(folder)
+})
+
 Given('user {string} has uploaded file with content {string} to {string}', async function (user, content, filename) {
   await waitBetweenFileUploadOperations()
   await webdav.uploadFileWithContent(user, content, filename)

--- a/tests/acceptance/stepDefinitions/generalContext.js
+++ b/tests/acceptance/stepDefinitions/generalContext.js
@@ -110,10 +110,10 @@ Given('the setting {string} of app {string} has been set to {string}', function 
     ])
 })
 
-Given('the setting {string} of app {string} has been set to {string} on remote server', async function (setting, app, value) {
-  return backendHelper.runOnRemoteBackend(occHelper.runOcc, [[
+Given('the setting {string} of app {string} has been set to {string} on remote server', function (setting, app, value) {
+  return backendHelper.runOnRemoteBackend(occHelper.runOcc, [
     'config:app:set', app, setting, '--value=' + value
-  ]])
+  ])
 })
 
 Given('the administrator has cleared the versions for user {string}', function (userId) {
@@ -147,7 +147,7 @@ Given('server {string} has been added as trusted server', function (server) {
 })
 
 Given('server {string} has been added as trusted server on remote server', function (url) {
-  return backendHelper.runOnRemoteBackend(setTrustedServer, [url])
+  return backendHelper.runOnRemoteBackend(setTrustedServer, url)
 })
 
 Before(function (testCase) {

--- a/tests/acceptance/stepDefinitions/notificationsContext.js
+++ b/tests/acceptance/stepDefinitions/notificationsContext.js
@@ -4,6 +4,7 @@ const httpHelper = require('../helpers/httpHelper')
 const userSettings = require('../helpers/userSettings')
 const fetch = require('node-fetch')
 const assert = require('assert')
+const util = require('util')
 
 When('user {string} is sent a notification', function (user) {
   const body = new URLSearchParams()
@@ -28,15 +29,26 @@ When('the user declines all shares displayed in the notifications on the webUI',
   return client.page.phoenixPage().declineAllSharesInNotification()
 })
 
-Given('app {string} has been enabled', function (app) {
+Given('app {string} has been {}', function (app, action) {
+  assert.ok(
+    action === 'enabled' || action === 'disabled',
+    "only supported either 'enabled' or 'disabled'. Passed: " + action
+  )
   const headers = httpHelper.createAuthHeader('admin')
+  const method = action === 'enabled' ? 'POST' : 'DELETE'
+
+  const errorMessage = util.format(
+    'Failed while trying to %s the app',
+    action === 'enabled' ? 'enable' : 'disable'
+  )
   return fetch(client.globals.backend_url + '/ocs/v2.php/cloud/apps/' + app + '?format=json', {
     headers,
-    body: {},
-    method: 'POST'
+    method
   }).then(res => {
-    httpHelper.checkStatus(res, 'Failed while trying to enable the app')
+    httpHelper.checkStatus(res, errorMessage)
     return res.json()
+  }).then(data => {
+    httpHelper.checkOCSStatus(data, errorMessage)
   })
 })
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Implements federation sharing tests and has made following changes to the tests:

- Refactor to add `http://` if the scheme does not exist for local and remote backend.
- Refactor to not set the remote backend if it does not exist.
- Remove `retry` for local test run.
- Remove unnecessary helpers from `backendHelper` such as `getBackendUrl()` (can be accessed through `client.globals`) and `changeBackend` (which was unused).
- Refactor `runOnRemoteBackend` to take variadic arguments and pass it directly to the function (first arg).
- Track config so as to rollback for remote backends.
- Refactor `assertUserHasShareWithDetails` to accept `%...%` (percent-enclosed values).
- Use `getCurrentBackendUrl()` on `propfind` and `uploadFileWithContent`.
- Use single setup entrypoints (previously, we had 2 each for local run and drone).
- Introduce new parameter type for `on remote server` available as `opt_on_remote`.
- Fix unawaited when deleting users on remote and local.
- Refactor `fileExists()` to only make an API call. `fileShouldExist` and `fileShouldExist` can be used for assertion.
- Get `REMOTE_BACKEND_URL`, `LAUNCH_URL` and `LOCAL_BACKEND_URL`  from environment variables on drone.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #2477

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI and locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...