### PR TITLE
Styling tweaks for share indicators and indirect share entries

### DIFF
--- a/apps/files/src/components/Collaborators/AutocompleteItem.vue
+++ b/apps/files/src/components/Collaborators/AutocompleteItem.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="uk-flex uk-flex-middle">
-    <avatar-image v-if="item.value.shareType === shareTypes.user" class="uk-margin-small-right" :width="50" :userid="item.value.shareWith" :userName="item.label" />
+    <avatar-image v-if="item.value.shareType === shareTypes.user" class="uk-margin-small-right" :width="48" :userid="item.value.shareWith" :userName="item.label" />
     <template v-else>
       <oc-icon v-if="item.value.shareType === shareTypes.group" class="uk-margin-small-right" name="group" size="large" key="avatar-group" />
       <oc-icon v-else class="uk-margin-small-right" name="person" size="large" key="avatar-generic-person" />

--- a/apps/files/src/components/Collaborators/Collaborator.vue
+++ b/apps/files/src/components/Collaborators/Collaborator.vue
@@ -21,7 +21,7 @@
         <oc-button v-if="modifiable" :ariaLabel="$gettext('Delete share')" @click="$emit('onDelete', collaborator)" variation="raw" class="files-collaborators-collaborator-delete">
           <oc-icon name="close" />
         </oc-button>
-        <oc-icon v-else name="lock"></oc-icon>
+        <oc-icon v-else name="lock" class="uk-invisible"></oc-icon>
       </oc-table-cell>
       <oc-table-cell shrink>
         <div key="collaborator-avatar-loaded">

--- a/apps/files/src/components/Collaborators/Collaborator.vue
+++ b/apps/files/src/components/Collaborators/Collaborator.vue
@@ -25,7 +25,7 @@
       </oc-table-cell>
       <oc-table-cell shrink>
         <div key="collaborator-avatar-loaded">
-          <avatar-image v-if="$_shareType === shareTypes.user" class="uk-margin-small-right" :width="50" :userid="collaborator.name" :userName="collaborator.displayName" />
+          <avatar-image v-if="$_shareType === shareTypes.user" class="uk-margin-small-right" :width="48" :userid="collaborator.name" :userName="collaborator.displayName" />
           <div v-else key="collaborator-avatar-placeholder">
             <oc-icon v-if="$_shareType === shareTypes.group" class="uk-margin-small-right" name="group" size="large" key="avatar-group" />
             <oc-icon v-else class="uk-margin-small-right" name="person" size="large" key="avatar-generic-person" />

--- a/apps/files/src/components/Collaborators/Collaborator.vue
+++ b/apps/files/src/components/Collaborators/Collaborator.vue
@@ -1,6 +1,6 @@
 <template>
   <oc-table middle class="files-collaborators-collaborator">
-    <oc-table-row v-if="$_reshareInformation" class="files-collaborators-collaborator-table-row-extra">
+    <oc-table-row v-if="$_reshareInformation" class="files-collaborators-collaborator-table-row-top">
       <oc-table-cell shrink colspan="2"></oc-table-cell>
       <oc-table-cell colspan="2">
         <div class="uk-text-meta uk-flex uk-flex-middle">
@@ -41,7 +41,7 @@
         </oc-button>
       </oc-table-cell>
     </oc-table-row>
-    <oc-table-row v-if="$_viaLabel" class="files-collaborators-collaborator-table-row-extra">
+    <oc-table-row v-if="$_viaLabel" class="files-collaborators-collaborator-table-row-bottom">
       <oc-table-cell shrink colspan="2"></oc-table-cell>
       <oc-table-cell colspan="2">
         <div class="uk-text-meta">
@@ -145,11 +145,14 @@ export default {
 
 <style scoped="scoped">
   /* FIXME: Move to ODS somehow */
-  .files-collaborators-collaborator-table-row-extra > td {
-    padding: 0 10px 5px 0;
+  .files-collaborators-collaborator-table-row-top > td {
+    padding: 0 10px 3px 0;
   }
   .files-collaborators-collaborator-table-row-info > td {
     padding: 0 10px 0 0;
+  }
+  .files-collaborators-collaborator-table-row-bottom > td {
+    padding: 3px 10px 0 0;
   }
   .files-collaborators-collaborator-via-label {
     max-width: 75%;

--- a/apps/files/src/components/Collaborators/Collaborator.vue
+++ b/apps/files/src/components/Collaborators/Collaborator.vue
@@ -1,18 +1,11 @@
 <template>
   <oc-table middle class="files-collaborators-collaborator">
-    <oc-table-row v-if="$_reshareInformation || $_viaLabel" class="files-collaborators-collaborator-table-row-extra">
+    <oc-table-row v-if="$_reshareInformation" class="files-collaborators-collaborator-table-row-extra">
       <oc-table-cell shrink colspan="2"></oc-table-cell>
       <oc-table-cell colspan="2">
-        <div v-if="$_reshareInformation" class="uk-text-meta uk-flex uk-flex-middle">
+        <div class="uk-text-meta uk-flex uk-flex-middle">
           <oc-icon name="repeat" class="uk-preserve-width" />
-          <span>{{ $_reshareInformation }}</span>
-        </div>
-        <div v-if="$_viaLabel" class="uk-text-meta">
-          <router-link :to="$_viaRouterParams" :aria-label="$gettext('Navigate to parent')"
-                       class="files-collaborators-collaborator-follow-via uk-flex uk-flex-middle">
-            <oc-icon name="exit_to_app" size="small" class="uk-preserve-width" />
-            <span class="oc-file-name uk-padding-remove uk-margin-xsmall-left uk-text-truncate files-collaborators-collaborator-via-label">{{ $_viaLabel }}</span>
-          </router-link>
+          <span class="uk-padding-remove uk-margin-xsmall-left uk-text-truncate">{{ $_reshareInformation }}</span>
         </div>
       </oc-table-cell>
     </oc-table-row>
@@ -46,6 +39,18 @@
         <oc-button v-if="modifiable" :aria-label="$gettext('Edit share')" @click="$emit('onEdit', collaborator)" variation="raw" class="files-collaborators-collaborator-edit">
           <oc-icon name="edit" />
         </oc-button>
+      </oc-table-cell>
+    </oc-table-row>
+    <oc-table-row v-if="$_viaLabel" class="files-collaborators-collaborator-table-row-extra">
+      <oc-table-cell shrink colspan="2"></oc-table-cell>
+      <oc-table-cell colspan="2">
+        <div class="uk-text-meta">
+          <router-link :to="$_viaRouterParams" :aria-label="$gettext('Navigate to parent')"
+                       class="files-collaborators-collaborator-follow-via uk-flex uk-flex-middle">
+            <oc-icon name="exit_to_app" size="small" class="uk-preserve-width" />
+            <span class="oc-file-name uk-padding-remove uk-margin-xsmall-left uk-text-truncate files-collaborators-collaborator-via-label">{{ $_viaLabel }}</span>
+          </router-link>
+        </div>
       </oc-table-cell>
     </oc-table-row>
   </oc-table>

--- a/apps/files/src/components/FileLinkSidebar.vue
+++ b/apps/files/src/components/FileLinkSidebar.vue
@@ -43,11 +43,9 @@
                                      @onEdit="$_editPublicLink" />
             </li>
           </transition-group>
+          <hr v-if="$_links.length > 0"/>
         </section>
-        <section v-if="$_indirectLinks.length > 0" class="uk-margin-medium-top">
-          <div class="uk-text-bold">
-            <translate>Public Links Via Parent</translate>
-          </div>
+        <section v-if="$_indirectLinks.length > 0">
           <transition-group class="uk-list uk-list-divider uk-overflow-hidden"
                             enter-active-class="uk-animation-slide-left-medium"
                             leave-active-class="uk-animation-slide-right-medium uk-animation-reverse"

--- a/apps/files/src/components/FileSharingSidebar.vue
+++ b/apps/files/src/components/FileSharingSidebar.vue
@@ -14,20 +14,15 @@
           key="no-reshare-permissions-message"
           v-text="noResharePermsMessage"
         />
-        <section v-if="$_ownerAndResharers.length > 0" class="uk-margin-medium-bottom">
-          <div class="uk-text-bold">
-            <translate>Owner</translate>
-          </div>
+        <section v-if="$_ownerAndResharers.length > 0">
           <ul class="uk-list uk-list-divider uk-overflow-hidden">
             <li v-for="collaborator in $_ownerAndResharers" :key="collaborator.key">
               <collaborator :collaborator="collaborator"/>
             </li>
           </ul>
+          <hr/>
         </section>
-        <section v-if="$_directOutgoingShares.length > 0" class="uk-margin-medium-bottom">
-          <div class="uk-text-bold">
-            <translate>Shares</translate>
-          </div>
+        <section v-if="$_directOutgoingShares.length > 0">
           <transition-group id="files-collaborators-list"
                             class="uk-list uk-list-divider uk-overflow-hidden"
                             enter-active-class="uk-animation-slide-left-medium"
@@ -38,16 +33,15 @@
               <collaborator :collaborator="collaborator" :modifiable="true" @onDelete="$_ocCollaborators_deleteShare" @onEdit="$_ocCollaborators_editShare"/>
             </li>
           </transition-group>
+          <hr/>
         </section>
-        <section v-if="$_indirectOutgoingShares.length > 0" class="uk-margin-medium-bottom">
-          <div class="uk-text-bold">
-            <translate>Via Parent</translate>
-          </div>
+        <section v-if="$_indirectOutgoingShares.length > 0">
           <ul class="uk-list uk-list-divider uk-overflow-hidden">
             <li v-for="collaborator in $_indirectOutgoingShares" :key="collaborator.key">
               <collaborator :collaborator="collaborator"/>
             </li>
           </ul>
+          <hr/>
         </section>
         <div v-if="$_noCollaborators && !$_sharesLoading" key="oc-collaborators-no-results"><translate>No collaborators</translate></div>
       </template>

--- a/apps/files/src/components/FilesLists/StatusIndicators/DefaultIndicators.vue
+++ b/apps/files/src/components/FilesLists/StatusIndicators/DefaultIndicators.vue
@@ -4,7 +4,7 @@
       v-for="(indicator, index) in indicators"
       :key="index"
       class="file-row-share-indicator uk-text-middle"
-      :class="{ 'uk-margin-xsmall-left' : index > 0 }"
+      :class="{ 'uk-margin-xsmall-left' : index > 0, 'uk-invisible' : !indicator.visible }"
       :aria-label="indicator.label"
       @click="indicator.handler(item, indicator.id)"
       variation="raw"
@@ -45,29 +45,21 @@ export default {
     ...mapGetters('Files', ['sharesTree']),
 
     indicators () {
-      const indicators = []
-
-      if (this.isUserShare(this.item)) {
-        indicators.push({
-          id: 'files-sharing',
-          label: this.shareUserIconLabel(this.item),
-          icon: 'group',
-          status: this.shareUserIconVariation(this.item),
-          handler: this.indicatorHandler
-        })
-      }
-
-      if (this.isLinkShare(this.item)) {
-        indicators.push({
-          id: 'file-link',
-          label: this.shareLinkIconLabel(this.item),
-          icon: 'link',
-          status: this.shareLinkIconVariation(this.item),
-          handler: this.indicatorHandler
-        })
-      }
-
-      return indicators
+      return [{
+        id: 'files-sharing',
+        label: this.shareUserIconLabel(this.item),
+        visible: this.isUserShare(this.item),
+        icon: 'group',
+        status: this.shareUserIconVariation(this.item),
+        handler: this.indicatorHandler
+      }, {
+        id: 'file-link',
+        label: this.shareLinkIconLabel(this.item),
+        visible: this.isLinkShare(this.item),
+        icon: 'link',
+        status: this.shareLinkIconVariation(this.item),
+        handler: this.indicatorHandler
+      }]
     },
 
     shareTypesIndirect () {

--- a/apps/files/src/components/PublicLinksSidebar/PublicLinkListItem.vue
+++ b/apps/files/src/components/PublicLinksSidebar/PublicLinkListItem.vue
@@ -31,7 +31,7 @@
         </oc-button>
       </oc-table-cell>
     </oc-table-row>
-    <oc-table-row v-if="$_viaLabel" class="files-file-links-link-table-row-extra">
+    <oc-table-row v-if="$_viaLabel" class="files-file-links-link-table-row-bottom">
       <oc-table-cell shrink></oc-table-cell>
       <oc-table-cell colspan="2">
         <div class="uk-text-meta">
@@ -114,11 +114,11 @@ export default {
 
 <style scoped="scoped">
   /* FIXME: Move to ODS somehow */
-  .files-file-links-link-table-row-extra > td {
-    padding: 0 10px 5px 0;
-  }
   .files-file-links-link-table-row-info > td {
     padding: 0 10px 0 0;
+  }
+  .files-file-links-link-table-row-bottom > td {
+    padding: 3px 10px 0 0;
   }
   .files-file-links-link-via-label {
     max-width: 65%;

--- a/apps/files/src/components/PublicLinksSidebar/PublicLinkListItem.vue
+++ b/apps/files/src/components/PublicLinksSidebar/PublicLinkListItem.vue
@@ -17,7 +17,7 @@
         <oc-button v-if="modifiable" :aria-label="$_deleteButtonLabel" @click="$emit('onDelete', link)" variation="raw" class="oc-files-file-link-delete">
           <oc-icon name="close" />
         </oc-button>
-        <oc-icon v-else name="lock" />
+        <oc-icon v-else name="lock" class="uk-invisible" />
       </oc-table-cell>
       <oc-table-cell>
         <a :href="link.url" target="_blank" :uk-tooltip="$_tooltipTextLink" class="uk-text-bold uk-text-truncate oc-files-file-link-url">{{ link.name }}</a>

--- a/apps/files/src/components/PublicLinksSidebar/PublicLinkListItem.vue
+++ b/apps/files/src/components/PublicLinksSidebar/PublicLinkListItem.vue
@@ -1,17 +1,5 @@
 <template>
   <oc-table middle class="files-file-links-link">
-    <oc-table-row v-if="$_viaLabel" class="files-file-links-link-table-row-extra">
-      <oc-table-cell shrink></oc-table-cell>
-      <oc-table-cell colspan="2">
-        <div class="uk-text-meta">
-          <router-link :to="$_viaRouterParams" :aria-label="$gettext('Navigate to parent')"
-                       class="oc-files-file-link-via uk-flex uk-flex-middle">
-            <oc-icon name="exit_to_app" size="small" class="uk-preserve-width" />
-            <span class="oc-file-name uk-padding-remove uk-margin-xsmall-left uk-text-truncate files-file-links-link-via-label">{{ $_viaLabel }}</span>
-          </router-link>
-        </div>
-      </oc-table-cell>
-    </oc-table-row>
     <oc-table-row class="files-file-links-link-table-row-info">
       <oc-table-cell shrink>
         <oc-button v-if="modifiable" :aria-label="$_deleteButtonLabel" @click="$emit('onDelete', link)" variation="raw" class="oc-files-file-link-delete">
@@ -41,6 +29,18 @@
                    v-clipboard:copy="link.url" v-clipboard:success="$_clipboardSuccessHandler"/>
           <oc-icon v-else name="ready" size="small" class="oc-files-file-link-copied-url _clipboard-success-animation"/>
         </oc-button>
+      </oc-table-cell>
+    </oc-table-row>
+    <oc-table-row v-if="$_viaLabel" class="files-file-links-link-table-row-extra">
+      <oc-table-cell shrink></oc-table-cell>
+      <oc-table-cell colspan="2">
+        <div class="uk-text-meta">
+          <router-link :to="$_viaRouterParams" :aria-label="$gettext('Navigate to parent')"
+                       class="oc-files-file-link-via uk-flex uk-flex-middle">
+            <oc-icon name="exit_to_app" size="small" class="uk-preserve-width" />
+            <span class="oc-file-name uk-padding-remove uk-margin-xsmall-left uk-text-truncate files-file-links-link-via-label">{{ $_viaLabel }}</span>
+          </router-link>
+        </div>
       </oc-table-cell>
     </oc-table-row>
   </oc-table>

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -780,24 +780,29 @@ module.exports = {
           this.elements.shareIndicatorsInFileRow.locateStrategy,
           shareIndicatorsXpath,
           (result) => {
-            result.value.forEach(async element => {
-              await this.api.elementIdAttribute(element.ELEMENT, 'aria-label', (attr) => {
-                switch (attr.value) {
-                  case 'Directly shared with collaborators':
-                    indicators.push('user-direct')
-                    break
-                  case 'Shared with collaborators through one of the parent folders':
-                    indicators.push('user-indirect')
-                    break
-                  case 'Directly shared with links':
-                    indicators.push('link-direct')
-                    break
-                  case 'Shared with links through one of the parent folders':
-                    indicators.push('link-indirect')
-                    break
-                  default:
-                    console.warn('Unknown share indicator found: "' + attr + '"')
+            result.value.forEach(element => {
+              return this.api.elementIdAttribute(element.ELEMENT, 'class', (attr) => {
+                if (attr.value.indexOf('uk-invisible') >= 0) {
+                  return
                 }
+                return this.api.elementIdAttribute(element.ELEMENT, 'aria-label', (attr) => {
+                  switch (attr.value) {
+                    case 'Directly shared with collaborators':
+                      indicators.push('user-direct')
+                      break
+                    case 'Shared with collaborators through one of the parent folders':
+                      indicators.push('user-indirect')
+                      break
+                    case 'Directly shared with links':
+                      indicators.push('link-direct')
+                      break
+                    case 'Shared with links through one of the parent folders':
+                      indicators.push('link-indirect')
+                      break
+                    default:
+                      console.warn('Unknown share indicator found: "' + attr + '"')
+                  }
+                })
               })
             })
           }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Related Issue
- [x] REQUIRES: https://github.com/owncloud/phoenix/pull/2932 to be merged first
- Fixes https://github.com/owncloud/phoenix/issues/2938

## Motivation and Context
See https://github.com/owncloud/phoenix/issues/2938

## How Has This Been Tested?
- manual test in web UI
- acceptance tests

## Screenshots (if appropriate):
### Share indicators alignment
![image](https://user-images.githubusercontent.com/277525/73471909-6c50bd80-438a-11ea-8c66-a0e0bc083b65.png)

### Indirect shares
- Reshare/via are now respectively on the top/bottom.
- Removed section headers
- No more lock icon but empty space instead
![image](https://user-images.githubusercontent.com/277525/73471948-7e326080-438a-11ea-989d-1859d66b3dd3.png)

![image](https://user-images.githubusercontent.com/277525/73471969-88ecf580-438a-11ea-8ae5-84a430bf5bb2.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] update changelog to mention this PR ?