### PR TITLE
Display breadcrumb if rootFolder is set with no value

### DIFF
--- a/apps/files/src/components/FilesAppBar.vue
+++ b/apps/files/src/components/FilesAppBar.vue
@@ -255,7 +255,7 @@ export default {
         })
         : []
 
-      if (rootFolder !== '/') {
+      if (rootFolder && rootFolder !== '/') {
         pathSplit.splice(0, 1)
         baseUrl = `/files/list/${rootFolder}%2F`
       }

--- a/tests/acceptance/features/webUIFiles/breadcrumb.feature
+++ b/tests/acceptance/features/webUIFiles/breadcrumb.feature
@@ -6,13 +6,11 @@ Feature: access breadcrumb
   Background:
     Given user "user1" has been created with default attributes
 
- @issue-2538
-  Scenario: Check breadCrumb for folder one level below the root folder when rootFolder is set
+  Scenario: Check breadCrumb for folder one level below the root folder when rootFolder is set with no value
     Given the property "rootFolder" has been set to "" in phoenix config file
     And user "user1" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
-    #    Then breadcrumb for folder "simple-folder" should be displayed on the webUI
-    Then there should be no breadcrumb displayed on the webUI
+    Then breadcrumb for folder "simple-folder" should be displayed on the webUI
     When the user opens folder "simple-empty-folder" using the webUI
     Then breadcrumb for folder "simple-empty-folder" should be displayed on the webUI
 


### PR DESCRIPTION
## Description
In case the root folder has been set with no value, keep the first item in the breadcrumbs.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #2538

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually
1. Set the rootFolder in config.json to ""
2. Navigate into a subfolder

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 