### PR TITLE
Remove duplicate methods to create new file in the acceptance test

### DIFF
--- a/tests/acceptance/features/webUIFiles/createFile.feature
+++ b/tests/acceptance/features/webUIFiles/createFile.feature
@@ -9,7 +9,7 @@ Feature: create files
     And the user has browsed to the files page
 
   Scenario: create a new file
-    When the user creates a new file "sample.txt" using the webUI
+    When the user creates a file with the name "sample.txt" using the webUI
     And the user browses to the files page
     Then file "sample.txt" should be listed on the webUI
 

--- a/tests/acceptance/pageObjects/filesPage.js
+++ b/tests/acceptance/pageObjects/filesPage.js
@@ -77,10 +77,10 @@ module.exports = {
         .click('@newFileMenuButton')
         .waitForElementVisible('@newFileButton')
         .click('@newFileButton')
-        .waitForElementVisible('@newFileInputField')
+        .waitForElementVisible('@newFileInput')
       if (name !== null) {
-        this.clearValueWithEvent('@newFileInputField')
-        this.setValue('@newFileInputField', name)
+        this.clearValueWithEvent('@newFileInput')
+        this.setValue('@newFileInput', name)
       }
       this
         .click('@newFileOkButton')
@@ -292,24 +292,13 @@ module.exports = {
         .waitForElementNotVisible(this.elements.fileOverwriteConfirm.selector)
         .waitForAjaxCallsToStartAndFinish()
     },
-    createNewFile: function (newFileName) {
-      return this
-        .waitForElementVisible('@newFileMenuButton')
-        .click('@newFileMenuButton')
-        .waitForElementVisible('@newFileButton')
-        .click('@newFileButton')
-        .waitForElementVisible('@newFileInputField')
-        .setValue('@newFileInputField', newFileName)
-        .waitForElementVisible('@newFileOkButton')
-        .click('@newFileOkButton')
-    },
     triesToCreateExistingFile: function (fileName) {
       return this.waitForElementVisible('@newFileMenuButton')
         .click('@newFileMenuButton')
         .waitForElementVisible('@newFileButton')
         .click('@newFileButton')
-        .waitForElementVisible('@newFileInputField')
-        .setValue('@newFileInputField', fileName)
+        .waitForElementVisible('@newFileInput')
+        .setValue('@newFileInput', fileName)
     },
     waitForErrorMessage: function (callback) {
       return this.waitForElementVisible('@fileAlreadyExistAlert')
@@ -382,6 +371,10 @@ module.exports = {
     },
     newFolderInput: {
       selector: '#new-folder-input'
+    },
+    newFileInput: {
+      selector: "//div[@id='new-file-dialog']//input[@type='text']",
+      locateStrategy: 'xpath'
     },
     newFolderOkButton: {
       selector: '#new-folder-ok'
@@ -480,10 +473,6 @@ module.exports = {
     },
     sidebarItemName: {
       selector: '#files-sidebar-item-name'
-    },
-    newFileInputField: {
-      selector: "//div[@id='new-file-dialog']//input[@type='text']",
-      locateStrategy: 'xpath'
     },
     createFileOkButtonDisabled: {
       selector: "//div[@id='new-file-dialog']//button[@disabled='disabled']/span[contains(text(), 'Ok')]",

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -813,10 +813,6 @@ When('the user uploads overwriting file {string} using the webUI', function (fil
     .then(() => client.page.filesPage().confirmFileOverwrite())
 })
 
-When('the user creates a new file {string} using the webUI', function (newFileName) {
-  return client.page.filesPage().createNewFile(newFileName)
-})
-
 When('the user tries to create a file with already existing name {string} using the webUI', function (fileName) {
   return client.page.filesPage().triesToCreateExistingFile(fileName)
 })


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Remove duplicate methods to create new file in the acceptance test

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #2710 

## Motivation and Context
This PR removes the duplicate methods present for the creation of files in the acceptance tests to make the codes tidy.

