### PR TITLE
Fixed existing collaborators in autocomplete

### DIFF
--- a/apps/files/src/components/Collaborators/NewCollaborator.vue
+++ b/apps/files/src/components/Collaborators/NewCollaborator.vue
@@ -169,7 +169,10 @@ export default {
             )
 
             const exists = this.shares.find(existingCollaborator => {
-              return collaborator.value.shareWith === existingCollaborator.name
+              return (
+                collaborator.value.shareWith === existingCollaborator.name &&
+                parseInt(collaborator.value.shareType, 10) === parseInt(existingCollaborator.info.share_type, 10)
+              )
             })
 
             if (selected || exists) {

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroupsEdgeCases.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroupsEdgeCases.feature
@@ -33,7 +33,6 @@ Feature: Sharing files and folders with internal groups
       | ?\?@#%@,; |
       | नेपाली    |
 
-  @issue-2419
   Scenario: Share file with a user and a group with same name
     Given these users have been created with default attributes:
       | username |
@@ -48,14 +47,13 @@ Feature: Sharing files and folders with internal groups
     And user "user3" has uploaded file with content "user3 file" to "/randomfile.txt"
     And user "user3" has logged in using the webUI
     When the user shares file "randomfile.txt" with user "User One" as "Editor" using the webUI
-#    And the user shares file "randomfile.txt" with group "user1" as "Editor" using the webUI
+    And the user shares file "randomfile.txt" with group "user1" as "Editor" using the webUI
     And the user opens the share creation dialog in the webUI
     And the user types "user1" in the share-with-field
     Then "group" "user1" should not be listed in the autocomplete list on the webUI
     And the content of file "randomfile.txt" for user "user1" should be "user3 file"
-#    And the content of file "randmfile.txt" for user "user2" should be "user3 file"
+    And the content of file "randomfile.txt" for user "user2" should be "user3 file"
 
-  @issue-2419
   Scenario: Share file with a group and a user with same name
     Given these users have been created with default attributes:
       | username |
@@ -69,12 +67,12 @@ Feature: Sharing files and folders with internal groups
     And user "user3" has uploaded file with content "user3 file" to "/randomfile.txt"
     And user "user3" has logged in using the webUI
     When the user shares file "randomfile.txt" with group "user1" as "Editor" using the webUI
-#    And the user shares file "randomfile.txt" with user "User One" as "Editor" using the webUI
+    And the user shares file "randomfile.txt" with user "User One" as "Editor" using the webUI
     And the user opens the share creation dialog in the webUI
     And the user types "user" in the share-with-field
     Then "user" "User One" should not be listed in the autocomplete list on the webUI
     And the content of file "randomfile.txt" for user "user2" should be "user3 file"
-#    And the content of file "randmfile.txt" for user "user1" should be "user3 file"
+    And the content of file "randomfile.txt" for user "user1" should be "user3 file"
 
   @yetToImplement
   Scenario: Share file with a user and again with a group with same name but different case


### PR DESCRIPTION
## Description
Do not hide collaborator if another entry with the same name exists if they are not the same type.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #2419

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Acceptance tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 