### PR TITLE
Build release on push event - otherwise it cannot be uploaded

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -170,7 +170,8 @@ def build(ctx):
 		'trigger': {
 			'ref': [
 				'refs/merge-requests/**',
-				'refs/heads/master'
+				'refs/heads/master',
+	            'refs/tags/**',
 			]
 		}
 	}
@@ -661,11 +662,6 @@ def buildRelease(ctx):
 			'cd /var/www/owncloud/phoenix',
 			'make -f Makefile.release dist'
 		],
-		'when': {
-			'event': [
-				'push'
-			]
-		},
 	},{
         'name': 'release-to-github',
         'image': 'plugins/github-release:1',


### PR DESCRIPTION
The pipeline publish-npm-and-demo-system was not executed on tag