### PR TITLE
[tests-only] Tests for reshare and additional user info in collaborators list

### DIFF
--- a/apps/files/src/components/Collaborators/Collaborator.vue
+++ b/apps/files/src/components/Collaborators/Collaborator.vue
@@ -5,7 +5,7 @@
       <oc-table-cell colspan="2">
         <div class="uk-text-meta uk-flex uk-flex-middle">
           <oc-icon name="repeat" class="uk-preserve-width" />
-          <span class="uk-padding-remove uk-margin-xsmall-left uk-text-truncate">{{ $_reshareInformation }}</span>
+          <span class="uk-padding-remove uk-margin-xsmall-left uk-text-truncate files-collaborators-collaborator-reshare-information">{{ $_reshareInformation }}</span>
         </div>
       </oc-table-cell>
     </oc-table-row>

--- a/apps/files/src/components/Collaborators/Collaborator.vue
+++ b/apps/files/src/components/Collaborators/Collaborator.vue
@@ -29,7 +29,7 @@
         <div class="uk-flex uk-flex-column uk-flex-center">
           <div class="oc-text">
             <span class="files-collaborators-collaborator-name uk-text-bold">{{ collaborator.displayName }}</span>
-            <span v-if="$_shareType === shareTypes.user && collaborator.info.share_with_additional_info.length > 0" class="uk-text-meta">({{ collaborator.info.share_with_additional_info }})</span>
+            <span v-if="$_shareType === shareTypes.user && collaborator.info.share_with_additional_info.length > 0" class="uk-text-meta files-collaborators-collaborator-additional-info">({{ collaborator.info.share_with_additional_info }})</span>
           </div>
           <span class="oc-text"><span class="files-collaborators-collaborator-role">{{ originalRole.label }}</span><template v-if="collaborator.expires"> | <translate :translate-params="{expires: formDateFromNow(collaborator.expires)}">Expires: %{expires}</translate></template></span>
           <span class="uk-text-meta files-collaborators-collaborator-share-type" v-text="$_ocCollaborators_collaboratorType(collaborator.info.share_type)" />

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -507,3 +507,21 @@ Feature: Sharing files and folders with internal users
     Then user "User Two" should be listed as "Editor" in the collaborators list on the webUI
     And user "User Three" should be listed as "Editor" reshared through "User Two" in the collaborators list on the webUI
 
+  Scenario Outline: collaborators list contains additional info when enabled
+    Given the setting "user_additional_info_field" of app "core" has been set to "<additional-info-field>"
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    When user "user1" has logged in using the webUI
+    And the user opens the share dialog for folder "simple-folder" using the webUI
+    Then user "User Two" should be listed with additional info "<additional-info-result>" in the collaborators list on the webUI
+    Examples:
+      | additional-info-field | additional-info-result |
+      | id                    | (user2)                |
+      | email                 | (user2@example.org)    |
+
+  Scenario: collaborators list does not contain additional info when disabled
+    Given the setting "user_additional_info_field" of app "core" has been set to ""
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    When user "user1" has logged in using the webUI
+    And the user opens the share dialog for folder "simple-folder" using the webUI
+    Then user "User Two" should be listed without additional info in the collaborators list on the webUI
+

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -498,3 +498,12 @@ Feature: Sharing files and folders with internal users
     And the user opens the share dialog for folder "simple-folder (2)" using the webUI
     Then user "User One" should be listed as "Owner" in the collaborators list on the webUI
 
+  Scenario: resource owner sees resharer in collaborators list
+    Given user "user3" has been created with default attributes
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user2" has shared folder "simple-folder (2)" with user "user3"
+    When user "user1" has logged in using the webUI
+    And the user opens the share dialog for folder "simple-folder" using the webUI
+    Then user "User Two" should be listed as "Editor" in the collaborators list on the webUI
+    And user "User Three" should be listed as "Editor" reshared through "User Two" in the collaborators list on the webUI
+

--- a/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
@@ -469,7 +469,7 @@ module.exports = {
               collaboratorResult[attrName] = text.value
             })
           } else {
-            collaboratorResult[attrName] = null
+            collaboratorResult[attrName] = false
           }
         }
 

--- a/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
@@ -436,7 +436,8 @@ module.exports = {
           role: this.elements.collaboratorInformationSubRole,
           shareType: this.elements.collaboratorInformationSubShareType,
           additionalInfo: this.elements.collaboratorInformationSubAdditionalInfo,
-          viaLabel: this.elements.collaboratorInformationSubVia
+          viaLabel: this.elements.collaboratorInformationSubVia,
+          resharer: this.elements.collaboratorInformationSubResharer
         }
       }
 
@@ -572,6 +573,10 @@ module.exports = {
     collaboratorInformationSubVia: {
       // within collaboratorsInformation
       selector: '.files-collaborators-collaborator-via-label'
+    },
+    collaboratorInformationSubResharer: {
+      // within collaboratorsInformation
+      selector: '.files-collaborators-collaborator-reshare-information'
     },
     collaboratorMoreInformation: {
       // within collaboratorInformationByCollaboratorName

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -166,7 +166,7 @@ const createPublicLink = function (sharer, data) {
  * @param {string} role
  * @returns {Promise}
  */
-const assertCollaboratorslistContains = function (type, name, role, via = null, resharedThrough = null) {
+const assertCollaboratorslistContains = function (type, name, role = null, via = null, resharedThrough = null, additionalInfo = null) {
   if (type !== 'user' && type !== 'group') {
     throw new Error('illegal type')
   }
@@ -183,12 +183,17 @@ const assertCollaboratorslistContains = function (type, name, role, via = null, 
         )
       }
 
-      assert.strictEqual(role, share.role)
+      if (role !== null) {
+        assert.strictEqual(role, share.role)
+      }
       if (via !== null) {
         assert.strictEqual('Via ' + via, share.viaLabel)
       }
       if (resharedThrough !== null) {
         assert.strictEqual(resharedThrough, share.resharer)
+      }
+      if (additionalInfo !== null) {
+        assert.strictEqual(additionalInfo, share.additionalInfo)
       }
     })
 }
@@ -718,6 +723,14 @@ Then('user {string} should be listed as {string} via {string} in the collaborato
 
 Then('user {string} should be listed as {string} reshared through {string} in the collaborators list on the webUI', function (user, role, resharedThrough) {
   return assertCollaboratorslistContains('user', user, role, null, resharedThrough)
+})
+
+Then('user {string} should be listed with additional info {string} in the collaborators list on the webUI', function (user, additionalInfo) {
+  return assertCollaboratorslistContains('user', user, null, null, null, additionalInfo)
+})
+
+Then('user {string} should be listed without additional info in the collaborators list on the webUI', function (user) {
+  return assertCollaboratorslistContains('user', user, null, null, null, false)
 })
 
 Then('user {string} should be listed as {string} in the collaborators list for file/folder/resource {string} on the webUI', async function (user, role, resource) {

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -166,7 +166,7 @@ const createPublicLink = function (sharer, data) {
  * @param {string} role
  * @returns {Promise}
  */
-const assertCollaboratorslistContains = function (type, name, role, via = null) {
+const assertCollaboratorslistContains = function (type, name, role, via = null, resharedThrough = null) {
   if (type !== 'user' && type !== 'group') {
     throw new Error('illegal type')
   }
@@ -186,6 +186,9 @@ const assertCollaboratorslistContains = function (type, name, role, via = null) 
       assert.strictEqual(role, share.role)
       if (via !== null) {
         assert.strictEqual('Via ' + via, share.viaLabel)
+      }
+      if (resharedThrough !== null) {
+        assert.strictEqual(resharedThrough, share.resharer)
       }
     })
 }
@@ -711,6 +714,10 @@ Then('user {string} should be listed as {string} in the collaborators list on th
 
 Then('user {string} should be listed as {string} via {string} in the collaborators list on the webUI', function (user, role, via) {
   return assertCollaboratorslistContains('user', user, role, via)
+})
+
+Then('user {string} should be listed as {string} reshared through {string} in the collaborators list on the webUI', function (user, role, resharedThrough) {
+  return assertCollaboratorslistContains('user', user, role, null, resharedThrough)
 })
 
 Then('user {string} should be listed as {string} in the collaborators list for file/folder/resource {string} on the webUI', async function (user, role, resource) {


### PR DESCRIPTION
## Description
Add tests for the reshare indicator in the collaborators list.
Add tests for the additional user info (aka extra fields) in the collaborators list.

## Related Issue
None raised.

## Motivation and Context
These tests were missing and their absence were discovered while working on #2918 

## How Has This Been Tested?
Acceptance tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

