### PR TITLE
 allow to set the selenium host by env. variable when running on saucelabs

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -76,6 +76,9 @@ config = {
 			'browsers': [
 				'IE11',
 			],
+			'extraEnvironment': {
+				'SELENIUM_HOST': 'saucelabs'
+			},
 			'cronOnly': True,
 			'filterTags': '@smokeTest and not @skip and not @skipOnIE',
 		},

--- a/.drone.yml
+++ b/.drone.yml
@@ -4149,6 +4149,7 @@ steps:
       from_secret: sauce_access_key
     SAUCE_USERNAME:
       from_secret: sauce_username
+    SELENIUM_HOST: saucelabs
     SELENIUM_PORT: 4445
     SERVER_HOST: http://phoenix
     TEST_CONTEXT: webUI[R,T,F]*
@@ -4319,6 +4320,7 @@ steps:
       from_secret: sauce_access_key
     SAUCE_USERNAME:
       from_secret: sauce_username
+    SELENIUM_HOST: saucelabs
     SELENIUM_PORT: 4445
     SERVER_HOST: http://phoenix
     TEST_CONTEXT: webUISharing*

--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -70,7 +70,6 @@ module.exports = {
       }
     },
     saucelabs: {
-      selenium_host: 'saucelabs',
       desiredCapabilities: {
         tunnelIdentifier: SAUCELABS_TUNNEL_NAME,
         screenResolution: '1280x1024',


### PR DESCRIPTION
## Description
obey the `SELENIUM_HOST` env. variable even when running on saucelabs

## Motivation and Context
when trying to connect from a local development machine to saucelabs (e.g. through sc-proxy) we need to be able to set the `SELENIUM_HOST` manually

## How Has This Been Tested?
run IE tests on PR

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] revert commit that runs IE tests on PR