### PR TITLE
Share indicator for direct and indirect shares in file list

### DIFF
--- a/apps/files/src/components/Collaborators/NewCollaborator.vue
+++ b/apps/files/src/components/Collaborators/NewCollaborator.vue
@@ -8,7 +8,7 @@
         :items="autocompleteResults"
         :itemsLoading="autocompleteInProgress"
         :placeholder="$_ocCollaborationStatus_autocompletePlacholder"
-        @update:input="onAutocompleteInput"
+        @update:input="$_onAutocompleteInput"
         :filter="filterRecipients"
         :fillOnSelection="false"
         id="oc-sharing-autocomplete"
@@ -76,6 +76,7 @@
 </template>
 
 <script>
+import _ from 'lodash'
 import { mapActions, mapGetters } from 'vuex'
 import Mixins from '../../mixins/collaborators'
 import { roleToBitmask } from '../../helpers/collaborators'
@@ -119,6 +120,8 @@ export default {
     this.$nextTick(() => {
       this.$refs.ocSharingAutocomplete.focus()
     })
+
+    this.$_onAutocompleteInput = _.debounce(this.$_onAutocompleteInput, 1000)
   },
 
   methods: {
@@ -136,7 +139,7 @@ export default {
       this.$emit('close')
     },
 
-    onAutocompleteInput (value) {
+    $_onAutocompleteInput (value) {
       if (
         value.length <
         parseInt(this.user.capabilities.files_sharing.search_min_length, 10)

--- a/apps/files/src/helpers/path.js
+++ b/apps/files/src/helpers/path.js
@@ -1,0 +1,36 @@
+/**
+ * Return all absolute parent paths.
+ *
+ * For example if passing in "a/b/c" it will return
+ * ["a/b", "a", ""]
+
+ * If an empty string or "/" is passed in, an empty array is returned.
+ *
+ * @param {String} path path to process
+ * @param {Boolean} includeCurrent whether to include the current path (with leading slash)
+ * @return {Array.<String>} parent paths
+ */
+export function getParentPaths (path, includeCurrent = false) {
+  if (path === '' || path === '/') {
+    return []
+  }
+
+  if (path.charAt(0) !== '/') {
+    path = '/' + path
+  }
+
+  const paths = []
+  const sections = path.split('/')
+
+  if (includeCurrent) {
+    paths.push(path)
+  }
+
+  sections.pop()
+  while (sections.length > 0) {
+    paths.push(sections.join('/'))
+    sections.pop()
+  }
+
+  return paths
+}

--- a/apps/files/src/helpers/shareTypes.js
+++ b/apps/files/src/helpers/shareTypes.js
@@ -1,0 +1,11 @@
+/**
+ * Share types
+ */
+export const shareTypes = {
+  user: 0,
+  group: 1,
+  userGroup: 2,
+  link: 3,
+  guest: 4,
+  remote: 6
+}

--- a/apps/files/src/store/getters.js
+++ b/apps/files/src/store/getters.js
@@ -81,8 +81,10 @@ export default {
   sharesLoading: state => {
     return state.sharesLoading
   },
+  sharesTree: state => state.sharesTree,
+  sharesTreeLoading: state => state.sharesTreeLoading,
   loadingFolder: state => {
-    return state.loadingFolder
+    return state.loadingFolder || state.sharesTreeLoading
   },
   quota: state => {
     return state.quota

--- a/apps/files/src/store/mutations.js
+++ b/apps/files/src/store/mutations.js
@@ -1,4 +1,5 @@
 import Vue from 'vue'
+import _ from 'lodash'
 
 export default {
   UPDATE_FILE_PROGRESS (state, file) {
@@ -137,6 +138,42 @@ export default {
   },
   SHARES_LOADING (state, loading) {
     state.sharesLoading = loading
+  },
+  SHARESTREE_CLEAR (state) {
+    state.sharesTree = {}
+  },
+  SHARESTREE_PRUNE_OUTSIDE_PATH (state, pathToKeep) {
+    if (pathToKeep !== '' && pathToKeep !== '/') {
+      // clear all children unrelated to the given path
+      //
+      // for example if the following paths are cached:
+      // - a
+      // - a/b
+      // - a/b/c
+      // - d/e/f
+      //
+      // and we request to keep only "a/b", the remaining tree becomes:
+      // - a
+      // - a/b
+      pathToKeep += '/'
+      if (pathToKeep.charAt(0) !== '/') {
+        pathToKeep = '/' + pathToKeep
+      }
+      state.sharesTree = _.pickBy(state.sharesTree, (shares, path) => {
+        return _.startsWith(pathToKeep, path + '/')
+      })
+    } else {
+      state.sharesTree = {}
+    }
+  },
+  SHARESTREE_ADD (state, sharesTree) {
+    Object.assign(state.sharesTree, sharesTree)
+  },
+  SHARESTREE_ERROR (state, error) {
+    state.sharesTreeError = error
+  },
+  SHARESTREE_LOADING (state, loading) {
+    state.sharesTreeLoading = loading
   },
   UPDATE_FOLDER_LOADING (state, value) {
     state.loadingFolder = value

--- a/apps/files/src/store/state.js
+++ b/apps/files/src/store/state.js
@@ -15,6 +15,7 @@ export default {
     '{http://owncloud.org/ns}fileid',
     '{http://owncloud.org/ns}owner-id',
     '{http://owncloud.org/ns}owner-display-name',
+    '{http://owncloud.org/ns}share-types',
     '{http://owncloud.org/ns}privatelink',
     '{DAV:}getcontentlength',
     '{http://owncloud.org/ns}size',
@@ -24,13 +25,27 @@ export default {
   ],
   dropzone: false,
   shareOpen: null,
+
+  /**
+   * Collaborator shares from currently highlighted element
+   */
   shares: [],
   sharesError: null,
   sharesLoading: false,
 
+  /**
+   * Link shares from currently highlighted element
+   */
   links: [],
   linksError: null,
   linksLoading: false,
+
+  /**
+   * Shares from parent folders
+   **/
+  sharesTree: {},
+  sharesTreeError: null,
+  sharesTreeLoading: false,
 
   loadingFolder: false,
   quota: {},

--- a/changelog/unreleased/2877
+++ b/changelog/unreleased/2877
@@ -1,0 +1,11 @@
+Enhancement: Add share indicator for direct and indirect shares in file list
+
+We've added the ability for the user to directly see whether a resource is shared in the file list.
+For this, share indicators in the form of a group icon and link icon will appear in a new column near the shared resource.
+The blue color of an icon tells whether outgoing shares exist directly on the resource.
+The grey color of an icon tells that incoming or outgoing shares exist on any of the parent folders.
+
+https://github.com/owncloud/phoenix/issues/2060
+https://github.com/owncloud/phoenix/issues/2894
+https://github.com/owncloud/phoenix/pull/2877
+

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -175,3 +175,106 @@ Feature: Sharing files and folders with internal groups
     And the user types "system-group" in the share-with-field
     Then the autocomplete list should not be displayed on the webUI
 
+  @issue-2060
+  Scenario: sharing indicator of items inside a shared folder two levels down
+    Given user "user1" has uploaded file with content "test" to "/simple-folder/lorem.txt"
+    And user "user1" has uploaded file with content "test" to "/simple-folder/simple-empty-folder/inside.txt"
+    And user "user1" has shared folder "simple-folder" with group "grp1"
+    When user "user1" has logged in using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName            | expectedIndicators |
+      | simple-folder       | user-direct        |
+    When the user opens folder "simple-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName            | expectedIndicators |
+      | simple-empty-folder | user-indirect      |
+      | lorem.txt           | user-indirect      |
+    When the user opens folder "simple-empty-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName            | expectedIndicators |
+      | inside.txt          | user-indirect      |
+
+  @issue-2060
+  Scenario: sharing indicator of items inside a re-shared folder
+    Given user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user2" has shared folder "simple-folder (2)" with group "grp1"
+    When user "user2" has logged in using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName            | expectedIndicators |
+      | simple-folder (2)   | user-direct        |
+    When the user opens folder "simple-folder (2)" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName            | expectedIndicators |
+      | simple-empty-folder | user-indirect      |
+      | lorem.txt           | user-indirect      |
+
+  @issue-2060
+  Scenario: sharing indicator of items inside a re-shared subfolder
+    Given user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user2" has shared folder "simple-folder (2)/simple-empty-folder" with group "grp1"
+    When user "user2" has logged in using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName            | expectedIndicators |
+      | simple-folder (2)   | user-indirect      |
+    When the user opens folder "simple-folder (2)" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName            | expectedIndicators |
+      | simple-empty-folder | user-direct        |
+      | lorem.txt           | user-indirect      |
+
+  @issue-2060
+  Scenario: sharing indicator of items inside an incoming shared folder
+    Given user "user1" has shared folder "simple-folder" with group "grp1"
+    When user "user2" has logged in using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName            | expectedIndicators |
+      | simple-folder (2)   | user-indirect      |
+    When the user opens folder "simple-folder (2)" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName            | expectedIndicators |
+      | simple-empty-folder | user-indirect      |
+      | lorem.txt           | user-indirect      |
+
+  @issue-2060
+  Scenario: no sharing indicator of items inside a not shared folder
+    Given user "user1" has shared file "/textfile0.txt" with group "grp1"
+    When user "user2" has logged in using the webUI
+    Then the following resources should not have share indicators on the webUI
+      | simple-folder       |
+    When the user opens folder "simple-folder" using the webUI
+    Then the following resources should not have share indicators on the webUI
+      | simple-empty-folder |
+      | lorem.txt           |
+
+  @issue-2060
+  Scenario: sharing indicator for file uploaded inside a shared folder
+    Given user "user1" has shared folder "/simple-empty-folder" with group "grp1"
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-empty-folder" using the webUI
+    And the user uploads file "new-lorem.txt" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName      | expectedIndicators |
+      | new-lorem.txt | user-indirect      |
+
+  @issue-2060
+  Scenario: sharing indicator for folder created inside a shared folder
+    Given user "user1" has shared folder "/simple-empty-folder" with group "grp1"
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-empty-folder" using the webUI
+    And the user creates a folder with the name "sub-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName      | expectedIndicators |
+      | sub-folder    | user-indirect      |
+
+  @skip @yetToImplement @issue-2897
+  Scenario: sharing details of items inside a shared folder shared with user and group
+    Given user "user3" has created folder "/simple-folder/sub-folder"
+    And user "user3" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/sub-folder/lorem.txt"
+    And user "user3" has shared folder "simple-folder" with user "user2"
+    And user "user3" has shared folder "/simple-folder/sub-folder" with group "grp1"
+    And user "user3" has logged in using the webUI
+    When the user opens folder "simple-folder/sub-folder" using the webUI
+    And the user opens the sharing tab from the file action menu of file "lorem.txt" using the webUI
+    Then user "User Two" should be listed as share receiver via "simple-folder" on the webUI
+    And group "grp1" should be listed as share receiver via "sub-folder" on the webUI
+

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -328,3 +328,151 @@ Feature: Sharing files and folders with internal users
     And folder "simple-folder" should not be listed on the webUI
     And as "user1" file "lorem.txt" should not exist
     And as "user1" folder "simple-folder" should not exist
+
+  @issue-2060
+  Scenario: sharing indicator of items inside a shared folder two levels down
+    Given user "user1" has created folder "/simple-folder/simple-empty-folder/new-folder"
+    And user "user1" has uploaded file with content "test" to "/simple-folder/simple-empty-folder/lorem.txt"
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    When user "user1" has logged in using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName            | expectedIndicators |
+      | simple-folder       | user-direct        |
+    When the user opens folder "simple-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName            | expectedIndicators |
+      | simple-empty-folder | user-indirect      |
+    When the user opens folder "simple-empty-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName   | expectedIndicators |
+      | new-folder | user-indirect      |
+      | lorem.txt  | user-indirect      |
+
+  @issue-2060
+  Scenario: sharing indicator of items inside a re-shared folder
+    Given user "user3" has been created with default attributes
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user2" has shared folder "simple-folder (2)" with user "user3"
+    When user "user2" has logged in using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName            | expectedIndicators |
+      | simple-folder (2)   | user-direct        |
+    When the user opens folder "simple-folder (2)" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName            | expectedIndicators |
+      | simple-empty-folder | user-indirect      |
+      | lorem.txt           | user-indirect      |
+
+  @issue-2060
+  Scenario: sharing indicator of items inside a re-shared subfolder
+    Given user "user3" has been created with default attributes
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user2" has shared folder "simple-folder (2)/simple-empty-folder" with user "user3"
+    When user "user2" has logged in using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName            | expectedIndicators |
+      | simple-folder (2)   | user-indirect      |
+    When the user opens folder "simple-folder (2)" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName            | expectedIndicators |
+      | simple-empty-folder | user-direct        |
+      | lorem.txt           | user-indirect      |
+
+  @issue-2060
+  Scenario: sharing indicator of items inside an incoming shared folder
+    Given user "user1" has shared folder "simple-folder" with user "user2"
+    When user "user2" has logged in using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName            | expectedIndicators |
+      | simple-folder (2)   | user-indirect      |
+    When the user opens folder "simple-folder (2)" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName            | expectedIndicators |
+      | simple-empty-folder | user-indirect      |
+      | lorem.txt           | user-indirect      |
+
+  @issue-2060
+  Scenario: no sharing indicator of items inside a not shared folder
+    Given user "user1" has shared file "/textfile0.txt" with user "user2"
+    When user "user2" has logged in using the webUI
+    Then the following resources should not have share indicators on the webUI
+      | simple-folder       |
+    When the user opens folder "simple-folder" using the webUI
+    Then the following resources should not have share indicators on the webUI
+      | simple-empty-folder |
+      | lorem.txt           |
+
+  @skip @yetToImplement @issue-2897
+  Scenario: sharing details of items inside a shared folder
+    Given these users have been created without skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+    And user "user1" has created folder "/simple-folder"
+    And user "user1" has created folder "/simple-folder/simple-empty-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user1" has logged in using the webUI
+    And the user has opened folder "simple-folder" using the webUI
+    When the user opens the sharing tab from the file action menu of folder "simple-empty-folder" using the webUI
+    Then user "user2" should be listed as share receiver via "simple-folder" on the webUI
+    When the user opens the sharing tab from the file action menu of file "lorem.txt" using the webUI
+    Then user "user2" should be listed as share receiver via "simple-folder" on the webUI
+
+  @skip @yetToImplement @issue-2897
+  Scenario: sharing details of items inside a re-shared folder
+    Given these users have been created without skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+      | user3    |
+    And user "user1" has created folder "/simple-folder"
+    And user "user1" has created folder "/simple-folder/simple-empty-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user2" has shared folder "simple-folder" with user "user3"
+    And user "user2" has logged in using the webUI
+    And the user has opened folder "simple-folder" using the webUI
+    When the user opens the sharing tab from the file action menu of folder "simple-empty-folder" using the webUI
+    Then user "user3" should be listed as share receiver via "simple-folder" on the webUI
+    When the user opens the sharing tab from the file action menu of file "lorem.txt" using the webUI
+    Then user "user3" should be listed as share receiver via "simple-folder" on the webUI
+
+  @issue-2060
+  Scenario: sharing indicator for file uploaded inside a shared folder
+    Given user "user1" has shared folder "/simple-empty-folder" with user "user2"
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-empty-folder" using the webUI
+    And the user uploads file "new-lorem.txt" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName      | expectedIndicators |
+      | new-lorem.txt | user-indirect      |
+
+  @issue-2060
+  Scenario: sharing indicator for folder created inside a shared folder
+    Given user "user1" has shared folder "/simple-empty-folder" with user "user2"
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-empty-folder" using the webUI
+    And the user creates a folder with the name "sub-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName      | expectedIndicators |
+      | sub-folder    | user-indirect      |
+
+  @skip @yetToImplement @issue-2897
+  Scenario: sharing details of items inside a shared folder shared with multiple users
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+      | user3    |
+    And user "user1" has created folder "/simple-folder"
+    And user "user1" has created folder "/simple-folder/sub-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/sub-folder/lorem.txt"
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user1" has shared folder "/simple-folder/sub-folder" with user "user3"
+    And user "user1" has logged in using the webUI
+    And the user has opened folder "simple-folder/sub-folder" using the webUI
+    When the user opens the sharing tab from the file action menu of file "lorem.txt" using the webUI
+    Then user "User Two" should be listed as share receiver via "simple-folder" on the webUI
+    And user "User Three" should be listed as share receiver via "sub-folder" on the webUI
+

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -838,3 +838,148 @@ Feature: Share by public link
 #      | name          |
 #      | links         |
 #      | collaborators |
+
+  @issue-2060
+  Scenario: sharing indicator inside a shared folder
+    Given user "user1" has created folder "/simple-folder/sub-folder"
+    And user "user1" has uploaded file with content "test" to "/simple-folder/textfile.txt"
+    And user "user1" has shared folder "simple-folder" with link with "read" permissions
+    When user "user1" has logged in using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName      | expectedIndicators |
+      | simple-folder | link-direct        |
+    When the user opens folder "simple-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName     | expectedIndicators |
+      | sub-folder   | link-indirect      |
+      | textfile.txt | link-indirect      |
+
+  @issue-2060
+  Scenario: sharing indicator for file uploaded inside a shared folder
+    Given user "user1" has shared folder "simple-folder" with link with "read" permissions
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    And the user uploads file "new-lorem.txt" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName      | expectedIndicators |
+      | new-lorem.txt | link-indirect      |
+
+  @issue-2060
+  Scenario: sharing indicator for folder created inside a shared folder
+    Given user "user1" has shared folder "simple-folder" with link with "read" permissions
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    And the user creates a folder with the name "sub-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName   | expectedIndicators |
+      | sub-folder | link-indirect      |
+
+  @issue-2060
+  Scenario: sharing indicators public link and collaborators inside a shared folder
+    Given user "user2" has been created with default attributes
+    And user "user1" has created folder "/simple-folder/sub-folder"
+    And user "user1" has uploaded file with content "test" to "/simple-folder/textfile.txt"
+    And user "user1" has shared folder "simple-folder" with link with "read" permissions
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    When user "user1" has logged in using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName      | expectedIndicators      |
+      | simple-folder | link-direct,user-direct |
+    When the user opens folder "simple-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName     | expectedIndicators |
+      | sub-folder   | link-indirect,user-indirect |
+      | textfile.txt | link-indirect,user-indirect |
+
+  @issue-2060
+  Scenario: sharing indicators public link from reshare
+    Given user "user2" has been created with default attributes
+    And user "user1" has created folder "/simple-folder/sub-folder"
+    And user "user1" has uploaded file with content "test" to "/simple-folder/textfile.txt"
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user2" has shared folder "simple-folder (2)" with link with "read" permissions
+    When user "user2" has logged in using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName          | expectedIndicators        |
+      | simple-folder (2) | link-direct,user-indirect |
+    When the user opens folder "simple-folder (2)" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName     | expectedIndicators |
+      | sub-folder   | link-indirect,user-indirect |
+      | textfile.txt | link-indirect,user-indirect |
+
+  @issue-2060
+  Scenario: sharing indicators public link from child of reshare
+    Given user "user2" has been created with default attributes
+    And user "user1" has created folder "/simple-folder/sub-folder"
+    And user "user1" has uploaded file with content "test" to "/simple-folder/textfile.txt"
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user2" has shared folder "simple-folder (2)/sub-folder" with link with "read" permissions
+    When user "user2" has logged in using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName          | expectedIndicators |
+      | simple-folder (2) | user-indirect      |
+    When the user opens folder "simple-folder (2)" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName     | expectedIndicators          |
+      | sub-folder   | link-direct,user-indirect   |
+      | textfile.txt | user-indirect |
+
+  @issue-2060
+  Scenario: no sharing indicator visible in file list from public link
+    Given user "user2" has been created with default attributes
+    And user "user3" has been created with default attributes
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user2" has shared folder "simple-folder (2)/simple-empty-folder" with user "user3"
+    And user "user2" has shared folder "simple-folder (2)" with link with "read" permissions
+    When the public uses the webUI to access the last public link created by user "user2"
+    Then the following resources should not have share indicators on the webUI
+      | simple-empty-folder |
+
+  @skip @yetToImplement @issue-2897
+  Scenario: sharing details of items inside a shared folder
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has created folder "/simple-folder/sub-folder"
+    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/textfile.txt"
+    And user "user1" has created a public link share with settings
+      | path | /simple-folder |
+      | name | Public Link    |
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    And the user opens the share dialog for folder "sub-folder"
+    And the user opens the public link share tab
+    Then public link "Public Link" should be listed as share receiver via "simple-folder" on the webUI
+
+  @skip @yetToImplement @issue-2897
+  Scenario: sharing details of multiple public link shares with different link names
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has created folder "/simple-folder/sub-folder"
+    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/sub-folder/textfile.txt"
+    And user "user1" has created a public link share with settings
+      | path | /simple-folder |
+      | name | Public Link    |
+    And user "user1" has created a public link share with settings
+      | path | /simple-folder/sub-folder      |
+      | name | strängé लिंक नाम (#2 &).नेपाली |
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    And the user opens the share dialog for folder "sub-folder"
+    And the user opens the public link share tab
+    Then public link "Public Link" should be listed as share receiver via "simple-folder" on the webUI
+    When the user opens folder "sub-folder" using the webUI
+    And the user opens the share dialog for file "textfile.txt"
+    And the user opens the public link share tab
+    Then public link "strängé लिंक नाम (#2 &).नेपाली" should be listed as share receiver via "sub-folder" on the webUI
+    And public link "Public Link" should be listed as share receiver via "simple-folder" on the webUI
+
+  @skip @yetToImplement @issue-2897
+  Scenario: sharing detail of items in the webUI shared by public links with empty name
+    Given user "user1" has created folder "/simple-folder"
+    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/textfile.txt"
+    And user "user1" has created a public link share with settings
+      | path | /simple-folder |
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    And the user opens the share dialog for file "textfile.txt"
+    And the user opens the public link share tab
+    Then public link with last share token should be listed as share receiver via "simple-folder" on the webUI

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -763,6 +763,42 @@ module.exports = {
       return this
     },
 
+    getShareIndicatorsForResource: async function (fileName) {
+      const resourceRowXpath = this.getFileRowSelectorByFileName(fileName)
+      const shareIndicatorsXpath = resourceRowXpath + this.elements.shareIndicatorsInFileRow.selector
+      const indicators = []
+      await this
+        .useXpath()
+        .moveToElement(resourceRowXpath, 0, 0)
+        .api.elements(
+          this.elements.shareIndicatorsInFileRow.locateStrategy,
+          shareIndicatorsXpath,
+          (result) => {
+            result.value.forEach(async element => {
+              await this.api.elementIdAttribute(element.ELEMENT, 'aria-label', (attr) => {
+                switch (attr.value) {
+                  case 'Directly shared with collaborators':
+                    indicators.push('user-direct')
+                    break
+                  case 'Shared with collaborators through one of the parent folders':
+                    indicators.push('user-indirect')
+                    break
+                  case 'Directly shared with links':
+                    indicators.push('link-direct')
+                    break
+                  case 'Shared with links through one of the parent folders':
+                    indicators.push('link-indirect')
+                    break
+                  default:
+                    console.warn('Unknown share indicator found: "' + attr + '"')
+                }
+              })
+            })
+          }
+        )
+      return indicators
+    },
+
     /**
      * Returns original string with replaced target character
      * @param   {string} string     String in which will be the target character replaced
@@ -855,6 +891,10 @@ module.exports = {
     },
     markedFavoriteInFileRow: {
       selector: '//span[contains(@class, "oc-star-shining")]',
+      locateStrategy: 'xpath'
+    },
+    shareIndicatorsInFileRow: {
+      selector: '//*[contains(@class, "file-row-share-indicator")]',
       locateStrategy: 'xpath'
     },
     sharingSideBar: {

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -1128,3 +1128,25 @@ Then('only favorite files containing pattern {string} in their name should be li
   const allListedFilesFolders = await client.page.filesPage().getAllListedResources()
   return assertDesiredResourcesListed(filesMatchingPattern, allListedFilesFolders)
 })
+
+Then('the following resources should have share indicators on the webUI', async function (dataTable) {
+  for (const { fileName, expectedIndicators } of dataTable.hashes()) {
+    const indicatorsArray = await client
+      .page.FilesPageElement.filesList().getShareIndicatorsForResource(fileName)
+
+    const expectedIndicatorsArray = expectedIndicators.split(',').map(s => s.trim())
+    assert.ok(
+      _.intersection(indicatorsArray, expectedIndicatorsArray).length === expectedIndicatorsArray.length,
+      `Expected share indicators to be the same for "${fileName}": expected [` + expectedIndicatorsArray.join(', ') + '] got [' + indicatorsArray.join(', ') + ']'
+    )
+  }
+})
+
+Then('the following resources should not have share indicators on the webUI', async function (dataTable) {
+  for (const fileName in dataTable.rows()) {
+    const indicatorsArray = await client
+      .page.FilesPageElement.filesList().getShareIndicatorsForResource(fileName)
+
+    assert.ok(!indicatorsArray.length, `Expected no share indicators present for "${fileName}"`)
+  }
+})


### PR DESCRIPTION
## Steps to view:

1. Setup a new OC 10.4 server
1. Run the script from https://github.com/owncloud/product/pull/40
1. Open Phoenix
1. Login as "bob" with password "test"
1. Browse the folders and enjoy the share indicators

<img width="690" alt="image" src="https://user-images.githubusercontent.com/277525/72359643-ecbac180-36ee-11ea-9f4e-25e1478613ec.png">

Ref: https://github.com/owncloud/owncloud-design-system/pull/607
For story: https://github.com/owncloud/enterprise/issues/3701

Fixes https://github.com/owncloud/phoenix/issues/2060
Fixes https://github.com/owncloud/phoenix/issues/2894

@pmaier1 FYI