### PR TITLE
send OCS-APIREQUEST header for OCS requests in tests

### DIFF
--- a/tests/acceptance/helpers/config.js
+++ b/tests/acceptance/helpers/config.js
@@ -14,7 +14,7 @@ const config = {}
 async function setSkeletonDirectory (server, admin) {
   const data = JSON.stringify({ directory: 'webUISkeleton' })
   const headers = {
-    ...httpHelper.createAuthHeader(admin),
+    ...httpHelper.createOCSRequestHeaders(admin),
     'Content-Type': 'application/json'
   }
   const apiUrl = join(

--- a/tests/acceptance/helpers/httpHelper.js
+++ b/tests/acceptance/helpers/httpHelper.js
@@ -4,7 +4,7 @@ const _ = require('lodash')
  *
  * @param {string} userId
  *
- * @returns {string}
+ * @returns {{Authorization: string}}
  */
 exports.createAuthHeader = function (userId) {
   const password = userSettings.getPasswordForUser(userId)
@@ -13,7 +13,18 @@ exports.createAuthHeader = function (userId) {
       Buffer.from(userId + ':' + password).toString('base64')
   }
 }
-
+/**
+ *
+ * @param {string} userId
+ *
+ * @returns {{<header>: string}}
+ */
+exports.createOCSRequestHeaders = function (userId) {
+  return {
+    ...this.createAuthHeader(userId),
+    'OCS-APIREQUEST': true
+  }
+}
 /**
  *
  * @param {node-fetch.Response} response

--- a/tests/acceptance/helpers/occHelper.js
+++ b/tests/acceptance/helpers/occHelper.js
@@ -9,7 +9,7 @@ const { join } = require('./path')
  * @param {Array} args
  */
 exports.runOcc = function (args) {
-  const headers = httpHelper.createAuthHeader('admin')
+  const headers = httpHelper.createOCSRequestHeaders('admin')
   const params = new URLSearchParams()
   params.append('command', args.join(' '))
   const apiURL = join(backendHelper.getCurrentBackendUrl(), '/ocs/v2.php/apps/testing/api/v1/occ?format=json')

--- a/tests/acceptance/helpers/sharingHelper.js
+++ b/tests/acceptance/helpers/sharingHelper.js
@@ -85,7 +85,8 @@ module.exports = {
    */
   assertUserHasShareWithDetails: function (user, expectedDetailsTable, filters = {}) {
     codify.replaceInlineTable(expectedDetailsTable)
-    const headers = httpHelper.createAuthHeader(user)
+    const headers = httpHelper.createOCSRequestHeaders(user)
+
     const sharingHelper = this
     const apiURL = new URL(join(client.globals.backend_url, '/ocs/v2.php/apps/files_sharing/api/v1/shares'))
     apiURL.search = new URLSearchParams({ format: 'json', ...filters }).toString()
@@ -131,7 +132,7 @@ module.exports = {
    */
   fetchLastPublicLinkShare: async function (linkCreator) {
     const self = this
-    const headers = httpHelper.createAuthHeader(linkCreator)
+    const headers = httpHelper.createOCSRequestHeaders(linkCreator)
     const apiURL = join(client.globals.backend_url, '/ocs/v2.php/apps/files_sharing/api/v1/shares?format=json')
     let lastShareToken
     let lastShare
@@ -164,7 +165,7 @@ module.exports = {
    * @returns {Object<[]>}
    */
   getAllPublicLinkShares: async function (sharer) {
-    const headers = httpHelper.createAuthHeader(sharer)
+    const headers = httpHelper.createOCSRequestHeaders(sharer)
     const data = []
     const apiURL = join(client.globals.backend_url, '/ocs/v2.php/apps/files_sharing/api/v1/shares?&format=json')
     const response = await fetch(apiURL, {
@@ -187,7 +188,7 @@ module.exports = {
    * @returns {Promise<[*]>}
    */
   getAllShares: function (user, sharedWithUser = false) {
-    const headers = httpHelper.createAuthHeader(user)
+    const headers = httpHelper.createOCSRequestHeaders(user)
     const params = new URLSearchParams()
     if (sharedWithUser === true) {
       params.set('shared_with_me', 'true')
@@ -236,7 +237,7 @@ module.exports = {
     }
     for (const element of elementsToDecline) {
       const shareID = element.id
-      const headers = httpHelper.createAuthHeader(user)
+      const headers = httpHelper.createOCSRequestHeaders(user)
       const apiURL = join(client.globals.backend_url,
         '/ocs/v2.php/apps/files_sharing/api/v1/shares/pending/',
         shareID,
@@ -276,7 +277,7 @@ module.exports = {
     }
     for (const element of elementsToAccept) {
       const shareID = element.id
-      const headers = httpHelper.createAuthHeader(user)
+      const headers = httpHelper.createOCSRequestHeaders(user)
       const apiURL = join(client.globals.backend_url,
         '/ocs/v2.php/apps/files_sharing/api/v1/shares/pending/',
         shareID,

--- a/tests/acceptance/stepDefinitions/generalContext.js
+++ b/tests/acceptance/stepDefinitions/generalContext.js
@@ -133,7 +133,7 @@ Given('the administrator has cleared the versions for all users', function () {
 const setTrustedServer = function (url) {
   const body = new URLSearchParams()
   body.append('url', url)
-  const headers = httpHelper.createAuthHeader(client.globals.backend_admin_username)
+  const headers = httpHelper.createOCSRequestHeaders(client.globals.backend_admin_username)
   const postUrl = join(backendHelper.getCurrentBackendUrl(), '/ocs/v2.php/apps/testing/api/v1/trustedservers?format=json')
   return fetch(postUrl,
     { method: 'POST', headers, body })
@@ -175,7 +175,7 @@ After(async function (testCase) {
   createdFiles.forEach(fileName => fs.unlinkSync(fileName))
 
   // clear file locks
-  const headers = httpHelper.createAuthHeader(client.globals.backend_admin_username)
+  const headers = httpHelper.createOCSRequestHeaders(client.globals.backend_admin_username)
   const body = new URLSearchParams()
   body.append('global', 'true')
   await fetch(join(client.globals.backend_url, '/ocs/v2.php/apps/testing/api/v1/lockprovisioning'),

--- a/tests/acceptance/stepDefinitions/notificationsContext.js
+++ b/tests/acceptance/stepDefinitions/notificationsContext.js
@@ -13,7 +13,7 @@ When('user {string} is sent a notification', function (user) {
   const apiURL = join(client.globals.backend_url, '/ocs/v2.php/apps/testing/api/v1/notifications')
 
   return fetch(apiURL,
-    { method: 'POST', headers: httpHelper.createAuthHeader(user), body: body }
+    { method: 'POST', headers: httpHelper.createOCSRequestHeaders(user), body: body }
   )
     .then(res => httpHelper.checkStatus(res, 'Could not generate notification.'))
 })
@@ -35,7 +35,7 @@ Given('app {string} has been {}', function (app, action) {
     action === 'enabled' || action === 'disabled',
     "only supported either 'enabled' or 'disabled'. Passed: " + action
   )
-  const headers = httpHelper.createAuthHeader('admin')
+  const headers = httpHelper.createOCSRequestHeaders('admin')
   const method = action === 'enabled' ? 'POST' : 'DELETE'
 
   const errorMessage = util.format(

--- a/tests/acceptance/stepDefinitions/provisioningContext.js
+++ b/tests/acceptance/stepDefinitions/provisioningContext.js
@@ -22,7 +22,7 @@ function createUser (userId, password, displayName = false, email = false) {
   const promiseList = []
 
   userSettings.addUserToCreatedUsersList(userId, password, displayName, email)
-  const headers = httpHelper.createAuthHeader(client.globals.backend_admin_username)
+  const headers = httpHelper.createOCSRequestHeaders(client.globals.backend_admin_username)
   return fetch(
     join(
       backendHelper.getCurrentBackendUrl(),
@@ -80,7 +80,7 @@ function createUser (userId, password, displayName = false, email = false) {
 }
 
 function deleteUser (userId) {
-  const headers = httpHelper.createAuthHeader(client.globals.backend_admin_username)
+  const headers = httpHelper.createOCSRequestHeaders(client.globals.backend_admin_username)
   userSettings.deleteUserFromCreatedUsersList(userId)
   return fetch(
     join(
@@ -92,7 +92,7 @@ function deleteUser (userId) {
 }
 
 function initUser (userId) {
-  const headers = httpHelper.createAuthHeader(userId)
+  const headers = httpHelper.createOCSRequestHeaders(userId)
   return fetch(
     join(
       backendHelper.getCurrentBackendUrl(),
@@ -112,7 +112,7 @@ function createGroup (groupId) {
   const body = new URLSearchParams()
   body.append('groupid', groupId)
   userSettings.addGroupToCreatedGroupsList(groupId)
-  const headers = httpHelper.createAuthHeader(client.globals.backend_admin_username)
+  const headers = httpHelper.createOCSRequestHeaders(client.globals.backend_admin_username)
   return fetch(join(client.globals.backend_url, '/ocs/v2.php/cloud/groups?format=json'), {
     method: 'POST',
     body: body,
@@ -126,7 +126,7 @@ function createGroup (groupId) {
  * @returns {*|Promise}
  */
 function deleteGroup (groupId) {
-  const headers = httpHelper.createAuthHeader(client.globals.backend_admin_username)
+  const headers = httpHelper.createOCSRequestHeaders(client.globals.backend_admin_username)
   userSettings.deleteGroupFromCreatedGroupsList(groupId)
   return fetch(join(client.globals.backend_url, '/ocs/v2.php/cloud/groups/', groupId),
     { method: 'DELETE', headers: headers })
@@ -136,7 +136,7 @@ function addToGroup (userId, groupId) {
   const body = new URLSearchParams()
   body.append('groupid', groupId)
 
-  const headers = httpHelper.createAuthHeader(client.globals.backend_admin_username)
+  const headers = httpHelper.createOCSRequestHeaders(client.globals.backend_admin_username)
   return fetch(join(client.globals.backend_url, `/ocs/v2.php/cloud/users/${userId}/groups`),
     { method: 'POST', body: body, headers: headers }
   )
@@ -158,7 +158,7 @@ Given('user {string} has been created with default attributes on remote server',
 })
 
 Given('the quota of user {string} has been set to {string}', function (userId, quota) {
-  const headers = httpHelper.createAuthHeader(client.globals.backend_admin_username)
+  const headers = httpHelper.createOCSRequestHeaders(client.globals.backend_admin_username)
   const body = new URLSearchParams()
   body.append('key', 'quota')
   body.append('value', quota)

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -113,12 +113,13 @@ const shareFileFolder = function (
       params.append(key, extraParams[key])
     }
   }
+
   return fetch(
     path.join(
       backendHelper.getCurrentBackendUrl(),
       '/ocs/v2.php/apps/files_sharing/api/v1/shares?format=json'
     ),
-    { method: 'POST', headers: httpHelper.createAuthHeader(sharer), body: params }
+    { method: 'POST', headers: httpHelper.createOCSRequestHeaders(sharer), body: params }
   )
     .then(res => res.json())
     .then(function (json) {


### PR DESCRIPTION
## Description
core requires now the 'OCS-APIREQUEST' header to be set in OCS requests, see https://github.com/owncloud/core/pull/36762

## Motivation and Context
fix CI

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...