### PR TITLE
Test click authorize button directly

### DIFF
--- a/tests/acceptance/pageObjects/ownCloudAuthorizePage.js
+++ b/tests/acceptance/pageObjects/ownCloudAuthorizePage.js
@@ -12,7 +12,6 @@ module.exports = {
     {
       authorize: function () {
         return this
-          .waitForElementVisible('@authorizeButton')
           .click('@authorizeButton')
           .waitForElementNotPresent({
             selector: '@authorizeButton',


### PR DESCRIPTION
## Description
Don't wait for the element to be visible, as the click method will wait
on its own.

Hoping that this can fix the issues that sometimes clicking doesn't do
anything, maybe because the layout shifts during page load
after the element was detected.

## Related Issue
None raised.

## Motivation and Context
We've been learning more about how Nightwatch works over time, so this older code might need some rework to reduce unneeded waiting times and speed up tests.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
