### PR TITLE
Display indirect shares for links

### DIFF
--- a/apps/files/src/components/Collaborators/Collaborator.vue
+++ b/apps/files/src/components/Collaborators/Collaborator.vue
@@ -11,7 +11,7 @@
           <router-link :to="$_viaRouterParams" :aria-label="$gettext('Navigate to parent')"
                        class="files-collaborators-collaborator-follow-via uk-flex uk-flex-middle">
             <oc-icon name="exit_to_app" size="small" class="uk-preserve-width" />
-            <span class="oc-file-name uk-padding-remove uk-text-truncate files-collaborators-collaborator-via-label">{{ $_viaLabel }}</span>
+            <span class="oc-file-name uk-padding-remove uk-margin-xsmall-left uk-text-truncate files-collaborators-collaborator-via-label">{{ $_viaLabel }}</span>
           </router-link>
         </div>
       </oc-table-cell>

--- a/apps/files/src/components/Collaborators/Collaborator.vue
+++ b/apps/files/src/components/Collaborators/Collaborator.vue
@@ -1,17 +1,17 @@
 <template>
   <oc-table middle class="files-collaborators-collaborator">
-    <oc-table-row v-if="$_reshareInformation || $_getViaLabel" class="files-collaborators-collaborator-table-row-extra">
+    <oc-table-row v-if="$_reshareInformation || $_viaLabel" class="files-collaborators-collaborator-table-row-extra">
       <oc-table-cell shrink colspan="2"></oc-table-cell>
       <oc-table-cell colspan="2">
         <div v-if="$_reshareInformation" class="uk-text-meta uk-flex uk-flex-middle">
           <oc-icon name="repeat" class="uk-preserve-width" />
           <span>{{ $_reshareInformation }}</span>
         </div>
-        <div v-if="$_getViaLabel" class="uk-text-meta">
-          <router-link :to="$_getViaRouterParams" :aria-label="$gettext('Navigate to parent')"
+        <div v-if="$_viaLabel" class="uk-text-meta">
+          <router-link :to="$_viaRouterParams" :aria-label="$gettext('Navigate to parent')"
                        class="files-collaborators-collaborator-follow-via uk-flex uk-flex-middle">
             <oc-icon name="exit_to_app" size="small" class="uk-preserve-width" />
-            <span class="oc-file-name uk-padding-remove uk-text-truncate files-collaborators-collaborator-via-label">{{ $_getViaLabel }}</span>
+            <span class="oc-file-name uk-padding-remove uk-text-truncate files-collaborators-collaborator-via-label">{{ $_viaLabel }}</span>
           </router-link>
         </div>
       </oc-table-cell>
@@ -99,7 +99,7 @@ export default {
       return parseInt(this.collaborator.info.share_type, 10)
     },
 
-    $_getViaLabel () {
+    $_viaLabel () {
       if (!this.$_isIndirectShare) {
         return null
       }
@@ -107,7 +107,7 @@ export default {
       return this.$gettextInterpolate(translated, { folderName: basename(this.collaborator.info.path) }, false)
     },
 
-    $_getViaRouterParams () {
+    $_viaRouterParams () {
       const viaPath = this.collaborator.info.path
       return {
         name: 'files-list',

--- a/apps/files/src/components/FileLinkSidebar.vue
+++ b/apps/files/src/components/FileLinkSidebar.vue
@@ -34,42 +34,17 @@
                             name="custom-classes-transition"
                             tag="ul">
             <li v-for="link in $_links" :key="'li-' + link.id">
-              <oc-table midldle class="files-file-links-link">
-                <oc-table-row class="files-file-links-link-table-row-info">
-                  <oc-table-cell shrink>
-                    <oc-button :aria-label="$_deleteButtonLabel" @click="$_removePublicLink(link)" variation="raw" class="oc-files-file-link-delete">
-                      <oc-icon name="close" />
-                    </oc-button>
-                  </oc-table-cell>
-                  <oc-table-cell>
-                    <a :href="link.url" target="_blank" :uk-tooltip="$_tooltipTextLink" class="uk-text-bold uk-text-truncate oc-files-file-link-url">{{ link.name }}</a>
-                    <br>
-                    <span class="uk-text-meta uk-text-break">
-                      <span class="oc-files-file-link-role">{{ link.description }}</span>
-                      <template v-if="link.expiration"> |
-                        <span v-translate>Expires</span> {{ formDateFromNow(link.expiration) }}
-                      </template>
-                      <template v-if="link.password"> |
-                        <span v-translate>Password protected</span>
-                      </template>
-                    </span>
-                  </oc-table-cell>
-                  <oc-table-cell shrink class="uk-text-nowrap">
-                    <oc-button :aria-label="$_publicLinkCopyLabel" variation="raw" class="oc-files-file-link-copy-url">
-                      <oc-icon v-if="!linksCopied[link.url]"  name="copy_to_clipboard" size="small"
-                               v-clipboard:copy="link.url" v-clipboard:success="$_clipboardSuccessHandler"/>
-                      <oc-icon v-else name="ready" size="small" class="oc-files-file-link-copied-url _clipboard-success-animation"/>
-                    </oc-button>
-                    <oc-button :aria-label="$_editButtonLabel" @click="$_editPublicLink(link)" variation="raw" class="oc-files-file-link-edit">
-                      <oc-icon name="edit" size="small"/>
-                    </oc-button>
-                  </oc-table-cell>
-                </oc-table-row>
-              </oc-table>
+              <public-link-list-item :link="link"
+                                     :modifiable="true"
+                                     :indirect="false"
+                                     :linksCopied="linksCopied"
+                                     @onCopy="$_clipboardSuccessHandler"
+                                     @onDelete="$_removePublicLink"
+                                     @onEdit="$_editPublicLink" />
             </li>
           </transition-group>
         </section>
-        <section v-if="$_indirectLinks.length > 0" class="uk-margin-medium-bottom">
+        <section v-if="$_indirectLinks.length > 0" class="uk-margin-medium-top">
           <div class="uk-text-bold">
             <translate>Public Links Via Parent</translate>
           </div>
@@ -79,43 +54,11 @@
                             name="custom-classes-transition"
                             tag="ul">
             <li v-for="link in $_indirectLinks" :key="'li-' + link.id">
-              <div class="uk-text-meta">
-                <router-link :to="$_getViaRouterParams(link)" :aria-label="$gettext('Navigate to parent')"
-                             class="oc-files-file-link-via uk-flex uk-flex-middle">
-                  <oc-icon name="exit_to_app" size="small" class="uk-preserve-width" />
-                  <span class="oc-file-name uk-padding-remove uk-text-truncate files-collaborators-collaborator-via-label">{{ $_getViaLabel(link) }}</span>
-                </router-link>
-              </div>
-              <oc-table midldle class="files-file-links-link">
-                <oc-table-row class="files-file-links-link-table-row-info">
-                  <oc-table-cell shrink>
-                    <oc-icon name="lock" />
-                  </oc-table-cell>
-                  <oc-table-cell>
-                    <a :href="link.url" target="_blank" :uk-tooltip="$_tooltipTextLink" class="uk-text-bold uk-text-truncate oc-files-file-link-url">{{ link.name }}</a>
-                    <br>
-                    <span class="uk-text-meta uk-text-break">
-                      <span class="oc-files-file-link-role">{{ link.description }}</span>
-                      <template v-if="link.expiration"> |
-                        <span v-translate>Expires</span> {{ formDateFromNow(link.expiration) }}
-                      </template>
-                      <template v-if="link.password"> |
-                        <span v-translate>Password protected</span>
-                      </template>
-                    </span>
-                  </oc-table-cell>
-                  <oc-table-cell shrink class="uk-text-nowrap">
-                    <oc-button :aria-label="$_publicLinkCopyLabel" variation="raw" class="oc-files-file-link-copy-url">
-                      <oc-icon v-if="!linksCopied[link.url]"  name="copy_to_clipboard" size="small"
-                               v-clipboard:copy="link.url" v-clipboard:success="$_clipboardSuccessHandler"/>
-                      <oc-icon v-else name="ready" size="small" class="oc-files-file-link-copied-url _clipboard-success-animation"/>
-                    </oc-button>
-                    <oc-button :aria-label="$_editButtonLabel" @click="$_editPublicLink(link)" variation="raw" class="oc-files-file-link-edit">
-                      <oc-icon name="edit" size="small"/>
-                    </oc-button>
-                  </oc-table-cell>
-                </oc-table-row>
-              </oc-table>
+              <public-link-list-item :link="link"
+                                     :modifiable="false"
+                                     :indirect="true"
+                                     :linksCopied="linksCopied"
+                                     @onCopy="$_clipboardSuccessHandler" />
             </li>
           </transition-group>
         </section>
@@ -137,10 +80,10 @@ import { mapGetters, mapActions, mapState } from 'vuex'
 import moment from 'moment'
 import mixins from '../mixins'
 import { shareTypes } from '../helpers/shareTypes'
-import { basename, dirname } from 'path'
 import { getParentPaths } from '../helpers/path'
 
 const EditPublicLink = _ => import('./PublicLinksSidebar/EditPublicLink.vue')
+const PublicLinkListItem = _ => import('./PublicLinksSidebar/PublicLinkListItem.vue')
 
 const PANEL_SHOW = 'showLinks'
 const PANEL_EDIT = 'editPublicLink'
@@ -148,7 +91,8 @@ const PANEL_EDIT = 'editPublicLink'
 export default {
   mixins: [mixins],
   components: {
-    EditPublicLink
+    EditPublicLink,
+    PublicLinkListItem
   },
   title: ($gettext) => {
     return $gettext('Links')
@@ -242,20 +186,8 @@ export default {
         enforced: expireDate.enforced === '1'
       }
     },
-    $_tooltipTextLink () {
-      return `title: ${this.$gettext('Click to open the link')}; pos: bottom`
-    },
     $_addButtonLabel () {
       return this.$gettext('Add public link')
-    },
-    $_deleteButtonLabel () {
-      return this.$gettext('Delete public link')
-    },
-    $_editButtonLabel () {
-      return this.$gettext('Edit public link')
-    },
-    $_publicLinkCopyLabel () {
-      return this.$gettext('Copy public link url')
     },
     $_privateLinkCopyLabel () {
       return this.$gettext('Copy private link url')
@@ -280,22 +212,6 @@ export default {
         permissions: 1,
         hasPassword: false,
         expireDate: (this.$_expirationDate.days) ? moment().add(this.$_expirationDate.days, 'days').endOf('day').toISOString() : null
-      }
-    },
-    $_getViaLabel (link) {
-      const translated = this.$gettext('Via %{folderName}')
-      return this.$gettextInterpolate(translated, { folderName: basename(link.info.path) }, false)
-    },
-    $_getViaRouterParams (link) {
-      const viaPath = link.info.path
-      return {
-        name: 'files-list',
-        params: {
-          item: dirname(viaPath) || '/'
-        },
-        query: {
-          scrollTo: basename(viaPath)
-        }
       }
     },
     $_removePublicLink (link) {
@@ -349,12 +265,6 @@ export default {
     100% {
       opacity: 0;
     }
-  }
-</style>
-<style scoped="scoped">
-  /* FIXME: Move to ODS somehow */
-  .files-file-links-link-table-row-info > td {
-    padding: 0 10px 0 0;
   }
 </style>
 <style>

--- a/apps/files/src/components/PublicLinksSidebar/PublicLinkListItem.vue
+++ b/apps/files/src/components/PublicLinksSidebar/PublicLinkListItem.vue
@@ -48,6 +48,7 @@
 
 <script>
 import { basename, dirname } from 'path'
+import mixins from '../../mixins'
 
 export default {
   name: 'PublicLinkListItem',
@@ -69,6 +70,7 @@ export default {
       default: () => {}
     }
   },
+  mixins: [mixins],
   computed: {
     $_viaLabel () {
       if (!this.indirect) {

--- a/apps/files/src/components/PublicLinksSidebar/PublicLinkListItem.vue
+++ b/apps/files/src/components/PublicLinksSidebar/PublicLinkListItem.vue
@@ -1,0 +1,124 @@
+<template>
+  <oc-table middle class="files-file-links-link">
+    <oc-table-row v-if="$_viaLabel" class="files-file-links-link-table-row-extra">
+      <oc-table-cell shrink></oc-table-cell>
+      <oc-table-cell colspan="2">
+        <div class="uk-text-meta">
+          <router-link :to="$_viaRouterParams" :aria-label="$gettext('Navigate to parent')"
+                       class="oc-files-file-link-via uk-flex uk-flex-middle">
+            <oc-icon name="exit_to_app" size="small" class="uk-preserve-width" />
+            <span class="oc-file-name uk-padding-remove uk-text-truncate files-file-links-link-via-label">{{ $_viaLabel }}</span>
+          </router-link>
+        </div>
+      </oc-table-cell>
+    </oc-table-row>
+    <oc-table-row class="files-file-links-link-table-row-info">
+      <oc-table-cell shrink>
+        <oc-button v-if="modifiable" :aria-label="$_deleteButtonLabel" @click="$emit('onDelete', link)" variation="raw" class="oc-files-file-link-delete">
+          <oc-icon name="close" />
+        </oc-button>
+        <oc-icon v-else name="lock" />
+      </oc-table-cell>
+      <oc-table-cell>
+        <a :href="link.url" target="_blank" :uk-tooltip="$_tooltipTextLink" class="uk-text-bold uk-text-truncate oc-files-file-link-url">{{ link.name }}</a>
+        <br>
+        <span class="uk-text-meta uk-text-break">
+                      <span class="oc-files-file-link-role">{{ link.description }}</span>
+                      <template v-if="link.expiration"> |
+                        <span v-translate>Expires</span> {{ formDateFromNow(link.expiration) }}
+                      </template>
+                      <template v-if="link.password"> |
+                        <span v-translate>Password protected</span>
+                      </template>
+                    </span>
+      </oc-table-cell>
+      <oc-table-cell shrink class="uk-text-nowrap">
+        <oc-button :aria-label="$_publicLinkCopyLabel" variation="raw" class="oc-files-file-link-copy-url">
+          <oc-icon v-if="!linksCopied[link.url]"  name="copy_to_clipboard" size="small"
+                   v-clipboard:copy="link.url" v-clipboard:success="$_clipboardSuccessHandler"/>
+          <oc-icon v-else name="ready" size="small" class="oc-files-file-link-copied-url _clipboard-success-animation"/>
+        </oc-button>
+        <oc-button v-if="modifiable" :aria-label="$_editButtonLabel" @click="$emit('onEdit', link)" variation="raw" class="oc-files-file-link-edit">
+          <oc-icon name="edit" size="small"/>
+        </oc-button>
+      </oc-table-cell>
+    </oc-table-row>
+  </oc-table>
+</template>
+
+<script>
+import { basename, dirname } from 'path'
+
+export default {
+  name: 'PublicLinkListItem',
+  props: {
+    link: {
+      type: Object,
+      required: true
+    },
+    modifiable: {
+      type: Boolean,
+      default: false
+    },
+    indirect: {
+      type: Boolean,
+      default: false
+    },
+    linksCopied: {
+      type: Object,
+      default: () => {}
+    }
+  },
+  computed: {
+    $_viaLabel () {
+      if (!this.indirect) {
+        return null
+      }
+      const translated = this.$gettext('Via %{folderName}')
+      return this.$gettextInterpolate(translated, { folderName: basename(this.link.info.path) }, false)
+    },
+    $_viaRouterParams () {
+      const viaPath = this.link.info.path
+      return {
+        name: 'files-list',
+        params: {
+          item: dirname(viaPath) || '/'
+        },
+        query: {
+          scrollTo: basename(viaPath)
+        }
+      }
+    },
+    $_tooltipTextLink () {
+      return `title: ${this.$gettext('Click to open the link')}; pos: bottom`
+    },
+    $_deleteButtonLabel () {
+      return this.$gettext('Delete public link')
+    },
+    $_editButtonLabel () {
+      return this.$gettext('Edit public link')
+    },
+    $_publicLinkCopyLabel () {
+      return this.$gettext('Copy public link url')
+    }
+  },
+  methods: {
+    $_clipboardSuccessHandler (event) {
+      this.$emit('onCopy', event)
+    }
+  }
+}
+</script>
+
+<style scoped="scoped">
+  /* FIXME: Move to ODS somehow */
+  .files-file-links-link-table-row-extra > td {
+    padding: 0 10px 5px 0;
+  }
+  .files-file-links-link-table-row-info > td {
+    padding: 0 10px 0 0;
+  }
+  .files-file-links-link-via-label {
+    max-width: 65%;
+  }
+</style>

--- a/apps/files/src/components/PublicLinksSidebar/PublicLinkListItem.vue
+++ b/apps/files/src/components/PublicLinksSidebar/PublicLinkListItem.vue
@@ -33,13 +33,13 @@
                     </span>
       </oc-table-cell>
       <oc-table-cell shrink class="uk-text-nowrap">
+        <oc-button v-if="modifiable" :aria-label="$_editButtonLabel" @click="$emit('onEdit', link)" variation="raw" class="oc-files-file-link-edit">
+          <oc-icon name="edit" size="small"/>
+        </oc-button>
         <oc-button :aria-label="$_publicLinkCopyLabel" variation="raw" class="oc-files-file-link-copy-url">
           <oc-icon v-if="!linksCopied[link.url]"  name="copy_to_clipboard" size="small"
                    v-clipboard:copy="link.url" v-clipboard:success="$_clipboardSuccessHandler"/>
           <oc-icon v-else name="ready" size="small" class="oc-files-file-link-copied-url _clipboard-success-animation"/>
-        </oc-button>
-        <oc-button v-if="modifiable" :aria-label="$_editButtonLabel" @click="$emit('onEdit', link)" variation="raw" class="oc-files-file-link-edit">
-          <oc-icon name="edit" size="small"/>
         </oc-button>
       </oc-table-cell>
     </oc-table-row>

--- a/apps/files/src/components/PublicLinksSidebar/PublicLinkListItem.vue
+++ b/apps/files/src/components/PublicLinksSidebar/PublicLinkListItem.vue
@@ -7,7 +7,7 @@
           <router-link :to="$_viaRouterParams" :aria-label="$gettext('Navigate to parent')"
                        class="oc-files-file-link-via uk-flex uk-flex-middle">
             <oc-icon name="exit_to_app" size="small" class="uk-preserve-width" />
-            <span class="oc-file-name uk-padding-remove uk-text-truncate files-file-links-link-via-label">{{ $_viaLabel }}</span>
+            <span class="oc-file-name uk-padding-remove uk-margin-xsmall-left uk-text-truncate files-file-links-link-via-label">{{ $_viaLabel }}</span>
           </router-link>
         </div>
       </oc-table-cell>

--- a/changelog/unreleased/2897
+++ b/changelog/unreleased/2897
@@ -1,8 +1,10 @@
-Enhancement: Show indirect outgoing shares in collaborators list
+Enhancement: Show indirect outgoing shares in shares panel
 
 Whenever outgoing shares exist on any parent resource from the currently viewed resource,
-the collaborators panel will now show these outgoing shares with a link to jump to the matching parent
+the shares panel will now show these outgoing shares with a link to jump to the matching parent
 resource.
+This applies to both indirect collaborators shares and also to indirect public link shares.
 
 https://github.com/owncloud/phoenix/issues/2897
 https://github.com/owncloud/phoenix/pull/2929
+https://github.com/owncloud/phoenix/pull/2932

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -935,43 +935,29 @@ Feature: Share by public link
     Then the following resources should not have share indicators on the webUI
       | simple-empty-folder |
 
-  @skip @yetToImplement @issue-2897
-  Scenario: sharing details of items inside a shared folder
+  @issue-2897
+  Scenario: sharing details of indirect items inside a shared folder
     Given user "user1" has created folder "/simple-folder/sub-folder"
     And user "user1" has uploaded file with content "test" to "/simple-folder/textfile.txt"
-    And user "user1" has created a public link share with following settings
+    And user "user1" has created a public link with following settings
       | path | /simple-folder |
       | name | Public Link    |
     And user "user1" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
-    And the user opens the link share dialog for folder "sub-folder"
-    Then public link "Public Link" should be listed as share receiver via "simple-folder" on the webUI
+    Then a link named "Public Link" should be listed with role "Viewer" in the public link list of resource "sub-folder" via "simple-folder" on the webUI
 
-  @skip @yetToImplement @issue-2897
-  Scenario: sharing details of multiple public link shares with different link names
+  @issue-2897
+  Scenario: sharing details of multiple indirect public link shares
     Given user "user1" has created folder "/simple-folder/sub-folder"
     And user "user1" has uploaded file with content "test" to "/simple-folder/sub-folder/textfile.txt"
-    And user "user1" has created a public link share with following settings
+    And user "user1" has created a public link with following settings
       | path | /simple-folder |
       | name | Public Link    |
-    And user "user1" has created a public link share with following settings
+    And user "user1" has created a public link with following settings
       | path | /simple-folder/sub-folder      |
       | name | strängé लिंक नाम (#2 &).नेपाली |
     And user "user1" has logged in using the webUI
-    When the user opens folder "simple-folder" using the webUI
-    And the user opens the link share dialog for folder "sub-folder"
-    Then public link "Public Link" should be listed as share receiver via "simple-folder" on the webUI
-    When the user opens folder "sub-folder" using the webUI
-    And the user opens the link share dialog for file "textfile.txt"
-    Then public link "strängé लिंक नाम (#2 &).नेपाली" should be listed as share receiver via "sub-folder" on the webUI
-    And public link "Public Link" should be listed as share receiver via "simple-folder" on the webUI
+    When the user opens folder "simple-folder/sub-folder" directly on the webUI
+    Then a link named "Public Link" should be listed with role "Viewer" in the public link list of resource "textfile.txt" via "simple-folder" on the webUI
+    And a link named "strängé लिंक नाम (#2 &).नेपाली" should be listed with role "Viewer" in the public link list of resource "textfile.txt" via "sub-folder" on the webUI
 
-  @skip @yetToImplement @issue-2897
-  Scenario: sharing detail of items in the webUI shared by public links with empty name
-    Given user "user1" has uploaded file with content "test" to "/simple-folder/textfile.txt"
-    And user "user1" has created a public link share with following settings
-      | path | /simple-folder |
-    And user "user1" has logged in using the webUI
-    When the user opens folder "simple-folder" using the webUI
-    And the user opens the link share dialog for file "textfile.txt"
-    Then public link with last share token should be listed as share receiver via "simple-folder" on the webUI


### PR DESCRIPTION
## Description
Display indirect link shares in the links panel when link shares exist on any parent resource.

## Related Issue
Fixes https://github.com/owncloud/phoenix/issues/2897
- [x] REQUIRES: indirect shares in collaborators: https://github.com/owncloud/phoenix/pull/2929
- [x] REQUIRES: link panel styling improvements: https://github.com/owncloud/phoenix/pull/2917
(the PR is based on top of the two PRs)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- manual test web UI
- [x] acceptance tests

## Screenshots (if appropriate):
<img width="960" alt="image" src="https://user-images.githubusercontent.com/277525/73390312-1f131400-42d6-11ea-9bb1-b2cb19fd11f6.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] fix styling, especially the "via" part
- [ ] tests
- [ ] changelog