### PR TITLE
Register store which is imported instead of required

### DIFF
--- a/src/phoenix.js
+++ b/src/phoenix.js
@@ -128,9 +128,11 @@ function loadApps () {
         }
       })
     }
+
     if (app.store) {
-      store.registerModule(app.appInfo.name, app.store.default)
+      registerStoreModule(app)
     }
+
     store.dispatch('registerApp', app.appInfo)
     if (config.external_apps) {
       store.dispatch('loadExternalAppConfig', { app: app.appInfo, config })
@@ -174,6 +176,14 @@ function loadApps () {
     .then(res => {
       store.dispatch('loadTheme', res)
     })
+}
+
+function registerStoreModule (app) {
+  if (app.store.default) {
+    return store.registerModule(app.appInfo.name, app.store.default)
+  }
+
+  return store.registerModule(app.appInfo.name, app.store)
 }
 
 function missingConfig () {


### PR DESCRIPTION
## Description
Register a store module even if it was imported into extension instead of required.

## Motivation and Context
Don't enforce how the store is included in the extension.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 