### PR TITLE
Catch console errors in CI

### DIFF
--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -76,7 +76,8 @@ module.exports = {
         screenResolution: '1280x1024',
         username: SAUCE_USERNAME,
         access_key: SAUCE_ACCESS_KEY,
-        idleTimeout: 180
+        idleTimeout: 180,
+        loggingPrefs: { browser: 'ALL' }
       }
     }
   }

--- a/tests/acceptance/helpers/browserConsole.js
+++ b/tests/acceptance/helpers/browserConsole.js
@@ -27,6 +27,7 @@ export async function getAllLogsWithDateTime (level = null) {
   }
 
   return logs
-    .filter(e => !e.message.includes('favicon.ico'))
+    // avatar issue https://github.com/owncloud/phoenix/issues/2977
+    .filter(e => !e.message.includes('favicon.ico') && !e.message.includes('/dav/avatars/'))
     .map(formatLog)
 }

--- a/tests/acceptance/setup.js
+++ b/tests/acceptance/setup.js
@@ -1,3 +1,4 @@
+import assert from 'assert'
 import { setDefaultTimeout, After, Before, defineParameterType } from 'cucumber'
 import { createSession, closeSession, client, startWebDriver, stopWebDriver } from 'nightwatch-api'
 import { rollbackConfigs, setConfigs, cacheConfigs } from './helpers/config'
@@ -79,12 +80,16 @@ After(function closeSessionForEnv () {
   return closeSession()
 })
 
-After(async function tryToReadBrowserConsoleOnFailure ({ result }) {
+After(async function checkBrowserConsole ({ result }) {
+  let scope = 'SEVERE'
   if (result.status === 'failed') {
-    const logs = await getAllLogsWithDateTime('SEVERE')
-    if (logs.length > 0) {
-      console.log('\nThe following logs were found in the browser console:\n')
-      logs.forEach(log => console.log(log))
-    }
+    // also grab debug messages in case they are helpful
+    scope = 'DEBUG'
+  }
+  const logs = await getAllLogsWithDateTime(scope)
+  if (logs.length > 0) {
+    console.log('\nThe following logs were found in the browser console:\n')
+    logs.forEach(log => console.log(log))
+    assert.fail('There were errors in the log')
   }
 })


### PR DESCRIPTION
## Description
Catch console errors in CI at the end of every test.
If any errors are found, the test will fail and the offending messages are printed out.

## Related Issue
Fixes #2728 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manual test with master, since we have console errors there already...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...