### PR TITLE
Remove empty parentheses in shared with others list

### DIFF
--- a/apps/files/src/components/Collaborators/SharedFilesList.vue
+++ b/apps/files/src/components/Collaborators/SharedFilesList.vue
@@ -29,7 +29,10 @@
       </div>
       <div class="uk-text-meta uk-text-nowrap uk-width-small">
         <div v-if="$route.name === 'files-shared-with-others'" key="shared-with-cell">
-          {{ item.sharedWith }} (<translate v-if="item.shareType === 1">group</translate>)
+          <span v-text="item.sharedWith" />
+          <span v-if="item.shareType === 1">
+            (<translate>group</translate>)
+          </span>
         </div>
         <div v-else key="shared-from-cell">
           {{ item.shareOwnerDisplayname }}


### PR DESCRIPTION
## Description
If the shared with an entry is not group, hide parentheses

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #2442

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually
- test case 1: Share item with user
- test case 2: Share item with group

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/25989331/70997029-62be0f80-20d4-11ea-8e2e-0a687f8b8365.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 