### PR TITLE
Display indirect outgoing shares in collaborators panel

### DIFF
--- a/apps/files/src/components/Collaborators/Collaborator.vue
+++ b/apps/files/src/components/Collaborators/Collaborator.vue
@@ -18,7 +18,7 @@
     </oc-table-row>
     <oc-table-row class="files-collaborators-collaborator-table-row-info">
       <oc-table-cell shrink>
-        <oc-button v-if="collaborator.modifiable" :ariaLabel="$gettext('Delete share')" @click="$emit('onDelete', collaborator)" variation="raw" class="files-collaborators-collaborator-delete">
+        <oc-button v-if="modifiable" :ariaLabel="$gettext('Delete share')" @click="$emit('onDelete', collaborator)" variation="raw" class="files-collaborators-collaborator-delete">
           <oc-icon name="close" />
         </oc-button>
         <oc-icon v-else name="lock"></oc-icon>
@@ -43,7 +43,7 @@
         </div>
       </oc-table-cell>
       <oc-table-cell shrink>
-        <oc-button v-if="collaborator.modifiable" :aria-label="$gettext('Edit share')" @click="$emit('onEdit', collaborator)" variation="raw" class="files-collaborators-collaborator-edit">
+        <oc-button v-if="modifiable" :aria-label="$gettext('Edit share')" @click="$emit('onEdit', collaborator)" variation="raw" class="files-collaborators-collaborator-edit">
           <oc-icon name="edit" />
         </oc-button>
       </oc-table-cell>
@@ -59,7 +59,16 @@ import Mixins from '../../mixins/collaborators'
 
 export default {
   name: 'Collaborator',
-  props: ['collaborator'],
+  props: {
+    collaborator: {
+      type: Object,
+      required: true
+    },
+    modifiable: {
+      type: Boolean,
+      default: false
+    }
+  },
   mixins: [
     Mixins
   ],

--- a/apps/files/src/components/Collaborators/Collaborator.vue
+++ b/apps/files/src/components/Collaborators/Collaborator.vue
@@ -71,11 +71,11 @@ export default {
   computed: {
     ...mapGetters(['user']),
 
-    $_isIndirectIncomingShare () {
+    $_isIndirectShare () {
       // it is assumed that the "incoming" attribute only exists
       // on shares coming from this.sharesTree which are all indirect
       // and not related to the current folder
-      return this.collaborator.incoming
+      return this.collaborator.incoming || this.collaborator.outgoing
     },
 
     $_reshareInformation () {
@@ -91,7 +91,7 @@ export default {
     },
 
     $_getViaLabel () {
-      if (!this.$_isIndirectIncomingShare) {
+      if (!this.$_isIndirectShare) {
         return null
       }
       const translated = this.$gettext('Via %{folderName}')

--- a/changelog/unreleased/2897
+++ b/changelog/unreleased/2897
@@ -1,0 +1,8 @@
+Enhancement: Show indirect outgoing shares in collaborators list
+
+Whenever outgoing shares exist on any parent resource from the currently viewed resource,
+the collaborators panel will now show these outgoing shares with a link to jump to the matching parent
+resource.
+
+https://github.com/owncloud/phoenix/issues/2897
+https://github.com/owncloud/phoenix/pull/2929

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -422,7 +422,7 @@ Feature: Sharing files and folders with internal users
       | fileName      | expectedIndicators |
       | sub-folder    | user-indirect      |
 
-  @skip @yetToImplement @issue-2897
+  @issue-2897
   Scenario: sharing details of items inside a shared folder
     Given user "user3" has been created with default attributes
     And user "user1" has uploaded file with content "test" to "/simple-folder/lorem.txt"
@@ -434,26 +434,26 @@ Feature: Sharing files and folders with internal users
     When the user opens the share dialog for file "lorem.txt" using the webUI
     Then user "User Two" should be listed as "Editor" via "simple-folder" in the collaborators list on the webUI
 
-  @skip @yetToImplement @issue-2897
+  @issue-2897
   Scenario: sharing details of items inside a re-shared folder
     Given user "user3" has been created with default attributes
     And user "user1" has uploaded file with content "test" to "/simple-folder/lorem.txt"
     And user "user1" has shared folder "simple-folder" with user "user2"
-    And user "user2" has shared folder "simple-folder" with user "user3"
+    And user "user2" has shared folder "simple-folder (2)" with user "user3"
     And user "user2" has logged in using the webUI
     And the user opens folder "simple-folder (2)" using the webUI
     When the user opens the share dialog for folder "simple-empty-folder" using the webUI
-    Then user "User Three" should be listed as "Editor" via "simple-folder" in the collaborators list on the webUI
+    Then user "User Three" should be listed as "Editor" via "simple-folder (2)" in the collaborators list on the webUI
     When the user opens the share dialog for file "lorem.txt" using the webUI
-    Then user "User Three" should be listed as "Editor" via "simple-folder" in the collaborators list on the webUI
+    Then user "User Three" should be listed as "Editor" via "simple-folder (2)" in the collaborators list on the webUI
 
-  @skip @yetToImplement @issue-2897
+  @issue-2897
   Scenario: sharing details of items inside a shared folder shared with multiple users
     Given user "user3" has been created with default attributes
     And user "user1" has created folder "/simple-folder/sub-folder"
     And user "user1" has uploaded file with content "test" to "/simple-folder/sub-folder/lorem.txt"
     And user "user1" has shared folder "simple-folder" with user "user2"
-    And user "user1" has shared folder "/simple-folder/sub-folder" with user "user3"
+    And user "user1" has shared folder "simple-folder/sub-folder" with user "user3"
     And user "user1" has logged in using the webUI
     And the user opens folder "simple-folder/sub-folder" directly on the webUI
     When the user opens the share dialog for file "lorem.txt" using the webUI


### PR DESCRIPTION
## Description

The collaborators panel now has an additional section that displays the list of collaborators from outgoing shares that exist via one of the parent resources.

## Related Issue
- Partial fix for https://github.com/owncloud/phoenix/issues/2897 (collaborators part, not links)
- [x] REQUIRES: https://github.com/owncloud/phoenix/pull/2918 to be merged first as this PR is based on it

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- manual test
- acceptance tests

## Screenshots (if appropriate):
<img width="957" alt="image" src="https://user-images.githubusercontent.com/277525/73280635-1f84af80-41ef-11ea-906b-5eab00cc1a1e.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] add acceptance tests for the new section
- [x] add changelog
