### PR TITLE
Join users and groups in collab sidebar

### DIFF
--- a/apps/files/src/components/FileSharingSidebar.vue
+++ b/apps/files/src/components/FileSharingSidebar.vue
@@ -14,7 +14,7 @@
         />
         <div v-if="$_ocCollaborators.length > 0" id="files-collaborators-list" key="oc-collaborators-user-list">
           <template v-for="collaborator in $_ocCollaborators">
-            <oc-grid :key="collaborator.info.id" gutter="small" class="files-collaborators-collaborator">
+            <oc-grid :key="collaborator.info.id" :flex="true" gutter="small" class="files-collaborators-collaborator">
               <div>
                 <oc-button :ariaLabel="$gettext('Delete share')" @click="$_ocCollaborators_deleteShare(collaborator)" variation="raw" class="files-collaborators-collaborator-delete">
                   <oc-icon name="close" />

--- a/apps/files/src/components/FileSharingSidebar.vue
+++ b/apps/files/src/components/FileSharingSidebar.vue
@@ -50,6 +50,7 @@
 <script>
 import { mapGetters, mapActions, mapState } from 'vuex'
 import Mixins from '../mixins/collaborators'
+import { textUtils } from '../helpers/textUtils'
 const NewCollaborator = _ => import('./Collaborators/NewCollaborator.vue')
 const EditCollaborator = _ => import('./Collaborators/EditCollaborator.vue')
 const Collaborator = _ => import('./Collaborators/Collaborator.vue')
@@ -118,7 +119,7 @@ export default {
               return this.$_ocCollaborators_isGroup(c1) ? -1 : 1
             }
           } else {
-            return name1 < name2 ? -1 : 1
+            return textUtils.naturalSortCompare(name1, name2)
           }
         })
     },

--- a/apps/files/src/components/FileSharingSidebar.vue
+++ b/apps/files/src/components/FileSharingSidebar.vue
@@ -12,45 +12,24 @@
           key="no-reshare-permissions-message"
           v-text="noResharePermsMessage"
         />
-        <div v-if="$_ocCollaborators_users.length > 0" id="files-collaborators-list" key="oc-collaborators-user-list">
-          <h5>
-            <translate>Users</translate>
-            ({{ $_ocCollaborators_users.length }})
-          </h5>
-          <template v-for="user in $_ocCollaborators_users">
-            <oc-grid :key="user.info.id" gutter="small" class="files-collaborators-collaborator">
+        <div v-if="$_ocCollaborators.length > 0" id="files-collaborators-list" key="oc-collaborators-user-list">
+          <template v-for="collaborator in $_ocCollaborators">
+            <oc-grid :key="collaborator.info.id" gutter="small" class="files-collaborators-collaborator">
               <div>
-                <oc-button :ariaLabel="$gettext('Delete share')" @click="$_ocCollaborators_deleteShare(user)" variation="raw" class="files-collaborators-collaborator-delete">
+                <oc-button :ariaLabel="$gettext('Delete share')" @click="$_ocCollaborators_deleteShare(collaborator)" variation="raw" class="files-collaborators-collaborator-delete">
                   <oc-icon name="close" />
                 </oc-button>
               </div>
-              <collaborator class="uk-width-expand" :collaborator="user" />
+              <collaborator class="uk-width-expand" :collaborator="collaborator" />
               <div class="uk-width-auto">
-                <oc-button :aria-label="$gettext('Edit share')" @click="$_ocCollaborators_editShare(user)" variation="raw" class="files-collaborators-collaborator-edit">
+                <oc-button :aria-label="$gettext('Edit share')" @click="$_ocCollaborators_editShare(collaborator)" variation="raw" class="files-collaborators-collaborator-edit">
                   <oc-icon name="edit" />
                 </oc-button>
               </div>
             </oc-grid>
           </template>
         </div>
-        <div v-if="$_ocCollaborators_groups.length > 0" id="files-collaborators-list-groups" key="oc-collaborators-group-list">
-          <h5>
-            <translate>Groups</translate>
-            ({{ $_ocCollaborators_groups.length }})
-          </h5>
-          <template v-for="group in $_ocCollaborators_groups">
-            <oc-grid :key="group.info.id" gutter="small" class="files-collaborators-collaborator">
-              <oc-button :aria-label="$gettext('Delete share')" @click="$_ocCollaborators_deleteShare(group)" variation="raw" class="files-collaborators-collaborator-delete uk-vertical-align">
-                <oc-icon name="close" />
-              </oc-button>
-              <collaborator class="uk-width-expand" :collaborator="group" />
-              <oc-button :aria-label="$gettext('Edit share')" @click="$_ocCollaborators_editShare(group)" variation="raw" class="files-collaborators-collaborator-edit">
-                <oc-icon name="edit" />
-              </oc-button>
-            </oc-grid>
-          </template>
-        </div>
-        <div v-if="!shares.length && !sharesLoading" key="oc-collaborators-no-results"><translate>No collaborators</translate></div>
+        <div v-else-if="!sharesLoading" key="oc-collaborators-no-results"><translate>No collaborators</translate></div>
       </template>
     </div>
     <div :aria-hidden="visiblePanel != 'newCollaborator'" :inert="visiblePanel != 'newCollaborator'">
@@ -125,15 +104,23 @@ export default {
     selectedFile () {
       return this.highlightedFile
     },
-    $_ocCollaborators_users () {
-      return this.shares.filter(collaborator => {
-        return collaborator.info.share_type === '0' || collaborator.info.share_type === '6'
-      })
-    },
-    $_ocCollaborators_groups () {
-      return this.shares.filter(collaborator => {
-        return collaborator.info.share_type === '1'
-      })
+    $_ocCollaborators () {
+      return this.shares
+        .filter(collaborator => this.$_ocCollaborators_isUser(collaborator) || this.$_ocCollaborators_isGroup(collaborator))
+        .sort((c1, c2) => {
+          const name1 = c1.displayName.toLowerCase().trim()
+          const name2 = c2.displayName.toLowerCase().trim()
+          // sorting priority 1: display name (lower case, ascending), 2: share type (groups first), 3: id (ascending)
+          if (name1 === name2) {
+            if (this.$_ocCollaborators_isGroup(c1) === this.$_ocCollaborators_isGroup(c2)) {
+              return parseInt(c1.info.id, 10) < parseInt(c2.info.id, 10) ? -1 : 1
+            } else {
+              return this.$_ocCollaborators_isGroup(c1) ? -1 : 1
+            }
+          } else {
+            return name1 < name2 ? -1 : 1
+          }
+        })
     },
     $_ocCollaborators_canShare () {
       return this.highlightedFile.canShare()
@@ -158,6 +145,12 @@ export default {
         client: this.$client,
         share: share
       })
+    },
+    $_ocCollaborators_isUser (collaborator) {
+      return collaborator.info.share_type === '0' || collaborator.info.share_type === '6'
+    },
+    $_ocCollaborators_isGroup (collaborator) {
+      return collaborator.info.share_type === '1'
     }
   }
 }

--- a/apps/files/src/fileSortFunctions.js
+++ b/apps/files/src/fileSortFunctions.js
@@ -1,55 +1,4 @@
-/**
- * Compare two strings to provide a natural sort
- * @param a first string to compare
- * @param b second string to compare
- * @return -1 if b comes before a, 1 if a comes before b
- * or 0 if the strings are identical
- */
-function _chunkify (t) {
-  // Adapted from http://my.opera.com/GreyWyvern/blog/show.dml/1671288
-  const tz = []; let x = 0; let y = -1; let n = 0; let c
-
-  while (x < t.length) {
-    c = t.charAt(x)
-    // only include the dot in strings
-    const m = ((!n && c === '.') || (c >= '0' && c <= '9'))
-    if (m !== n) {
-      // next chunk
-      y++
-      tz[y] = ''
-      n = m
-    }
-    tz[y] += c
-    x++
-  }
-  return tz
-}
-
-function _naturalSortCompare (a, b) {
-  const aa = _chunkify(a)
-  const bb = _chunkify(b)
-  let x, aNum, bNum
-
-  for (x = 0; aa[x] && bb[x]; x++) {
-    if (aa[x] !== bb[x]) {
-      aNum = Number(aa[x])
-      bNum = Number(bb[x])
-      // note: == is correct here
-      // eslint-disable-next-line eqeqeq
-      if (aNum == aa[x] && bNum == bb[x]) {
-        return aNum - bNum
-      } else {
-        // Forcing 'en' locale to match the server-side locale which is
-        // always 'en'.
-        //
-        // Note: This setting isn't supported by all browsers but for the ones
-        // that do there will be more consistency between client-server sorting
-        return aa[x].localeCompare(bb[x], 'en')
-      }
-    }
-  }
-  return aa.length - bb.length
-}
+import { textUtils } from './helpers/textUtils'
 
 function name (fileInfo1, fileInfo2) {
   if (fileInfo1.type === 'folder' && fileInfo2.type !== 'folder') {
@@ -58,7 +7,7 @@ function name (fileInfo1, fileInfo2) {
   if (fileInfo1.type !== 'folder' && fileInfo2.type === 'folder') {
     return 1
   }
-  return _naturalSortCompare(fileInfo1.name, fileInfo2.name)
+  return textUtils.naturalSortCompare(fileInfo1.name, fileInfo2.name)
 }
 
 export const fileSortFunctions = {

--- a/apps/files/src/helpers/textUtils.js
+++ b/apps/files/src/helpers/textUtils.js
@@ -1,0 +1,56 @@
+function _chunkify (t) {
+  // Adapted from http://my.opera.com/GreyWyvern/blog/show.dml/1671288
+  const tz = []; let x = 0; let y = -1; let n = 0; let c
+
+  while (x < t.length) {
+    c = t.charAt(x)
+    // only include the dot in strings
+    const m = ((!n && c === '.') || (c >= '0' && c <= '9'))
+    if (m !== n) {
+      // next chunk
+      y++
+      tz[y] = ''
+      n = m
+    }
+    tz[y] += c
+    x++
+  }
+  return tz
+}
+
+/**
+ * Compare two strings to provide a natural sort
+ * @param a first string to compare
+ * @param b second string to compare
+ * @return number Negative integer if b comes before a, positive integer if a comes before b
+ * or 0 if the strings are identical
+ */
+function naturalSortCompare (a, b) {
+  const aa = _chunkify(a)
+  const bb = _chunkify(b)
+  let x, aNum, bNum
+
+  for (x = 0; aa[x] && bb[x]; x++) {
+    if (aa[x] !== bb[x]) {
+      aNum = Number(aa[x])
+      bNum = Number(bb[x])
+      // note: == is correct here
+      // eslint-disable-next-line eqeqeq
+      if (aNum == aa[x] && bNum == bb[x]) {
+        return aNum - bNum
+      } else {
+        // Forcing 'en' locale to match the server-side locale which is
+        // always 'en'.
+        //
+        // Note: This setting isn't supported by all browsers but for the ones
+        // that do there will be more consistency between client-server sorting
+        return aa[x].localeCompare(bb[x], 'en')
+      }
+    }
+  }
+  return aa.length - bb.length
+}
+
+export const textUtils = {
+  naturalSortCompare
+}

--- a/changelog/unreleased/2900
+++ b/changelog/unreleased/2900
@@ -1,0 +1,7 @@
+Change: Join users and groups into a single list in collaborators sidebar
+
+Users and groups were shown as two separate lists (users, then groups) in the collaborators sidebar.
+This separation is now removed, i.e. there is only one list with all collaborators, sorted by display name
+(lower case, ascending). On equal names groups are shown first.
+
+https://github.com/owncloud/phoenix/issues/2900

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -12,8 +12,17 @@ Feature: Sharing files and folders with internal groups
     And these groups have been created:
       | groupname |
       | grp1      |
+      | grp11     |
     And user "user1" has been added to group "grp1"
     And user "user2" has been added to group "grp1"
+
+  Scenario: share a folder with multiple collaborators and check collaborator list order
+    Given user "user3" has logged in using the webUI
+    When the user shares folder "simple-folder" with group "grp11" as "Viewer" using the webUI
+    And the user shares folder "simple-folder" with user "User Two" as "Viewer" using the webUI
+    And the user shares folder "simple-folder" with group "grp1" as "Viewer" using the webUI
+    And the user shares folder "simple-folder" with user "User One" as "Viewer" using the webUI
+    Then the current collaborators list should have order "grp1,grp11,User One,User Two"
 
   Scenario Outline: share a file & folder with another internal user
     Given user "user3" has logged in using the webUI

--- a/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
@@ -421,12 +421,31 @@ module.exports = {
         .waitForOutstandingAjaxCalls()
         .api.elements('css selector', this.elements.collaboratorsInformation, result => {
           result.value.map(item => {
-            promiseList.push(new Promise((resolve, reject) => {
+            promiseList.push(new Promise((resolve) => {
               this.api.elementIdText(item[Object.keys(item)[0]], text => {
                 resolve(text.value)
               })
-            })
-            )
+            }))
+          })
+        })
+      return Promise.all(promiseList)
+    },
+    /**
+     *
+     * @returns {Promise.<string[]>} Array of user/group display names in share list
+     */
+    getCollaboratorsListNames: async function () {
+      const promiseList = []
+      await this.initAjaxCounters()
+        .waitForElementPresent({ selector: '@collaboratorsInformation', abortOnFailure: false })
+        .waitForOutstandingAjaxCalls()
+        .api.elements('css selector', this.elements.collaboratorInformationName, result => {
+          result.value.map(item => {
+            promiseList.push(new Promise((resolve) => {
+              this.api.elementIdText(item[Object.keys(item)[0]], text => {
+                resolve(text.value)
+              })
+            }))
           })
         })
       return Promise.all(promiseList)
@@ -495,6 +514,9 @@ module.exports = {
     collaboratorInformationByCollaboratorName: {
       selector: '//*[contains(@class, "files-collaborators-collaborator-name") and .="%s"]/ancestor::div[contains(concat(" ", @class, " "), " files-collaborators-collaborator ")]',
       locateStrategy: 'xpath'
+    },
+    collaboratorInformationName: {
+      selector: '.files-collaborators-collaborator .files-collaborators-collaborator-information-text .files-collaborators-collaborator-name'
     },
     collaboratorMoreInformation: {
       // within collaboratorInformationByCollaboratorName

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -740,8 +740,8 @@ Then('user {string} should not be listed in the collaborators list on the webUI'
   return assertCollaboratorslistDoesNotContain('user', user)
 })
 
-Then('group {string} should not be listed in the collaborators list on the webUI', function (user) {
-  return assertCollaboratorslistDoesNotContain('group', user)
+Then('group {string} should not be listed in the collaborators list on the webUI', function (group) {
+  return assertCollaboratorslistDoesNotContain('group', group)
 })
 
 Then('user {string} should have received a share with these details:', function (user, expectedDetailsTable) {
@@ -794,6 +794,11 @@ Then('the collaborators list for file/folder/resource {string} should be empty',
     .getCollaboratorsList()
   ).length
   assert.strictEqual(count, 0, `Expected to have no collaborators for '${resource}', Found: ${count}`)
+})
+
+Then('the current collaborators list should have order {string}', async function (expectedNames) {
+  const actualNames = (await client.page.FilesPageElement.sharingDialog().getCollaboratorsListNames()).join(',')
+  assert.strictEqual(actualNames, expectedNames, `Expected to have collaborators in order '${expectedNames}', Found: ${actualNames}`)
 })
 
 Then('file/folder {string} shared by {string} should be in {string} state on the webUI',


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
In the collaborators sidebar, the users and groups were two separate lists. This PR joins all collaborators into a single list. In oc10 the collaborators were sorted by ids (ASC), now they are sorted by displayName (lower case, ascending), on equal names, groups are shown first.
This also fixes a visual offset to the left when displaying group shares.
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/phoenix/issues/2900

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual check in Chrome + Firefox and selenium tests with sharing context.

## Screenshots:
### oC10
![Bildschirmfoto 2020-01-23 um 08 47 01](https://user-images.githubusercontent.com/3532843/72970709-7db52b00-3dc8-11ea-8f3e-32467e6341cf.png)

### Phoenix before change
![Bildschirmfoto 2020-01-23 um 08 45 27](https://user-images.githubusercontent.com/3532843/72970729-860d6600-3dc8-11ea-86bc-1c597dff5599.png)

### Phoenix after change
![Bildschirmfoto 2020-01-23 um 09 41 24](https://user-images.githubusercontent.com/3532843/72970747-8dcd0a80-3dc8-11ea-80b8-db88a1be4a52.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->