### PR TITLE
Adjust labels in "new" menu in files app

### DIFF
--- a/apps/draw-io/src/app.js
+++ b/apps/draw-io/src/app.js
@@ -23,7 +23,7 @@ const appInfo = {
     routeName: 'draw-io-edit',
     newFileMenu: {
       menuTitle ($gettext) {
-        return $gettext('Create new draw.io document…')
+        return $gettext('New draw.io document…')
       }
     }
   }

--- a/apps/files/src/components/FilesAppBar.vue
+++ b/apps/files/src/components/FilesAppBar.vue
@@ -36,7 +36,7 @@
               <oc-nav>
                 <file-upload :path='currentPath' :headers="headers" @success="onFileSuccess" @error="onFileError" @progress="onFileProgress"></file-upload>
                 <folder-upload v-if="!isIE11()" :rootPath='item' :path='currentPath' :headers="headers" @success="onFileSuccess" @error="onFileError" @progress="onFileProgress"></folder-upload>
-                <oc-nav-item @click="showCreateFolderDialog" id="new-folder-btn" icon="create_new_folder"><translate>Create new folder…</translate></oc-nav-item>
+                <oc-nav-item @click="showCreateFolderDialog" id="new-folder-btn" icon="create_new_folder"><translate>New folder…</translate></oc-nav-item>
                 <oc-nav-item v-for="(newFileHandler, key) in newFileHandlers"
                   :key="key"
                   @click="showCreateFileDialog(newFileHandler.ext, newFileHandler.action)"
@@ -167,7 +167,7 @@ export default {
       return this.$gettext('Folder name')
     },
     $_createFolderDialogTitle () {
-      return this.$gettext('Create new folder…')
+      return this.$gettext('New folder…')
     },
     $_createFileDialogPlaceholder () {
       return this.$gettext('Enter new file name…')
@@ -176,7 +176,7 @@ export default {
       return this.$gettext('File name')
     },
     $_createFileDialogTitle () {
-      return this.$gettext('Create new file…')
+      return this.$gettext('New file…')
     },
     _cannotCreateDialogText () {
       if (!this.canUpload) {

--- a/apps/markdown-editor/src/app.js
+++ b/apps/markdown-editor/src/app.js
@@ -26,7 +26,7 @@ const appInfo = {
     extension: 'txt',
     newFileMenu: {
       menuTitle ($gettext) {
-        return $gettext('Create new plain text file…')
+        return $gettext('New plain text file…')
       }
     }
   },
@@ -34,7 +34,7 @@ const appInfo = {
     extension: 'md',
     newFileMenu: {
       menuTitle ($gettext) {
-        return $gettext('Create new mark-down file…')
+        return $gettext('New mark-down file…')
       }
     }
   }

--- a/changelog/unreleased/2902
+++ b/changelog/unreleased/2902
@@ -1,0 +1,7 @@
+Change: Adjusted labels in files list
+
+Renamed "Modification time" to "Updated" to make it look less technical.
+Replace "Create new" with "New" in the "New" menu as it makes it look less cluttered when trying to spot a matching entry.
+
+https://github.com/owncloud/phoenix/pull/2902
+https://github.com/owncloud/phoenix/pull/2905


### PR DESCRIPTION
## Description
Replace "Create new" with "New" as it makes it look less cluttered when
trying to spot a matching entry.

Added changelog entry for this one and also another column header
change.

## Related Issue
None raised, quick fix.

## Motivation and Context
See description

## How Has This Been Tested?
Manual test, see screenshot

## Screenshots (if appropriate):
<img width="353" alt="image" src="https://user-images.githubusercontent.com/277525/72890429-22286600-3d12-11ea-8a56-22130b48fece.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
