### PR TITLE
Fix template issues in both link and sharing sidebar.

### DIFF
--- a/apps/files/src/components/FileLinkSidebar.vue
+++ b/apps/files/src/components/FileLinkSidebar.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="uk-position-relative" id="oc-files-file-link">
-    <div v-show="visiblePanel === PANEL_SHOW" :aria-hidden="visiblePanel !== PANEL_SHOW">
+    <div v-show="visiblePanel === PANEL_SHOW" :aria-hidden="visiblePanel !== PANEL_SHOW" :key="PANEL_SHOW">
       <oc-loader v-if="linksLoading" :aria-label="$gettext('Loading list of file links')"/>
       <template v-else>
         <section v-if="$_privateLinkOfHighlightedFile">
@@ -71,7 +71,7 @@
         </section>
       </template>
     </div>
-    <div v-if="visiblePanel === PANEL_EDIT">
+    <div v-if="visiblePanel === PANEL_EDIT" :key="PANEL_EDIT">
       <transition enter-active-class="uk-animation-slide-right uk-animation-fast"
                   leave-active-class="uk-animation-slide-right uk-animation-reverse uk-animation-fast"
                   name="custom-classes-transition">


### PR DESCRIPTION
# Description
Templates of file link and sharing sidebars had minor issues regarding
- misuse of `aria-hidden` and `inert` instead of proper `v-if` or `v-show`+`aria-hidden` usage
- modifying variable directly in click binding -> moved to method
- view switching based on strings instead of constants
- a missing translation in an `aria-label`

## How Has This Been Tested?
* local Chrome and Firefox
- [ ] acceptance tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 