### PR TITLE
Fix Changelog generator for forked repos

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -182,6 +182,7 @@ def build(ctx):
 
 def changelog(ctx):
 	pipelines = []
+	repo_slug = ctx.build.source_repo if ctx.build.source_repo else ctx.repo.slug
 
 	result = {
 		'kind': 'pipeline',
@@ -199,7 +200,7 @@ def changelog(ctx):
 					'actions': [
 						'clone',
 					],
-					'remote': 'https://github.com/%s' % (ctx.repo.slug),
+					'remote': 'https://github.com/%s' % (repo_slug),
 					'branch': ctx.build.source if ctx.build.event == 'pull_request' else 'master',
 					'path': '/drone/src',
 					'netrc_machine': 'github.com',


### PR DESCRIPTION
## Description
Fix Changelog generator for forked repos

## Motivation and Context
The changelog clone step clones the working repo and checks out the source branch.
If you are merging a branch from a forked repo, the repo slug is different.

## How Has This Been Tested?
Drone CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...