### PR TITLE
Added collaborator entries for owner and resharer

### DIFF
--- a/apps/files/src/components/Collaborators/Collaborator.vue
+++ b/apps/files/src/components/Collaborators/Collaborator.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div v-if="user.id !== collaborator.info.uid_owner" class="uk-text-meta uk-flex uk-flex-middle uk-margin-small-bottom"><oc-icon name="repeat" class="uk-margin-small-right" /> {{ collaborator.info.displayname_owner }}</div>
+    <div v-if="$_reshareInformation" class="uk-text-meta uk-flex uk-flex-middle uk-margin-small-bottom"><oc-icon name="repeat" class="uk-margin-small-right" /> {{ $_reshareInformation }}</div>
     <div class="files-collaborators-collaborator-information uk-flex uk-flex-wrap uk-flex-middle">
       <oc-spinner v-if="loading" key="collaborator-avatar-spinner" uk-spinner="ratio:1.6" class="uk-margin-small-right" :aria-label="$gettext('Loading')"/>
       <div v-else key="collaborator-avatar-loaded">
@@ -43,12 +43,27 @@ export default {
   computed: {
     ...mapGetters(['user']),
 
+    $_reshareInformation () {
+      if (this.collaborator.role.name === 'owner' || this.collaborator.role.name === 'resharer' || this.user.id === this.collaborator.info.uid_owner) {
+        return null
+      }
+
+      return this.collaborator.info.displayname_owner
+    },
+
     originalRole () {
       if (this.collaborator.role.name === 'advancedRole') {
         return this.advancedRole
       }
 
-      return this.roles[this.collaborator.role.name]
+      const role = this.displayRoles[this.collaborator.role.name]
+      if (role) {
+        return role
+      }
+
+      return {
+        label: this.$gettext('Unknown Role')
+      }
     }
   },
   mounted () {

--- a/apps/files/src/mixins/collaborators.js
+++ b/apps/files/src/mixins/collaborators.js
@@ -6,6 +6,20 @@ export default {
     ...mapGetters(['getToken']),
     ...mapGetters('Files', ['highlightedFile']),
 
+    ownerRole () {
+      return {
+        name: 'owner',
+        label: this.$gettext('Owner')
+      }
+    },
+
+    resharerRole () {
+      return {
+        name: 'resharer',
+        label: this.$gettext('Resharer')
+      }
+    },
+
     advancedRole () {
       const advancedRole = {
         name: 'advancedRole',
@@ -46,6 +60,12 @@ export default {
       collaboratorRoles.advancedRole = this.advancedRole
 
       return collaboratorRoles
+    },
+    displayRoles () {
+      const result = this.roles
+      result[this.resharerRole.name] = this.resharerRole
+      result[this.ownerRole.name] = this.ownerRole
+      return result
     }
   },
   methods: {

--- a/apps/files/src/store/mutations.js
+++ b/apps/files/src/store/mutations.js
@@ -139,6 +139,16 @@ export default {
   SHARES_LOADING (state, loading) {
     state.sharesLoading = loading
   },
+  INCOMING_SHARES_LOAD (state, shares) {
+    state.incomingShares = shares
+  },
+  INCOMING_SHARES_ERROR (state, error) {
+    state.incomingShares = []
+    state.incomingSharesError = error
+  },
+  INCOMING_SHARES_LOADING (state, loading) {
+    state.incomingSharesLoading = loading
+  },
   SHARESTREE_CLEAR (state) {
     state.sharesTree = {}
   },

--- a/apps/files/src/store/state.js
+++ b/apps/files/src/store/state.js
@@ -27,11 +27,18 @@ export default {
   shareOpen: null,
 
   /**
-   * Collaborator shares from currently highlighted element
+   * Outgoing shares from currently highlighted element
    */
   shares: [],
   sharesError: null,
   sharesLoading: false,
+
+  /**
+   * Incoming shares from currently highlighted element
+   */
+  incomingShares: {},
+  incomingSharesError: null,
+  incomingSharesLoading: false,
 
   /**
    * Link shares from currently highlighted element

--- a/tests/acceptance/features/webUIResharing/reshareUsers.feature
+++ b/tests/acceptance/features/webUIResharing/reshareUsers.feature
@@ -146,7 +146,10 @@ Feature: Resharing shared files with different permissions
     And user "user1" has logged in using the webUI
     When the user shares folder "simple-folder (2)" with user "User Three" as "Advanced permissions" with permissions "share, delete" using the webUI
     And the user re-logs in as "user3" using the webUI
-    Then the collaborators list for folder "simple-folder (2)" should be empty
+    And the user opens the share dialog for folder "simple-folder (2)" using the webUI
+    Then the current collaborators list should have order "User Two,User One"
+    And user "User Two" should be listed as "Owner" in the collaborators list on the webUI
+    And user "User One" should be listed as "Resharer" in the collaborators list on the webUI
     And user "user3" should have received a share with these details:
     | field       | value               |
     | uid_owner   | user1               |

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -299,22 +299,22 @@ Feature: Federation Sharing - sharing with users on other cloud storages
   @skip @yetToImplement @issue-2897
   Scenario: sharing details inside folder shared using federated sharing
     Given user "user1" has created folder "/simple-folder/sub-folder"
-    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/textfile.txt"
-    And user "user1" from server "LOCAL" has shared "/simple-folder" with user "user1" from server "REMOTE"
+    And user "user1" has uploaded file with content "test" to "/simple-folder/textfile.txt"
+    And the user shares folder "simple-folder" with remote user "user1" as "Editor" using the webUI
     When the user opens folder "simple-folder" using the webUI
-    And the user opens the share dialog for folder "sub-folder"
-    Then federated user "user1@%remote_server% (Remote share)" should be listed as share receiver via "simple-folder" on the webUI
+    And the user opens the share dialog for folder "sub-folder" using the webUI
+    Then user "user1@%remote_server% (Remote share)" should be listed as "Editor" via "simple-folder" in the collaborators list on the webUI
     When the user opens the share dialog for file "textfile.txt"
-    Then federated user "user1@%remote_server% (Remote share)" should be listed as share receiver via "simple-folder" on the webUI
+    Then user "user1@%remote_server% (Remote share)" should be listed as "Editor" via "simple-folder" in the collaborators list on the webUI
 
   @skip @yetToImplement @issue-2897
   Scenario: sharing details of items inside a shared folder shared with local user and federated user
-    Given user "user2" has been created with default attributes and without skeleton files
+    Given user "user2" has been created with default attributes
     And user "user1" has created folder "/simple-folder/sub-folder"
-    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/sub-folder/textfile.txt"
-    And user "user1" from server "LOCAL" has shared "/simple-folder" with user "user1" from server "REMOTE"
+    And user "user1" has uploaded file with content "test" to "/simple-folder/sub-folder/textfile.txt"
+    And the user shares folder "simple-folder" with remote user "user1" as "Editor" using the webUI
     And user "user1" has shared folder "simple-folder/sub-folder" with user "user2"
-    When the user opens folder "simple-folder/sub-folder" using the webUI
-    And the user opens the share dialog for file "textfile.txt"
-    Then federated user "user1@%remote_server% (Remote share)" should be listed as share receiver via "simple-folder" on the webUI
-    And user "User Two" should be listed as share receiver via "sub-folder" on the webUI
+    When the user opens folder "sub-folder" using the webUI
+    And the user opens the share dialog for file "textfile.txt" using the webUI
+    Then user "user1@%remote_server% (Remote share)" should be listed as "Editor" via "simple-folder" in the collaborators list on the webUI
+    And user "User Two" should be listed as "Editor" via "sub-folder" in the collaborators list on the webUI

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -278,12 +278,22 @@ Feature: Sharing files and folders with internal groups
   @skip @yetToImplement @issue-2897
   Scenario: sharing details of items inside a shared folder shared with user and group
     Given user "user3" has created folder "/simple-folder/sub-folder"
-    And user "user3" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/sub-folder/lorem.txt"
+    And user "user3" has uploaded file with content "test" to "/simple-folder/sub-folder/lorem.txt"
     And user "user3" has shared folder "simple-folder" with user "user2"
     And user "user3" has shared folder "/simple-folder/sub-folder" with group "grp1"
     And user "user3" has logged in using the webUI
-    When the user opens folder "simple-folder/sub-folder" using the webUI
-    And the user opens the sharing tab from the file action menu of file "lorem.txt" using the webUI
-    Then user "User Two" should be listed as share receiver via "simple-folder" on the webUI
-    And group "grp1" should be listed as share receiver via "sub-folder" on the webUI
+    When the user opens folder "simple-folder/sub-folder" directly on the webUI
+    And the user opens the share dialog for file "lorem.txt" using the webUI
+    Then user "User Two" should be listed as "Editor" via "simple-folder" in the collaborators list on the webUI
+    And group "grp1" should be listed as "Editor" via "sub-folder" in the collaborators list on the webUI
 
+  @skip @yetToImplement @issue-2898
+  Scenario: see resource owner of parent group shares in collaborators list
+    Given user "user3" has been created with default attributes
+    And user "user1" has shared folder "simple-folder" with group "grp1"
+    And user "user2" has shared folder "simple-folder (2)/simple-empty-folder" with user "user3"
+    And user "user3" has logged in using the webUI
+    And the user opens folder "simple-folder (2)" using the webUI
+    When the user opens the share dialog for folder "simple-empty-folder" using the webUI
+    # TODO: maybe there is already such step as the reshare icon is used already in other scenarios
+    Then user "User One" should be listed as "Owner" through "User Two" via "simple-folder (2)" in the collaborators list on the webUI

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -402,42 +402,6 @@ Feature: Sharing files and folders with internal users
       | simple-empty-folder |
       | lorem.txt           |
 
-  @skip @yetToImplement @issue-2897
-  Scenario: sharing details of items inside a shared folder
-    Given these users have been created without skeleton files:
-      | username |
-      | user1    |
-      | user2    |
-    And user "user1" has created folder "/simple-folder"
-    And user "user1" has created folder "/simple-folder/simple-empty-folder"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
-    And user "user1" has shared folder "simple-folder" with user "user2"
-    And user "user1" has logged in using the webUI
-    And the user has opened folder "simple-folder" using the webUI
-    When the user opens the sharing tab from the file action menu of folder "simple-empty-folder" using the webUI
-    Then user "user2" should be listed as share receiver via "simple-folder" on the webUI
-    When the user opens the sharing tab from the file action menu of file "lorem.txt" using the webUI
-    Then user "user2" should be listed as share receiver via "simple-folder" on the webUI
-
-  @skip @yetToImplement @issue-2897
-  Scenario: sharing details of items inside a re-shared folder
-    Given these users have been created without skeleton files:
-      | username |
-      | user1    |
-      | user2    |
-      | user3    |
-    And user "user1" has created folder "/simple-folder"
-    And user "user1" has created folder "/simple-folder/simple-empty-folder"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
-    And user "user1" has shared folder "simple-folder" with user "user2"
-    And user "user2" has shared folder "simple-folder" with user "user3"
-    And user "user2" has logged in using the webUI
-    And the user has opened folder "simple-folder" using the webUI
-    When the user opens the sharing tab from the file action menu of folder "simple-empty-folder" using the webUI
-    Then user "user3" should be listed as share receiver via "simple-folder" on the webUI
-    When the user opens the sharing tab from the file action menu of file "lorem.txt" using the webUI
-    Then user "user3" should be listed as share receiver via "simple-folder" on the webUI
-
   @issue-2060
   Scenario: sharing indicator for file uploaded inside a shared folder
     Given user "user1" has shared folder "/simple-empty-folder" with user "user2"
@@ -459,20 +423,68 @@ Feature: Sharing files and folders with internal users
       | sub-folder    | user-indirect      |
 
   @skip @yetToImplement @issue-2897
+  Scenario: sharing details of items inside a shared folder
+    Given user "user3" has been created with default attributes
+    And user "user1" has uploaded file with content "test" to "/simple-folder/lorem.txt"
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user1" has logged in using the webUI
+    And the user opens folder "simple-folder" using the webUI
+    When the user opens the share dialog for folder "simple-empty-folder" using the webUI
+    Then user "User Two" should be listed as "Editor" via "simple-folder" in the collaborators list on the webUI
+    When the user opens the share dialog for file "lorem.txt" using the webUI
+    Then user "User Two" should be listed as "Editor" via "simple-folder" in the collaborators list on the webUI
+
+  @skip @yetToImplement @issue-2897
+  Scenario: sharing details of items inside a re-shared folder
+    Given user "user3" has been created with default attributes
+    And user "user1" has uploaded file with content "test" to "/simple-folder/lorem.txt"
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user2" has shared folder "simple-folder" with user "user3"
+    And user "user2" has logged in using the webUI
+    And the user opens folder "simple-folder (2)" using the webUI
+    When the user opens the share dialog for folder "simple-empty-folder" using the webUI
+    Then user "User Three" should be listed as "Editor" via "simple-folder" in the collaborators list on the webUI
+    When the user opens the share dialog for file "lorem.txt" using the webUI
+    Then user "User Three" should be listed as "Editor" via "simple-folder" in the collaborators list on the webUI
+
+  @skip @yetToImplement @issue-2897
   Scenario: sharing details of items inside a shared folder shared with multiple users
-    Given these users have been created with default attributes and without skeleton files:
-      | username |
-      | user1    |
-      | user2    |
-      | user3    |
-    And user "user1" has created folder "/simple-folder"
+    Given user "user3" has been created with default attributes
     And user "user1" has created folder "/simple-folder/sub-folder"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/sub-folder/lorem.txt"
+    And user "user1" has uploaded file with content "test" to "/simple-folder/sub-folder/lorem.txt"
     And user "user1" has shared folder "simple-folder" with user "user2"
     And user "user1" has shared folder "/simple-folder/sub-folder" with user "user3"
     And user "user1" has logged in using the webUI
-    And the user has opened folder "simple-folder/sub-folder" using the webUI
-    When the user opens the sharing tab from the file action menu of file "lorem.txt" using the webUI
-    Then user "User Two" should be listed as share receiver via "simple-folder" on the webUI
-    And user "User Three" should be listed as share receiver via "sub-folder" on the webUI
+    And the user opens folder "simple-folder/sub-folder" directly on the webUI
+    When the user opens the share dialog for file "lorem.txt" using the webUI
+    Then user "User Two" should be listed as "Editor" via "simple-folder" in the collaborators list on the webUI
+    And user "User Three" should be listed as "Editor" via "sub-folder" in the collaborators list on the webUI
+
+  @issue-2898
+  Scenario: see resource owner in collaborators list for direct shares
+    Given user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user2" has logged in using the webUI
+    When the user opens the share dialog for folder "simple-folder (2)" using the webUI
+    Then user "User One" should be listed as "Owner" in the collaborators list on the webUI
+
+  @skip @yetToImplement @issue-2898
+  Scenario: see resource owner in collaborators list for reshares
+    Given user "user3" has been created with default attributes
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user2" has shared folder "simple-folder (2)" with user "user3"
+    And user "user3" has logged in using the webUI
+    When the user opens the share dialog for folder "simple-folder (2)" using the webUI
+    # TODO: maybe there is already such step as the reshare icon is used already in other scenarios
+    Then user "User One" should be listed as "Owner" through "User Two" in the collaborators list on the webUI
+
+  @skip @yetToImplement @skip @issue-2898
+  Scenario: see resource owner of parent shares in collaborators list
+    Given user "user3" has been created with default attributes
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user2" has shared folder "simple-folder (2)/simple-empty-folder" with user "user3"
+    And user "user3" has logged in using the webUI
+    And the user opens folder "simple-folder (2)" using the webUI
+    When the user opens the share dialog for folder "simple-empty-folder" using the webUI
+    # TODO: maybe there is already such step as the reshare icon is used already in other scenarios
+    Then user "User One" should be listed as "Owner" through "User Two" via "simple-folder (2)" in the collaborators list on the webUI
 

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -486,8 +486,7 @@ Feature: Share by public link
   Scenario: user shares a public link via email adding few addresses before and then removing some addresses afterwards
     Given the setting "shareapi_allow_public_notification" of app "core" has been set to "yes"
     And the user reloads the current page of the webUI
-    When the user opens the share dialog for folder "simple-folder" using the webUI
-    And the user opens the public link share tab
+    When the user opens the link share dialog for folder "simple-folder" using the webUI
     And the user opens the create public link share popup
     And the user adds the following email addresses using the webUI:
       | email           |
@@ -938,48 +937,41 @@ Feature: Share by public link
 
   @skip @yetToImplement @issue-2897
   Scenario: sharing details of items inside a shared folder
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has created folder "/simple-folder/sub-folder"
-    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/textfile.txt"
-    And user "user1" has created a public link share with settings
+    Given user "user1" has created folder "/simple-folder/sub-folder"
+    And user "user1" has uploaded file with content "test" to "/simple-folder/textfile.txt"
+    And user "user1" has created a public link share with following settings
       | path | /simple-folder |
       | name | Public Link    |
     And user "user1" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
-    And the user opens the share dialog for folder "sub-folder"
-    And the user opens the public link share tab
+    And the user opens the link share dialog for folder "sub-folder"
     Then public link "Public Link" should be listed as share receiver via "simple-folder" on the webUI
 
   @skip @yetToImplement @issue-2897
   Scenario: sharing details of multiple public link shares with different link names
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has created folder "/simple-folder/sub-folder"
-    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/sub-folder/textfile.txt"
-    And user "user1" has created a public link share with settings
+    Given user "user1" has created folder "/simple-folder/sub-folder"
+    And user "user1" has uploaded file with content "test" to "/simple-folder/sub-folder/textfile.txt"
+    And user "user1" has created a public link share with following settings
       | path | /simple-folder |
       | name | Public Link    |
-    And user "user1" has created a public link share with settings
+    And user "user1" has created a public link share with following settings
       | path | /simple-folder/sub-folder      |
       | name | strängé लिंक नाम (#2 &).नेपाली |
     And user "user1" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
-    And the user opens the share dialog for folder "sub-folder"
-    And the user opens the public link share tab
+    And the user opens the link share dialog for folder "sub-folder"
     Then public link "Public Link" should be listed as share receiver via "simple-folder" on the webUI
     When the user opens folder "sub-folder" using the webUI
-    And the user opens the share dialog for file "textfile.txt"
-    And the user opens the public link share tab
+    And the user opens the link share dialog for file "textfile.txt"
     Then public link "strängé लिंक नाम (#2 &).नेपाली" should be listed as share receiver via "sub-folder" on the webUI
     And public link "Public Link" should be listed as share receiver via "simple-folder" on the webUI
 
   @skip @yetToImplement @issue-2897
   Scenario: sharing detail of items in the webUI shared by public links with empty name
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/textfile.txt"
-    And user "user1" has created a public link share with settings
+    Given user "user1" has uploaded file with content "test" to "/simple-folder/textfile.txt"
+    And user "user1" has created a public link share with following settings
       | path | /simple-folder |
     And user "user1" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
-    And the user opens the share dialog for file "textfile.txt"
-    And the user opens the public link share tab
+    And the user opens the link share dialog for file "textfile.txt"
     Then public link with last share token should be listed as share receiver via "simple-folder" on the webUI

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -218,7 +218,7 @@ module.exports = {
      *
      * @param {string} fileName
      */
-    openSharingDialog: async function (fileName) {
+    openSharingDialog: async function (fileName, targetTab = 'collaborators') {
       await this.waitForFileVisible(fileName)
 
       await this
@@ -226,6 +226,12 @@ module.exports = {
         .performFileAction(fileName, FileAction.share)
         .waitForElementVisible('@sharingSideBar')
         .useCss()
+
+      if (targetTab === 'links') {
+        await this
+          .waitForElementVisible('@sidebarLinksTab')
+          .click('@sidebarLinksTab')
+      }
 
       return this.api.page.FilesPageElement.sharingDialog()
     },

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -166,7 +166,7 @@ const createPublicLink = function (sharer, data) {
  * @param {string} role
  * @returns {Promise}
  */
-const assertCollaboratorslistContains = function (type, name, role) {
+const assertCollaboratorslistContains = function (type, name, role, via = null) {
   return client.page.FilesPageElement.sharingDialog().getCollaboratorsList()
     .then(shares => {
       const cleanedShares = []
@@ -175,6 +175,9 @@ const assertCollaboratorslistContains = function (type, name, role) {
         // depending on the browser there are extra \n or not, so get rid of them all
       }
       let expectedString = name + ' ' + role
+      if (via) {
+        expectedString += ' via ' + via
+      }
       if (type === 'user') {
         expectedString = expectedString + client.page.FilesPageElement.sharingDialog().getUserSharePostfix()
       } else if (type === 'group') {
@@ -686,7 +689,11 @@ Then('{string} {string} should be listed in the autocomplete list on the webUI',
 })
 
 When('the user opens the share dialog for file/folder/resource {string} using the webUI', function (file) {
-  return client.page.FilesPageElement.filesList().openSharingDialog(file)
+  return client.page.FilesPageElement.filesList().openSharingDialog(file, 'collaborators')
+})
+
+When('the user opens the link share dialog for file/folder/resource {string} using the webUI', function (file) {
+  return client.page.FilesPageElement.filesList().openSharingDialog(file, 'link')
 })
 
 When('the user deletes {string} as collaborator for the current file/folder using the webUI', function (user) {
@@ -708,6 +715,10 @@ Then('user {string} should be listed as {string} in the collaborators list on th
   return assertCollaboratorslistContains('user', user, role)
 })
 
+Then('user {string} should be listed as {string} via {string} in the collaborators list on the webUI', function (user, role, via) {
+  return assertCollaboratorslistContains('user', user, role, via)
+})
+
 Then('user {string} should be listed as {string} in the collaborators list for file/folder/resource {string} on the webUI', async function (user, role, resource) {
   const api = client.page
     .FilesPageElement
@@ -722,6 +733,10 @@ Then('user {string} should be listed as {string} in the collaborators list for f
 
 Then('group {string} should be listed as {string} in the collaborators list on the webUI', function (group, role) {
   return assertCollaboratorslistContains('group', group, role)
+})
+
+Then('group {string} should be listed as {string} via {string} in the collaborators list on the webUI', function (group, role, via) {
+  return assertCollaboratorslistContains('group', group, role, via)
 })
 
 Then('group {string} should be listed as {string} in the collaborators list for file/folder/resource {string} on the webUI', async function (group, role, resource) {


### PR DESCRIPTION
## Description

Added share owner and resharer display for direct shares
    
- Added incomingShares in state, requested whenever the collaborators
    panel is opened, and used to retrieve the owner and resharer
    information.
- Share file owner and resharers are now displayed on top of the
      collaborators list for shares from the currently selected resource
- Added skipped tests for the next steps of related features.

## Related Issue
- Partial fix for https://github.com/owncloud/phoenix/issues/2898 (only addresses direct shares)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- acceptance tests

## Screenshots (if appropriate):
<img width="355" alt="image" src="https://user-images.githubusercontent.com/277525/73085139-83953400-3ece-11ea-9ba1-fc808dc71eca.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [x] actual implementation for share owner cases
- [ ] enable and adjust acceptance tests for the direct share case
- [ ] changelog entry
