### PR TITLE
Timeouts async script

### DIFF
--- a/tests/acceptance/setup.js
+++ b/tests/acceptance/setup.js
@@ -7,6 +7,7 @@ const RUNNING_ON_SAUCELABS = !!process.env.SAUCE_USERNAME
 
 const CUCUMBER_LOCAL_TIMEOUT = 60000
 const CUCUMBER_DRONE_TIMEOUT = 180000
+const SAUCELABS_ASYNC_SCRIPT_TIMEOUT = 10000
 const CUCUMBER_TIMEOUT = RUNNING_ON_CI ? CUCUMBER_DRONE_TIMEOUT : CUCUMBER_LOCAL_TIMEOUT
 setDefaultTimeout(CUCUMBER_TIMEOUT)
 
@@ -27,6 +28,7 @@ Before(function logSessionInfoOnSauceLabs () {
       .session(function (session) {
         console.log('  Link to saucelabs job: https://app.saucelabs.com/tests/' + session.sessionId)
       })
+      .timeoutsAsyncScript(SAUCELABS_ASYNC_SCRIPT_TIMEOUT)
   }
 })
 


### PR DESCRIPTION
## Description
asyncExecute is used in test since https://github.com/owncloud/phoenix/pull/2280
On saucelabs we often get timeouts with it
```
 Error while running .executeScriptAsync() protocol action: Timeout expired waiting for async script (WARNING: The server did not provide any stacktrace information)
```

so increase the timeout and hope for the best

## How Has This Been Tested?
run IE tests on this PR (usually only run nightly)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...