### PR TITLE
Move sharing indicators into own component and add extension point

### DIFF
--- a/apps/files/docs/extensionpoints.adoc
+++ b/apps/files/docs/extensionpoints.adoc
@@ -1,4 +1,4 @@
-## Extensionpoints
+## Extension points
 
 #### file-details-panel
 
@@ -17,3 +17,76 @@
 
 OC.$extend.request('files', 'file-details-panel', payload).then( response => {});
 ----
+
+### Files list status indicators
+
+An extension can extend status indicators in files list with custom component, properties and methods.
+Extending this list can be done by creating a new object inside of appInfo called `filesListIndicators`. This object can contain keys `name` and `component`.
+
+#### Props
+
+Please see known issues before using props in custom indicators.
+
+- `item`: resource to which are indicators assigned
+- `parentPath`: parent folder path of the item
+
+#### Example:
+
+##### App entry point
+[source,js]
+----
+import ExampleIndicators from './components/ExampleIndicators.vue'
+
+const appInfo = {
+  name: 'ExampleIndicators',
+  id: 'ExampleIndicators',
+  icon: 'info',
+  isFileEditor: false,
+  extensions: [],
+  filesListIndicators: [{
+    name: 'CustomIndicators',
+    component: ExampleIndicators
+  }]
+}
+----
+
+##### ExampleIndicators component
+[source,vue]
+----
+<template>
+  <oc-button
+    v-if="isFolder"
+    class="file-row-share-indicator uk-text-middle"
+    aria-label="Custom indicator"
+    @click="triggerAlert"
+    variation="raw"
+  >
+    <oc-icon
+      name="folder"
+      class="uk-text-middle"
+      size="small"
+      variation="active"
+    />
+  </oc-button>
+</template>
+
+<script>
+  export default {
+    name: 'ExampleIndicators',
+    computed: {
+      isFolder () {
+        return this.$parent.item.type === 'folder'
+      }
+    },
+    methods: {
+      triggerAlert () {
+        alert('Hello world')
+      }
+    }
+  }
+</script>
+----
+
+#### Known issues:
+
+Passing resource as a prop into the dynamic component causes Vuex mutation error. To avoid this, access resource direcly via parent component - `this.$parent.item`

--- a/apps/files/src/components/AllFilesList.vue
+++ b/apps/files/src/components/AllFilesList.vue
@@ -29,14 +29,7 @@
                 class="uk-margin-small-left"
               />
             </div>
-            <div>
-              <oc-button v-if="$_isUserShare(item)" class="file-row-share-indicator uk-text-middle" :aria-label="$_shareUserIconLabel(item)" @click="$_openSideBar(item, 'files-sharing')" variation="raw">
-                <oc-icon name="group" class="uk-text-middle" size="small" :variation="$_shareUserIconVariation(item)"/>
-              </oc-button>
-              <oc-button v-if="$_isLinkShare(item)" class="file-row-share-indicator uk-text-middle" :aria-label="$_shareLinkIconLabel(item)" @click="$_openSideBar(item, 'file-link')" variation="raw">
-                <oc-icon name="link" class="uk-text-middle" size="small" :variation="$_shareLinkIconVariation(item)"/>
-              </oc-button>
-            </div>
+            <StatusIndicators :item="item" :parentPath="currentFolder.path" @click="$_openSideBar" />
             <div class="uk-text-meta uk-text-nowrap uk-width-small" :class="{ 'uk-visible@s' : !_sidebarOpen, 'uk-hidden'  : _sidebarOpen }">
               {{ item.size | fileSize }}
             </div>
@@ -75,18 +68,16 @@
 <script>
 import FileList from './FileList.vue'
 import { mapGetters, mapActions, mapState } from 'vuex'
-import { shareTypes } from '../helpers/shareTypes'
-import { getParentPaths } from '../helpers/path'
 
 import Mixins from '../mixins'
 import FileActions from '../fileactions'
-import intersection from 'lodash/intersection'
 
-const userShareTypes = [shareTypes.user, shareTypes.group, shareTypes.guest, shareTypes.remote]
+const StatusIndicators = () => import('./FilesLists/StatusIndicators/StatusIndicators.vue')
 
 export default {
   components: {
-    FileList
+    FileList,
+    StatusIndicators
   },
   mixins: [
     Mixins,
@@ -108,46 +99,6 @@ export default {
 
     $_openSideBar (item, sideBarName) {
       this.$emit('sideBarOpen', item, sideBarName)
-    },
-
-    $_isDirectUserShare (item) {
-      return (intersection(userShareTypes, item.shareTypes).length > 0)
-    },
-
-    $_isIndirectUserShare (item) {
-      return (item.isReceivedShare() || intersection(userShareTypes, this.$_shareTypesIndirect).length > 0)
-    },
-
-    $_isDirectLinkShare (item) {
-      return (item.shareTypes.indexOf(shareTypes.link) >= 0)
-    },
-
-    $_isIndirectLinkShare (item) {
-      return (this.$_shareTypesIndirect.indexOf(shareTypes.link) >= 0)
-    },
-
-    $_isUserShare (item) {
-      return this.$_isDirectUserShare(item) || this.$_isIndirectUserShare(item)
-    },
-
-    $_isLinkShare (item) {
-      return this.$_isDirectLinkShare(item) || this.$_isIndirectLinkShare(item)
-    },
-
-    $_shareUserIconVariation (item) {
-      return this.$_isDirectUserShare(item) ? 'active' : 'passive'
-    },
-
-    $_shareLinkIconVariation (item) {
-      return this.$_isDirectLinkShare(item) ? 'active' : 'passive'
-    },
-
-    $_shareUserIconLabel (item) {
-      return this.$_isDirectUserShare(item) ? this.$gettext('Directly shared with collaborators') : this.$gettext('Shared with collaborators through one of the parent folders')
-    },
-
-    $_shareLinkIconLabel (item) {
-      return this.$_isDirectLinkShare(item) ? this.$gettext('Directly shared with links') : this.$gettext('Shared with links through one of the parent folders')
     },
 
     $_ocFilesFolder_getFolder () {
@@ -216,36 +167,11 @@ export default {
   },
   computed: {
     ...mapState(['route']),
-    ...mapGetters('Files', ['loadingFolder', 'activeFiles', 'quota', 'filesTotalSize', 'activeFilesCount', 'currentFolder', 'sharesTree']),
+    ...mapGetters('Files', ['loadingFolder', 'activeFiles', 'quota', 'filesTotalSize', 'activeFilesCount', 'currentFolder']),
     ...mapGetters(['configuration']),
 
     item () {
       return this.$route.params.item
-    },
-
-    $_shareTypesIndirect () {
-      const parentPaths = getParentPaths(this.currentFolder.path, true)
-      if (parentPaths.length === 0) {
-        return []
-      }
-
-      // remove root entry
-      parentPaths.pop()
-
-      const shareTypes = {}
-      parentPaths.forEach((parentPath) => {
-        // TODO: optimize for performance by skipping once we got all known types
-        const shares = this.sharesTree[parentPath]
-        if (shares) {
-          shares.forEach((share) => {
-            // note: no distinction between incoming and outgoing shares as we display the same
-            // indirect indicator for them
-            shareTypes[share.info.share_type] = true
-          })
-        }
-      })
-
-      return Object.keys(shareTypes).map(shareType => parseInt(shareType, 10))
     },
 
     quotaVisible () {

--- a/apps/files/src/components/FilesLists/StatusIndicators/StatusIndicators.vue
+++ b/apps/files/src/components/FilesLists/StatusIndicators/StatusIndicators.vue
@@ -1,0 +1,63 @@
+<template>
+  <div class="uk-flex uk-flex-middle">
+    <DefaultIndicators
+      v-if="displayDefaultIndicators"
+      :item="item"
+      :parentPath="parentPath"
+      :class="{ 'uk-margin-xsmall-right' : customIndicators }"
+      @click="openSidebar"
+    />
+    <template v-if="customIndicators">
+      <component
+        v-for="(indicator, index) in customIndicators"
+        :is="indicator.component"
+        :key="index"
+      />
+    </template>
+  </div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+
+const DefaultIndicators = () => import('./DefaultIndicators.vue')
+
+export default {
+  name: 'StatusIndicators',
+
+  components: {
+    DefaultIndicators
+  },
+
+  props: {
+    // FIXME: Find a way to pass item into dynamic component as a prop without mutation error
+    item: {
+      type: Object,
+      required: true
+    },
+    parentPath: {
+      type: String,
+      required: true
+    }
+  },
+
+  computed: {
+    ...mapGetters(['configuration', 'customFilesListIndicators']),
+
+    displayDefaultIndicators () {
+      return !this.configuration.theme.filesList.hideDefaultStatusIndicators
+    },
+
+    customIndicators () {
+      return this.customFilesListIndicators
+    }
+  },
+
+  methods: {
+    // TODO: Adjust to send the event via store
+    openSidebar (item, indicatorId) {
+      this.$emit('click', item, indicatorId)
+    }
+  }
+}
+</script>

--- a/changelog/unreleased/2895-1
+++ b/changelog/unreleased/2895-1
@@ -1,0 +1,7 @@
+Enhancement: Add files list status indicators extension point
+
+We've added the ability for the extension to inject custom status indicator into files list.
+New indicators will then appear next to the default one.
+
+https://github.com/owncloud/phoenix/issues/2895
+https://github.com/owncloud/phoenix/pull/2928

--- a/changelog/unreleased/2895-2
+++ b/changelog/unreleased/2895-2
@@ -1,0 +1,6 @@
+Enhancement: Add theme option to disable default files list status indicators
+
+We've added the option into the theme to disable default files list status indicators.
+
+https://github.com/owncloud/phoenix/issues/2895
+https://github.com/owncloud/phoenix/pull/2928

--- a/src/store/apps.js
+++ b/src/store/apps.js
@@ -8,6 +8,7 @@ const state = {
   extensions: {},
   newFileHandlers: [],
   fileSideBars: [],
+  customFilesListIndicators: [],
   meta: {}
 }
 
@@ -118,6 +119,15 @@ const mutations = {
       })
       state.fileSideBars = list
     }
+
+    if (appInfo.filesListIndicators) {
+      const indicators = state.customFilesListIndicators
+      appInfo.filesListIndicators.forEach(indicator => {
+        indicators.push(indicator)
+      })
+      state.customFilesListIndicators = indicators
+    }
+
     if (!appInfo.id) return
     // name: use id as fallback display name
     // icon: use empty box as fallback icon
@@ -164,7 +174,8 @@ const getters = {
   },
   fileSideBars: state => {
     return state.fileSideBars
-  }
+  },
+  customFilesListIndicators: state => state.customFilesListIndicators
 }
 
 export default {

--- a/src/store/config.js
+++ b/src/store/config.js
@@ -23,6 +23,9 @@ const state = {
     },
     logo: {
       favicon: ''
+    },
+    filesList: {
+      hideDefaultStatusIndicators: false
     }
   }
 }

--- a/themes/owncloud.json
+++ b/themes/owncloud.json
@@ -5,5 +5,8 @@
   },
   "logo": {
     "favicon": "themes/owncloud/favicon.jpg"
+  },
+  "filesList": {
+    "hideDefaultStatusIndicators": false
   }
 }


### PR DESCRIPTION
## Description
Move sharing indicators into smaller components, enable disabling of default indicators and add extension point for new indicators.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #2895

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually
1. Disable default indicators inside of theme
2. Create new indicators (example https://github.com/LukasHirt/phoenix-status-indicators) or add a custom indicators into already existing extension

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/25989331/73272567-e0e8f800-41e2-11ea-9944-b42bb6b89a10.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Add changelog item
- [x] Implement click handlers for default indicators