### PR TITLE
Implemented virtual scroll in trash bin

### DIFF
--- a/apps/files/src/components/FileList.vue
+++ b/apps/files/src/components/FileList.vue
@@ -66,7 +66,7 @@
                 />
               </div>
               <oc-button
-                :id="`files-file-list-action-button-small-resolution-${item.id}${{ '-active': active }}`"
+                :id="actionsDropdownButtonId(item.id, active)"
                 icon="more_vert"
                 :class="{ 'uk-hidden@m' : !compactMode, 'uk-visible@s uk-hidden@xl' : compactMode }"
                 :disabled="$_actionInProgress(item)"
@@ -135,6 +135,11 @@ export default {
     isActionEnabled: {
       type: Function,
       required: true
+    },
+    selectableRow: {
+      type: Boolean,
+      required: false,
+      default: true
     }
   },
   data () {
@@ -247,6 +252,8 @@ export default {
       return 'file-row'
     },
     selectRow (item, event) {
+      if (!this.selectableRow) return
+
       if (item.status && (item.status === 1 || item.status === 2)) return
 
       event.stopPropagation()
@@ -286,6 +293,14 @@ export default {
       this.rowActionsDisplayed = false
       this.rowActionsItem = {}
       this.rowActions = []
+    },
+
+    actionsDropdownButtonId (id, active) {
+      if (active) {
+        return `files-file-list-action-button-small-resolution-${id}-active`
+      }
+
+      return `files-file-list-action-button-small-resolution-${id}`
     }
   },
   computed: {

--- a/apps/files/src/components/FilesLists/RowActionsDropdown.vue
+++ b/apps/files/src/components/FilesLists/RowActionsDropdown.vue
@@ -3,11 +3,10 @@
     v-if="displayed"
     :boundary="`#files-file-list-action-button-small-resolution-${item.id}-active`"
     :options="{ offset: 0 }"
-    :toggle="`#files-file-list-action-button-small-resolution-${item.id}`"
+    :toggle="`#files-file-list-action-button-small-resolution-${item.id}-active`"
     position="bottom-right"
     id="files-list-row-actions-dropdown"
     class="uk-open uk-drop-stack"
-    :data-actions-dropdown-for-item="nameForDropdownData(item.name)"
   >
     <ul class="uk-list">
       <li v-for="action in actions" :key="action.ariaLabel">

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -24,13 +24,8 @@ module.exports = {
      * @param {string} fileName
      * @returns {string}
      */
-    getActionSelectorLowRes: function (action, itemName) {
-      // Escape double quotes inside of selector
-      if (itemName.indexOf('"') > -1) {
-        itemName = this.replaceChar(itemName, '"', '&quot;')
-      }
-
-      const actionsDropdownSelector = util.format(this.elements.itemActionsDropdown.selector, itemName)
+    getActionSelectorLowRes: function (action) {
+      const actionsDropdownSelector = this.elements.itemActionsDropdown.selector
       const actionSelector = this.elements[action + 'ButtonInFileRow'].selector
 
       return `${actionsDropdownSelector}${actionSelector}`
@@ -420,26 +415,8 @@ module.exports = {
       const linkSelector = this.getFileLinkSelectorByFileName(fileName)
 
       await this.waitForElementPresent('@filesTableContainer')
-
       await this.filesListScrollToTop()
-
-      // TODO: After virtual scroll is implemented also in trashbin get rid of this
-      let trashbin = false
-      await this.api.url(result => {
-        if (result.value.indexOf('trash-bin') > -1) {
-          trashbin = true
-        }
-      })
-
-      if (trashbin) {
-        const rowSelector = this.getFileRowSelectorByFileName(fileName)
-
-        this
-          .useXpath()
-          .waitForElementVisible(rowSelector)
-      } else {
-        await this.findItemInFilesList(fileName)
-      }
+      await this.findItemInFilesList(fileName)
 
       // Find the item in files list if it's not in the view
       await this
@@ -835,11 +812,11 @@ module.exports = {
       locateStrategy: 'xpath'
     },
     restoreButtonInFileRow: {
-      selector: '//span[.="Restore"]',
+      selector: '//button[@aria-label="Restore"]',
       locateStrategy: 'xpath'
     },
     deleteImmediatelyButtonInFileRow: {
-      selector: '//span[.="Delete immediately"]',
+      selector: '//button[@aria-label="Delete"]',
       locateStrategy: 'xpath'
     },
     deleteFileConfirmationBtn: {
@@ -864,12 +841,10 @@ module.exports = {
       selector: '#oc-dialog-rename-confirm'
     },
     fileRowByName: {
-      // FIXME: When the virtual scroll is implemented in trashbin adjust the selector
-      selector: '//span[@class="oc-file-name"][text()=%s and not(../span[@class="oc-file-extension"])]/../../../../../*[@data-is-visible="true"]'
+      selector: '//span[@class="oc-file-name"][text()=%s and not(../span[@class="oc-file-extension"])]/../../../../../div[@data-is-visible="true"]'
     },
     fileRowByNameAndExtension: {
-      // FIXME: When the virtual scroll is implemented in trashbin adjust the selector
-      selector: '//span[span/text()=%s and span/text()="%s"]/../../../../*[@data-is-visible="true"]'
+      selector: '//span[span/text()=%s and span/text()="%s"]/../../../../div[@data-is-visible="true"]'
     },
     fileLinkInFileRow: {
       selector: '//span[contains(@class, "file-row-name")]'
@@ -932,8 +907,8 @@ module.exports = {
       selector: '.files-collaborators-lists'
     },
     itemActionsDropdown: {
-      // FIXME: Use id after virtual scroll was implemented in trashbin
-      selector: '//div[@data-actions-dropdown-for-item="%s"]'
+      selector: '//div[@id="files-list-row-actions-dropdown"]',
+      locateStrategy: 'xpath'
     },
     foldersCount: {
       selector: '#files-list-count-folders'


### PR DESCRIPTION
## Description
Re-use FileList component with the virtual scroll inside of trash bin.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #2723

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Drone

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 