### PR TITLE
File actions now always appear in dropdown form

### DIFF
--- a/apps/files/src/components/FileList.vue
+++ b/apps/files/src/components/FileList.vue
@@ -16,11 +16,10 @@
         </div>
         <slot name="headerColumns"/>
         <div
-          class="uk-text-meta uk-text-right uk-width-auto "
-          :class="{ 'uk-width-small@s uk-width-medium@m' : !compactMode }"
+          class="uk-text-meta uk-text-right uk-width-small uk-margin-small-right"
           v-translate
         >
-          Actions
+          More
         </div>
       </oc-grid>
       <div id="files-list-container" class="uk-flex-1" v-if="!loading">
@@ -47,32 +46,21 @@
                 />
               </div>
               <slot name="rowColumns" :item="item" :index="item.id" />
-              <div :class="{ 'uk-visible@s' : compactMode, 'uk-width-small@s uk-width-medium@m': !compactMode }" class="uk-width-auto uk-text-right">
-                <div
-                  class="uk-button-group"
-                  :class="{
-                    'uk-visible@m' : !compactMode,
-                    'uk-visible@xl' : compactMode
-                  }"
-                >
-                  <oc-button
-                    v-for="action in actions"
-                    :key="action.ariaLabel"
-                    @click.stop="action.handler(item, action.handlerData)"
-                    :disabled="!$_isActionEnabled(item, action) || $_actionInProgress(item)"
-                    :icon="action.icon"
-                    :ariaLabel="action.ariaLabel"
-                    :uk-tooltip="$_disabledActionTooltip(item)"
-                  />
-                </div>
+              <div class="uk-width-small uk-text-right uk-margin-small-right">
                 <oc-button
                   :id="actionsDropdownButtonId(item.id, active)"
-                  icon="more_vert"
-                  :class="{ 'uk-hidden@m' : !compactMode, 'uk-visible@s uk-hidden@xl' : compactMode }"
+                  class="files-list-row-show-actions"
                   :disabled="$_actionInProgress(item)"
-                  :aria-label="'show-file-actions'"
+                  :aria-label="$gettext('Show file actions')"
                   @click.stop="toggleRowActionsDropdown(item)"
-                />
+                  variation="raw"
+                >
+                  <oc-icon
+                    name="more_vert"
+                    class="uk-text-middle"
+                    size="small"
+                  />
+                </oc-button>
               </div>
             </oc-grid>
           </div>

--- a/changelog/unreleased/2974
+++ b/changelog/unreleased/2974
@@ -1,0 +1,7 @@
+Change: File actions now always behind three dots button
+
+The inline file actions button didn't look very nice and made the UI look cluttered.
+This change hides them behind a three dots button on the line, the same that was already visible in responsive mode.
+The three dots button also now has no more border and looks nicer.
+
+https://github.com/owncloud/phoenix/pull/2974


### PR DESCRIPTION
## Description
Removed the inline file action buttons, they are now always available
under the three dots button.

## Related Issue
Fixes https://github.com/owncloud/enterprise/issues/3740

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manual test in regular and responsive mode: the three dots button still works.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] changelog