### PR TITLE
Fix add/remove animations for collaborators and links

### DIFF
--- a/apps/files/src/components/Collaborators/Collaborator.vue
+++ b/apps/files/src/components/Collaborators/Collaborator.vue
@@ -11,9 +11,10 @@
     </oc-table-row>
     <oc-table-row class="files-collaborators-collaborator-table-row-info">
       <oc-table-cell shrink>
-        <oc-button v-if="modifiable" :ariaLabel="$gettext('Delete share')" @click="$emit('onDelete', collaborator)" variation="raw" class="files-collaborators-collaborator-delete">
+        <oc-button v-if="$_deleteButtonVisible" :ariaLabel="$gettext('Delete share')" @click="$_removeShare" variation="raw" class="files-collaborators-collaborator-delete">
           <oc-icon name="close" />
         </oc-button>
+        <oc-spinner v-else-if="$_loadingSpinnerVisible" :aria-label="$gettext('Removing collaborator') + '...'" size="small" />
         <oc-icon v-else name="lock" class="uk-invisible"></oc-icon>
       </oc-table-cell>
       <oc-table-cell shrink>
@@ -36,7 +37,7 @@
         </div>
       </oc-table-cell>
       <oc-table-cell shrink>
-        <oc-button v-if="modifiable" :aria-label="$gettext('Edit share')" @click="$emit('onEdit', collaborator)" variation="raw" class="files-collaborators-collaborator-edit">
+        <oc-button v-if="$_editButtonVisible" :aria-label="$gettext('Edit share')" @click="$emit('onEdit', collaborator)" variation="raw" class="files-collaborators-collaborator-edit">
           <oc-icon name="edit" />
         </oc-button>
       </oc-table-cell>
@@ -79,11 +80,22 @@ export default {
   },
   data: function () {
     return {
-      shareTypes
+      shareTypes,
+      removalInProgress: false
     }
   },
   computed: {
     ...mapGetters(['user']),
+
+    $_loadingSpinnerVisible () {
+      return this.modifiable && this.removalInProgress
+    },
+    $_deleteButtonVisible () {
+      return this.modifiable && !this.removalInProgress
+    },
+    $_editButtonVisible () {
+      return this.modifiable && !this.removalInProgress
+    },
 
     $_isIndirectShare () {
       // it is assumed that the "incoming" attribute only exists
@@ -138,6 +150,12 @@ export default {
       return {
         label: this.$gettext('Unknown Role')
       }
+    }
+  },
+  methods: {
+    $_removeShare () {
+      this.removalInProgress = true
+      this.$emit('onDelete', this.collaborator)
     }
   }
 }

--- a/apps/files/src/components/Collaborators/CollaboratorsEditOptions.vue
+++ b/apps/files/src/components/Collaborators/CollaboratorsEditOptions.vue
@@ -111,15 +111,17 @@ export default {
     }
   },
   methods: {
-    selectRole (role, propagate = true) {
+    selectRole (role) {
       this.selectedRole = role
-
-      this.$emit('optionChange', { role: this.selectedRole, permissions: this.additionalPermissions, expirationDate: this.expirationDate, propagate: propagate })
+      this.publishChange()
     },
 
     checkAdditionalPermissions (permissions) {
       this.additionalPermissions = permissions
+      this.publishChange()
+    },
 
+    publishChange () {
       this.$emit('optionChange', { role: this.selectedRole, permissions: this.additionalPermissions, expirationDate: this.expirationDate })
     }
   }

--- a/apps/files/src/components/Collaborators/EditCollaborator.vue
+++ b/apps/files/src/components/Collaborators/EditCollaborator.vue
@@ -6,23 +6,26 @@
     </div>
     <hr class="divider" />
     <collaborators-edit-options
-      :existingRole="collaborator.role"
-      :collaboratorsPermissions="collaboratorsPermissions"
+      :existingRole="$_originalRole"
+      :collaboratorsPermissions="$_originalPermissions"
       @optionChange="collaboratorOptionChanged"
       class="uk-margin-bottom"
     />
     <hr class="divider" />
     <oc-grid gutter="small" class="uk-margin-bottom">
       <div>
-        <oc-button class="files-collaborators-collaborator-cancel" :disabled="collaboratorSaving" @click="$_ocCollaborators_cancelChanges">
+        <oc-button class="files-collaborators-collaborator-cancel" :disabled="saving" @click="$_ocCollaborators_cancelChanges">
           <translate>Cancel</translate>
         </oc-button>
-        <oc-button variation="primary" :disabled="collaboratorSaving || !editing" :aria-label="_saveButtonLabel" @click="$_ocCollaborators_saveChanges(collaborator)">
-          <translate>Save</translate>
+        <oc-button v-if="saving" :disabled="true">
+          <oc-spinner :aria-label="$gettext('Saving Share')" class="uk-position-small uk-position-center-left" size="small"/>
+          <span :aria-hidden="true" class="uk-margin-small-left" v-translate>Saving Share</span>
+        </oc-button>
+        <oc-button v-else variation="primary" :disabled="!$_hasChanges" :aria-label="$gettext('Save Share')" @click="$_ocCollaborators_saveChanges">
+          <translate>Save Share</translate>
         </oc-button>
       </div>
     </oc-grid>
-    <oc-spinner v-if="collaboratorSaving" class="uk-margin-small-left" :aria-label="$gettext('Saving')"/>
   </div>
 </template>
 
@@ -43,101 +46,78 @@ export default {
   mixins: [
     Mixins
   ],
-  props: ['collaborator'],
+  props: {
+    collaborator: {
+      type: Object,
+      required: true
+    }
+  },
   data () {
     return {
-      editing: false,
-      selectedNewRole: null,
+      selectedRole: null,
       additionalPermissions: null,
-      permissionsChanged: false
+      saving: false
     }
   },
   computed: {
-    ...mapGetters('Files', ['highlightedFile', 'collaboratorSaving', 'collaboratorsEditInProgress']),
+    ...mapGetters('Files', ['highlightedFile']),
     ...mapGetters(['user']),
 
-    _saveButtonLabel () {
-      return this.$gettext('Save Share')
-    },
-
-    originalRole () {
-      return this.roles[this.collaborator.role].tag
-    },
-
-    collaboratorsPermissions () {
+    $_originalPermissions () {
       const permissions = this.collaborator.customPermissions
-
       return filterObject(permissions, (key, value) => value)
+    },
+
+    $_originalRole () {
+      return this.roles[this.collaborator.role.name]
+    },
+
+    $_permissionsBitmask () {
+      const role = this.selectedRole || this.$_originalRole
+      const permissions = this.additionalPermissions || Object.keys(this.$_originalPermissions)
+      return roleToBitmask(role, permissions)
+    },
+
+    $_hasChanges () {
+      if (this.selectedRole !== null && this.selectedRole.name !== this.$_originalRole.name) {
+        // if the role has changed, always return true. The user doesn't need to understand if two bitmasks of different roles are the same!
+        return true
+      }
+      const originalBitmask = roleToBitmask(this.$_originalRole, Object.keys(this.$_originalPermissions))
+      return originalBitmask !== this.$_permissionsBitmask
     }
   },
   methods: {
-    ...mapActions('Files', ['changeShare', 'toggleCollaboratorsEdit']),
+    ...mapActions('Files', ['changeShare']),
 
-    close () {
-      this.$emit('close')
-    },
+    $_ocCollaborators_saveChanges () {
+      this.saving = true
 
-    $_ocCollaborators_saveChanges (collaborator) {
-      if (!this.selectedRole) this.selectedRole = this.roles[collaborator.role.name]
-      let permissions = this.additionalPermissions
-
-      if (!permissions) {
-        permissions = []
-        for (const permission in this.collaboratorsPermissions) {
-          permissions.push(permission)
-        }
-      }
-
-      const bitmask = roleToBitmask(this.selectedRole, permissions, this.highlightedFile.type === 'folder')
+      if (!this.selectedRole) this.selectedRole = this.$_originalRole
+      const bitmask = this.$_permissionsBitmask
 
       this.changeShare({
         client: this.$client,
-        share: collaborator,
-        // TODO: After changing to tabs view, this can be dropped
+        share: this.collaborator,
         // Map bitmask to role to get the correct role in case the advanced role was mapped to existing role
         role: bitmaskToRole(bitmask, this.highlightedFile.type === 'folder'),
         permissions: bitmask
       })
-        .then(() => {
-          this.editing = false
-          this.toggleCollaboratorsEdit(false)
-          this.close()
+        .then(() => this.$_ocCollaborators_cancelChanges())
+        .catch(() => {
+          this.saving = false
         })
     },
-    $_ocCollaborators_changeRole (role) {
-      this.selectedNewRole = role
-    },
-    $_ocCollaborators_selectedRoleName (collaborator) {
-      if (!this.selectedNewRole) {
-        return this.roles[collaborator.role].name
-      }
 
-      return this.selectedNewRole.name
-    },
-    $_ocCollaborators_selectedRoleDescription (collaborator) {
-      if (!this.selectedNewRole) {
-        return this.roles[collaborator.role].description
-      }
-
-      return this.selectedNewRole.description
-    },
     $_ocCollaborators_cancelChanges () {
-      this.selectedNewRole = null
-      this.editing = false
-      this.toggleCollaboratorsEdit(false)
+      this.selectedRole = null
+      this.additionalPermissions = null
+      this.saving = false
       this.close()
     },
 
-    onChange () {
-      // TODO: Bring this back
-      // if (this.selectedRole.name === this.originalRole.name && !this.permissionsChanged) {
-      //   this.editing = false
-      //   this.toggleCollaboratorsEdit(false)
-      //   return
-      // }
-
-      this.editing = true
-      this.toggleCollaboratorsEdit(true)
+    close () {
+      this.$emit('close')
     }
   }
 }

--- a/apps/files/src/components/FileLinkSidebar.vue
+++ b/apps/files/src/components/FileLinkSidebar.vue
@@ -27,8 +27,7 @@
           <div class="uk-margin-small-top uk-margin-small-bottom">
             <oc-button @click="$_addPublicLink" icon="add" variation="primary" id="files-file-link-add">{{ $_addButtonLabel }}</oc-button>
           </div>
-          <transition-group v-if="$_links.length > 0"
-                            class="uk-list uk-list-divider uk-overflow-hidden"
+          <transition-group class="uk-list uk-list-divider uk-overflow-hidden"
                             enter-active-class="uk-animation-slide-left-medium"
                             leave-active-class="uk-animation-slide-right-medium uk-animation-reverse"
                             name="custom-classes-transition"

--- a/apps/files/src/components/FileSharingSidebar.vue
+++ b/apps/files/src/components/FileSharingSidebar.vue
@@ -22,7 +22,7 @@
           </ul>
           <hr/>
         </section>
-        <section v-if="$_directOutgoingShares.length > 0">
+        <section>
           <transition-group id="files-collaborators-list"
                             class="uk-list uk-list-divider uk-overflow-hidden"
                             enter-active-class="uk-animation-slide-left-medium"
@@ -33,7 +33,7 @@
               <collaborator :collaborator="collaborator" :modifiable="true" @onDelete="$_ocCollaborators_deleteShare" @onEdit="$_ocCollaborators_editShare"/>
             </li>
           </transition-group>
-          <hr/>
+          <hr v-if="$_directOutgoingShares.length > 0" />
         </section>
         <section v-if="$_indirectOutgoingShares.length > 0">
           <ul class="uk-list uk-list-divider uk-overflow-hidden">

--- a/apps/files/src/components/FileSharingSidebar.vue
+++ b/apps/files/src/components/FileSharingSidebar.vue
@@ -98,9 +98,9 @@ export default {
       currentShare: null,
 
       // panel types
-      PANEL_SHOW: PANEL_SHOW,
-      PANEL_EDIT: PANEL_EDIT,
-      PANEL_NEW: PANEL_NEW
+      PANEL_SHOW,
+      PANEL_EDIT,
+      PANEL_NEW
     }
   },
   computed: {
@@ -269,7 +269,6 @@ export default {
     }
   },
   mounted () {
-    this.toggleCollaboratorsEdit(false)
     if (this.highlightedFile) {
       this.$_reloadShares()
     } else {

--- a/apps/files/src/components/PublicLinksSidebar/EditPublicLink.vue
+++ b/apps/files/src/components/PublicLinksSidebar/EditPublicLink.vue
@@ -61,16 +61,10 @@
       <hr class="divider"/>
       <oc-grid class="uk-margin-bottom" gutter="small">
         <div>
-          <oc-button :disabled="linksLoading" @click="$_closeForm" id="oc-files-file-link-cancel">
+          <oc-button :disabled="saving" @click="$_closeForm" id="oc-files-file-link-cancel">
             <translate>Cancel</translate>
           </oc-button>
-          <oc-button :disabled="!$_isValid" @click="$_addLink" v-if="!linksLoading && $_isNew" variation="primary" id="oc-files-file-link-create">
-            <translate>Create Public Link</translate>
-          </oc-button>
-          <oc-button :disabled="!$_isValid || !$_hasChanges" @click="$_updateLink" v-else-if="!linksLoading && !$_isNew" variation="primary" id="oc-files-file-link-save">
-            <translate>Save Public Link</translate>
-          </oc-button>
-          <button class="uk-button uk-button-default uk-position-relative" disabled v-else>
+          <button v-if="saving" class="uk-button uk-button-default uk-position-relative" disabled>
             <template v-if="$_isNew">
               <oc-spinner :ariaLabel="$gettext('Creating Public Link')" class="uk-position-small uk-position-center-left" size="small"/>
               <span :aria-hidden="true" class="uk-margin-small-left" v-translate>Creating Public Link</span>
@@ -80,6 +74,14 @@
               <span :aria-hidden="true" class="uk-margin-small-left" v-translate>Saving Public Link</span>
             </template>
           </button>
+          <template v-else>
+            <oc-button v-if="$_isNew" :disabled="!$_isValid" @click="$_addLink" variation="primary" id="oc-files-file-link-create">
+              <translate>Create Public Link</translate>
+            </oc-button>
+            <oc-button v-else :disabled="!$_isValid || !$_hasChanges" @click="$_updateLink" variation="primary" id="oc-files-file-link-save">
+              <translate>Save Public Link</translate>
+            </oc-button>
+          </template>
         </div>
       </oc-grid>
     </form>
@@ -103,6 +105,7 @@ export default {
   props: ['params'],
   data () {
     return {
+      saving: false,
       password: null,
       errors: false,
       ...this.params,
@@ -119,7 +122,7 @@ export default {
     return $gettext('Links')
   },
   computed: {
-    ...mapGetters('Files', ['highlightedFile', 'linksLoading']),
+    ...mapGetters('Files', ['highlightedFile']),
     ...mapGetters(['getToken', 'capabilities']),
 
     $_isNew () {
@@ -242,6 +245,8 @@ export default {
     },
 
     $_addLink () {
+      this.saving = true
+
       const params = {
         expireDate: this.expireDate,
         permissions: this.permissions,
@@ -258,14 +263,18 @@ export default {
         $gettext: this.$gettext,
         params
       }).then(e => {
+        this.saving = false
         this.errors = false
         this.$_closeForm()
       }).catch(e => {
+        this.saving = false
         this.errors = e
       })
     },
 
     $_updateLink () {
+      this.saving = true
+
       const params = {
         expireDate: this.expireDate,
         permissions: this.permissions,
@@ -282,9 +291,11 @@ export default {
         $gettext: this.$gettext,
         params
       }).then(() => {
+        this.saving = false
         this.errors = false
         this.$_closeForm()
       }).catch(e => {
+        this.saving = false
         this.errors = e
       })
     },

--- a/apps/files/src/components/PublicLinksSidebar/PublicLinkListItem.vue
+++ b/apps/files/src/components/PublicLinksSidebar/PublicLinkListItem.vue
@@ -2,9 +2,10 @@
   <oc-table middle class="files-file-links-link">
     <oc-table-row class="files-file-links-link-table-row-info">
       <oc-table-cell shrink>
-        <oc-button v-if="modifiable" :aria-label="$_deleteButtonLabel" @click="$emit('onDelete', link)" variation="raw" class="oc-files-file-link-delete">
+        <oc-button v-if="$_deleteButtonVisible" :aria-label="$_deleteButtonLabel" @click="$_removeLink" variation="raw" class="oc-files-file-link-delete">
           <oc-icon name="close" />
         </oc-button>
+        <oc-spinner v-else-if="$_loadingSpinnerVisible" :aria-label="$gettext('Removing public link') + '...'" size="small" />
         <oc-icon v-else name="lock" class="uk-invisible" />
       </oc-table-cell>
       <oc-table-cell>
@@ -21,7 +22,7 @@
                     </span>
       </oc-table-cell>
       <oc-table-cell shrink class="uk-text-nowrap">
-        <oc-button v-if="modifiable" :aria-label="$_editButtonLabel" @click="$emit('onEdit', link)" variation="raw" class="oc-files-file-link-edit">
+        <oc-button v-if="$_editButtonVisible" :aria-label="$_editButtonLabel" @click="$emit('onEdit', link)" variation="raw" class="oc-files-file-link-edit">
           <oc-icon name="edit" size="small"/>
         </oc-button>
         <oc-button :aria-label="$_publicLinkCopyLabel" variation="raw" class="oc-files-file-link-copy-url">
@@ -71,7 +72,21 @@ export default {
       default: () => {}
     }
   },
+  data () {
+    return {
+      removalInProgress: false
+    }
+  },
   computed: {
+    $_loadingSpinnerVisible () {
+      return this.modifiable && this.removalInProgress
+    },
+    $_deleteButtonVisible () {
+      return this.modifiable && !this.removalInProgress
+    },
+    $_editButtonVisible () {
+      return this.modifiable && !this.removalInProgress
+    },
     $_viaLabel () {
       if (!this.indirect) {
         return null
@@ -107,6 +122,10 @@ export default {
   methods: {
     $_clipboardSuccessHandler (event) {
       this.$emit('onCopy', event)
+    },
+    $_removeLink () {
+      this.removalInProgress = true
+      this.$emit('onDelete', this.link)
     }
   }
 }

--- a/apps/files/src/mixins/collaborators.js
+++ b/apps/files/src/mixins/collaborators.js
@@ -1,4 +1,4 @@
-import { mapGetters, mapActions } from 'vuex'
+import { mapGetters } from 'vuex'
 import roles from '../helpers/collaboratorRolesDefinition'
 
 export default {
@@ -69,8 +69,6 @@ export default {
     }
   },
   methods: {
-    ...mapActions('Files', ['toggleCollaboratorsEdit']),
-
     $_ocCollaborators_collaboratorType (type) {
       if (parseInt(type, 10) === 0) return this.$gettext('User')
 
@@ -78,20 +76,9 @@ export default {
 
       return this.$gettext('Group')
     },
-    $_ocCollaborators_switchPermission (permission) {
-      this.permissionsChanged = true
-      this[permission] = !this[permission]
-      this.editing = true
-      this.toggleCollaboratorsEdit(true)
-    },
-    collaboratorOptionChanged ({ role, permissions, propagate = true }) {
+    collaboratorOptionChanged ({ role, permissions }) {
       this.selectedRole = role
       this.additionalPermissions = permissions
-
-      if (propagate) {
-        this.editing = true
-        this.toggleCollaboratorsEdit(true)
-      }
     }
   }
 }

--- a/apps/files/src/store/getters.js
+++ b/apps/files/src/store/getters.js
@@ -87,14 +87,8 @@ export default {
   highlightedFile: state => {
     return state.highlightedFile
   },
-  collaboratorSaving: state => {
-    return state.collaboratorSaving
-  },
   publicLinkPassword: state => {
     return state.publicLinkPassword
-  },
-  collaboratorsEditInProgress: state => {
-    return state.collaboratorsEditInProgress
   },
   links: state => {
     return state.links

--- a/apps/files/src/store/mutations.js
+++ b/apps/files/src/store/mutations.js
@@ -225,14 +225,8 @@ export default {
     }
     state.highlightedFile = file
   },
-  TOGGLE_COLLABORATOR_SAVING (state, saving) {
-    state.collaboratorSaving = saving
-  },
   SET_PUBLIC_LINK_PASSWORD (state, password) {
     state.publicLinkPassword = password
-  },
-  TOGGLE_COLLABORATORS_EDIT (state, inProgress) {
-    state.collaboratorsEditInProgress = inProgress
   },
   LINKS_PURGE (state) {
     state.links = []

--- a/apps/files/src/store/state.js
+++ b/apps/files/src/store/state.js
@@ -57,9 +57,7 @@ export default {
   overwriteDialogTitle: null,
   overwriteDialogMessage: null,
   highlightedFile: null,
-  collaboratorSaving: false,
   publicLinkPassword: null,
-  collaboratorsEditInProgress: false,
   uploaded: [],
   actionsInProgress: [],
 

--- a/changelog/unreleased/2937
+++ b/changelog/unreleased/2937
@@ -1,0 +1,9 @@
+Bugfix: Prevent loader in sidebar on add/remove
+
+When adding or removing a public link or collaborator, the respective list view sidebar panels briefly hid the panel and showed a loader instead.
+The UI is supposed to show a visual transition of a new list item into the list on adding, as well as a visual transition out of the list on deletion.
+This is fixed now by not triggering the loading state on add and remove actions anymore. A loading state is only meant to appear when the user
+navigates to the shares of another file/folder.
+
+https://github.com/owncloud/phoenix/issues/2937
+https://github.com/owncloud/phoenix/pull/2952


### PR DESCRIPTION
# Detailed Description
Collaborator and link forms (adding/editing) unnecessarily trigger mutations on loading states (`SHARES_LOADING` and `LINKS_LOADING`). This causes animations for adding and removing collaborators/links to fail in the respective panels. While fixing this, some old code has been cleaned up as well.
- [x] removed triggers for busy-state for collaborator and link saving/creating. using local variable in respective form components now. This fixes the animations in the sidebar panels when adding or removing items, as the loader is not triggered anymore. As saving can be represented within the respective form, there is no need to push this state into the store.
- [x] removed unused code in collaborator editing form
- [x] changed buttons in collaborator forms to represent a saving-state when still in saving mode
- [x] re-introduced a data change detection for collaborators.
- [x] switched promise handling when adding collaborators to using p-queue

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/phoenix/issues/2937

## Motivation and Context
Fix animations and clean up old code.

## How Has This Ben Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- local in Chrome and Firefox
- [ ] selenium

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
