### PR TITLE
Also show owner and resharer for indirect shares

### DIFF
--- a/apps/files/src/components/Collaborators/Collaborator.vue
+++ b/apps/files/src/components/Collaborators/Collaborator.vue
@@ -1,31 +1,60 @@
 <template>
-  <div>
-    <div v-if="$_reshareInformation" class="uk-text-meta uk-flex uk-flex-middle uk-margin-small-bottom"><oc-icon name="repeat" class="uk-margin-small-right" /> {{ $_reshareInformation }}</div>
-    <div class="files-collaborators-collaborator-information uk-flex uk-flex-wrap uk-flex-middle">
-      <div key="collaborator-avatar-loaded">
-        <avatar-image v-if="$_shareType === shareTypes.user" class="uk-margin-small-right" :width="50" :userid="collaborator.name" :userName="collaborator.displayName" />
-        <div v-else key="collaborator-avatar-placeholder">
-          <oc-icon v-if="$_shareType === shareTypes.group" class="uk-margin-small-right" name="group" size="large" key="avatar-group" />
-          <oc-icon v-else class="uk-margin-small-right" name="person" size="large" key="avatar-generic-person" />
+  <oc-table middle class="files-collaborators-collaborator">
+    <oc-table-row v-if="$_reshareInformation || $_getViaLabel" class="files-collaborators-collaborator-table-row-extra">
+      <oc-table-cell shrink colspan="2"></oc-table-cell>
+      <oc-table-cell colspan="2">
+        <div v-if="$_reshareInformation" class="uk-text-meta uk-flex uk-flex-middle">
+          <oc-icon name="repeat" class="uk-preserve-width" />
+          <span>{{ $_reshareInformation }}</span>
         </div>
-      </div>
-      <div class="uk-flex uk-flex-column uk-flex-center files-collaborators-collaborator-information-text">
-        <div class="oc-text">
-          <span class="files-collaborators-collaborator-name uk-text-bold">{{ collaborator.displayName }}</span>
-          <span v-if="parseInt(collaborator.info.share_type, 10) === 0 && collaborator.info.share_with_additional_info.length > 0" class="uk-text-meta">
-            ({{ collaborator.info.share_with_additional_info }})
-          </span>
+        <div v-if="$_getViaLabel" class="uk-text-meta">
+          <router-link :to="$_getViaRouterParams" :aria-label="$gettext('Navigate to parent')"
+                       class="files-collaborators-collaborator-follow-via uk-flex uk-flex-middle">
+            <oc-icon name="exit_to_app" size="small" class="uk-preserve-width" />
+            <span class="oc-file-name uk-padding-remove uk-text-truncate files-collaborators-collaborator-via-label">{{ $_getViaLabel }}</span>
+          </router-link>
         </div>
-        <span class="oc-text">{{ originalRole.label }}<template v-if="collaborator.expires"> | <translate :translate-params="{expires: formDateFromNow(collaborator.expires)}">Expires: %{expires}</translate></template></span>
-        <span class="uk-text-meta" v-text="$_ocCollaborators_collaboratorType(collaborator.info.share_type)" />
-      </div>
-    </div>
-  </div>
+      </oc-table-cell>
+    </oc-table-row>
+    <oc-table-row class="files-collaborators-collaborator-table-row-info">
+      <oc-table-cell shrink>
+        <oc-button v-if="collaborator.modifiable" :ariaLabel="$gettext('Delete share')" @click="$emit('onDelete', collaborator)" variation="raw" class="files-collaborators-collaborator-delete">
+          <oc-icon name="close" />
+        </oc-button>
+        <oc-icon v-else name="lock"></oc-icon>
+      </oc-table-cell>
+      <oc-table-cell shrink>
+        <div key="collaborator-avatar-loaded">
+          <avatar-image v-if="$_shareType === shareTypes.user" class="uk-margin-small-right" :width="50" :userid="collaborator.name" :userName="collaborator.displayName" />
+          <div v-else key="collaborator-avatar-placeholder">
+            <oc-icon v-if="$_shareType === shareTypes.group" class="uk-margin-small-right" name="group" size="large" key="avatar-group" />
+            <oc-icon v-else class="uk-margin-small-right" name="person" size="large" key="avatar-generic-person" />
+          </div>
+        </div>
+      </oc-table-cell>
+      <oc-table-cell>
+        <div class="uk-flex uk-flex-column uk-flex-center">
+          <div class="oc-text">
+            <span class="files-collaborators-collaborator-name uk-text-bold">{{ collaborator.displayName }}</span>
+            <span v-if="$_shareType === shareTypes.user && collaborator.info.share_with_additional_info.length > 0" class="uk-text-meta">({{ collaborator.info.share_with_additional_info }})</span>
+          </div>
+          <span class="oc-text"><span class="files-collaborators-collaborator-role">{{ originalRole.label }}</span><template v-if="collaborator.expires"> | <translate :translate-params="{expires: formDateFromNow(collaborator.expires)}">Expires: %{expires}</translate></template></span>
+          <span class="uk-text-meta files-collaborators-collaborator-share-type" v-text="$_ocCollaborators_collaboratorType(collaborator.info.share_type)" />
+        </div>
+      </oc-table-cell>
+      <oc-table-cell shrink>
+        <oc-button v-if="collaborator.modifiable" :aria-label="$gettext('Edit share')" @click="$emit('onEdit', collaborator)" variation="raw" class="files-collaborators-collaborator-edit">
+          <oc-icon name="edit" />
+        </oc-button>
+      </oc-table-cell>
+    </oc-table-row>
+  </oc-table>
 </template>
 
 <script>
 import { mapGetters } from 'vuex'
 import { shareTypes } from '../../helpers/shareTypes'
+import { basename, dirname } from 'path'
 import Mixins from '../../mixins/collaborators'
 
 export default {
@@ -42,6 +71,13 @@ export default {
   computed: {
     ...mapGetters(['user']),
 
+    $_isIndirectIncomingShare () {
+      // it is assumed that the "incoming" attribute only exists
+      // on shares coming from this.sharesTree which are all indirect
+      // and not related to the current folder
+      return this.collaborator.incoming
+    },
+
     $_reshareInformation () {
       if (this.collaborator.role.name === 'owner' || this.collaborator.role.name === 'resharer' || this.user.id === this.collaborator.info.uid_owner) {
         return null
@@ -52,6 +88,27 @@ export default {
 
     $_shareType () {
       return parseInt(this.collaborator.info.share_type, 10)
+    },
+
+    $_getViaLabel () {
+      if (!this.$_isIndirectIncomingShare) {
+        return null
+      }
+      const translated = this.$gettext('Via %{folderName}')
+      return this.$gettextInterpolate(translated, { folderName: basename(this.collaborator.info.path) }, false)
+    },
+
+    $_getViaRouterParams () {
+      const viaPath = this.collaborator.info.path
+      return {
+        name: 'files-list',
+        params: {
+          item: dirname(viaPath) || '/'
+        },
+        query: {
+          scrollTo: basename(viaPath)
+        }
+      }
     },
 
     originalRole () {
@@ -72,6 +129,18 @@ export default {
 }
 </script>
 
+<style scoped="scoped">
+  /* FIXME: Move to ODS somehow */
+  .files-collaborators-collaborator-table-row-extra > td {
+    padding: 0 10px 5px 0;
+  }
+  .files-collaborators-collaborator-table-row-info > td {
+    padding: 0 10px 0 0;
+  }
+  .files-collaborators-collaborator-via-label {
+    max-width: 75%;
+  }
+</style>
 <style>
   /* TODO: Move to ODS  */
   .oc-text {

--- a/apps/files/src/components/Collaborators/EditCollaborator.vue
+++ b/apps/files/src/components/Collaborators/EditCollaborator.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="files-collaborators-collaborator-edit-dialog">
     <div v-if="user.id !== collaborator.info.uid_owner" class="uk-text-meta uk-flex uk-flex-middle uk-margin-small-bottom"><oc-icon name="repeat" class="uk-margin-small-right" /> {{ collaborator.info.displayname_owner }}</div>
-    <div class="files-collaborators-collaborator-information uk-flex uk-flex-wrap uk-flex-middle">
+    <div class="uk-flex uk-flex-wrap uk-flex-middle">
       <collaborator class="uk-width-expand" :collaborator="collaborator" />
     </div>
     <hr class="divider" />

--- a/apps/files/src/components/FileLinkSidebar.vue
+++ b/apps/files/src/components/FileLinkSidebar.vue
@@ -18,7 +18,8 @@
         <div class="uk-margin-small-top uk-margin-small-bottom">
           <oc-button @click="$_addPublicLink" icon="add" variation="primary" id="files-file-link-add">{{ $_addButtonLabel }}</oc-button>
         </div>
-        <transition-group class="uk-list uk-list-divider uk-overflow-hidden"
+        <transition-group v-if="$_links.length > 0"
+                          class="uk-list uk-list-divider uk-overflow-hidden"
                           enter-active-class="uk-animation-slide-left-medium"
                           leave-active-class="uk-animation-slide-right-medium uk-animation-reverse"
                           name="custom-classes-transition"
@@ -45,9 +46,7 @@
             </oc-grid>
           </li>
         </transition-group>
-        <p class="uk-text-meta" v-if="$_links.length === 0" v-translate>
-          Links can be shared with external collaborators.
-        </p>
+        <p class="uk-text-meta" v-else><translate>Links can be shared with external collaborators.</translate></p>
       </template>
     </div>
     <div v-else-if="visiblePanel === PANEL_EDIT">

--- a/apps/files/src/store/state.js
+++ b/apps/files/src/store/state.js
@@ -36,7 +36,7 @@ export default {
   /**
    * Incoming shares from currently highlighted element
    */
-  incomingShares: {},
+  incomingShares: [],
   incomingSharesError: null,
   incomingSharesLoading: false,
 

--- a/changelog/unreleased/2898
+++ b/changelog/unreleased/2898
@@ -1,0 +1,8 @@
+Enhancement: Add owner and resharer in collaborators list
+
+The top of the collaborators list now display new entries for the resource owner and the resharer when applicable,
+and also visible when viewing a child resource of a shared folder (indirect share).
+
+https://github.com/owncloud/phoenix/issues/2898
+https://github.com/owncloud/phoenix/pull/2915
+https://github.com/owncloud/phoenix/pull/2918

--- a/package.json
+++ b/package.json
@@ -123,5 +123,8 @@
       "yarn lint --fix",
       "git add"
     ]
+  },
+  "dependencies": {
+    "path": "^0.12.7"
   }
 }

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -287,13 +287,14 @@ Feature: Sharing files and folders with internal groups
     Then user "User Two" should be listed as "Editor" via "simple-folder" in the collaborators list on the webUI
     And group "grp1" should be listed as "Editor" via "sub-folder" in the collaborators list on the webUI
 
-  @skip @yetToImplement @issue-2898
+  @issue-2898
   Scenario: see resource owner of parent group shares in collaborators list
     Given user "user3" has been created with default attributes
     And user "user1" has shared folder "simple-folder" with group "grp1"
-    And user "user2" has shared folder "simple-folder (2)/simple-empty-folder" with user "user3"
+    And user "user2" has shared folder "simple-folder (2)" with user "user3"
     And user "user3" has logged in using the webUI
     And the user opens folder "simple-folder (2)" using the webUI
     When the user opens the share dialog for folder "simple-empty-folder" using the webUI
-    # TODO: maybe there is already such step as the reshare icon is used already in other scenarios
-    Then user "User One" should be listed as "Owner" through "User Two" via "simple-folder (2)" in the collaborators list on the webUI
+    Then user "User One" should be listed as "Owner" via "simple-folder (2)" in the collaborators list on the webUI
+    And user "User Two" should be listed as "Resharer" via "simple-folder (2)" in the collaborators list on the webUI
+    And the current collaborators list should have order "User One,User Two"

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -467,24 +467,34 @@ Feature: Sharing files and folders with internal users
     When the user opens the share dialog for folder "simple-folder (2)" using the webUI
     Then user "User One" should be listed as "Owner" in the collaborators list on the webUI
 
-  @skip @yetToImplement @issue-2898
+  @issue-2898
   Scenario: see resource owner in collaborators list for reshares
     Given user "user3" has been created with default attributes
     And user "user1" has shared folder "simple-folder" with user "user2"
     And user "user2" has shared folder "simple-folder (2)" with user "user3"
     And user "user3" has logged in using the webUI
     When the user opens the share dialog for folder "simple-folder (2)" using the webUI
-    # TODO: maybe there is already such step as the reshare icon is used already in other scenarios
-    Then user "User One" should be listed as "Owner" through "User Two" in the collaborators list on the webUI
+    Then user "User One" should be listed as "Owner" in the collaborators list on the webUI
+    And user "User Two" should be listed as "Resharer" in the collaborators list on the webUI
+    And the current collaborators list should have order "User One,User Two"
 
-  @skip @yetToImplement @skip @issue-2898
+  @issue-2898
   Scenario: see resource owner of parent shares in collaborators list
     Given user "user3" has been created with default attributes
     And user "user1" has shared folder "simple-folder" with user "user2"
-    And user "user2" has shared folder "simple-folder (2)/simple-empty-folder" with user "user3"
+    And user "user2" has shared folder "simple-folder (2)" with user "user3"
     And user "user3" has logged in using the webUI
     And the user opens folder "simple-folder (2)" using the webUI
     When the user opens the share dialog for folder "simple-empty-folder" using the webUI
-    # TODO: maybe there is already such step as the reshare icon is used already in other scenarios
-    Then user "User One" should be listed as "Owner" through "User Two" via "simple-folder (2)" in the collaborators list on the webUI
+    Then user "User One" should be listed as "Owner" via "simple-folder (2)" in the collaborators list on the webUI
+    And user "User Two" should be listed as "Resharer" via "simple-folder (2)" in the collaborators list on the webUI
+    And the current collaborators list should have order "User One,User Two"
+
+  @issue-2898
+  Scenario: see resource owner for direct shares in "shared with me"
+    Given user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user2" has logged in using the webUI
+    When the user browses to the shared-with-me page
+    And the user opens the share dialog for folder "simple-folder (2)" using the webUI
+    Then user "User One" should be listed as "Owner" in the collaborators list on the webUI
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2751,9 +2751,9 @@ date-fns@^1.27.2:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
-"davclient.js@git+https://github.com/owncloud/davclient.js.git":
+"davclient.js@https://github.com/owncloud/davclient.js.git":
   version "0.2.1"
-  resolved "git+https://github.com/owncloud/davclient.js.git#1ab200d099a3c2cd2ef919c3a56353ce26865994"
+  resolved "https://github.com/owncloud/davclient.js.git#1ab200d099a3c2cd2ef919c3a56353ce26865994"
 
 de-indent@^1.0.2:
   version "1.0.2"
@@ -6801,6 +6801,14 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+path@^0.12.7:
+  version "0.12.7"
+  resolved "https://registry.yarnpkg.com/path/-/path-0.12.7.tgz#d4dc2a506c4ce2197eb481ebfcd5b36c0140b10f"
+  integrity sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=
+  dependencies:
+    process "^0.11.1"
+    util "^0.10.3"
+
 pause-stream@0.0.11:
   version "0.0.11"
   resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
@@ -7081,7 +7089,7 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-process@^0.11.10:
+process@^0.11.1, process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
@@ -8983,6 +8991,13 @@ util@0.10.3:
   integrity sha1-evsa/lCAUkZInj23/g7TeTNqwPk=
   dependencies:
     inherits "2.0.1"
+
+util@^0.10.3:
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.10.4.tgz#3aa0125bfe668a4672de58857d3ace27ecb76901"
+  integrity sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==
+  dependencies:
+    inherits "2.0.3"
 
 util@^0.11.0:
   version "0.11.1"


### PR DESCRIPTION
## Description
Display collaborator entries for indirect shares (inherited from parent resources) for owner and resharer.

## Related Issue
Follow up of https://github.com/owncloud/phoenix/pull/2915
Fixes https://github.com/owncloud/phoenix/issues/2898

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- visual check in collaborators panel
- acceptance tests for the new cases

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [x] Fix avatar for owner and resharer
- [x] Display "via" label
- [x] ~~Use "redo" icon instead of anchor~~ Use "exit to app"
- [x] TEST: unskip and adjust acceptance tests
- [x] TEST: extend some tests to also include "Resharer" entry
- [x] TEST: add test for "shared with me"
- [x] add ellipsis on via text
