### PR TITLE
Update share indicator in file row after changes in panel

### DIFF
--- a/apps/files/src/components/Collaborators/NewCollaborator.vue
+++ b/apps/files/src/components/Collaborators/NewCollaborator.vue
@@ -109,7 +109,7 @@ export default {
   },
   computed: {
     ...mapGetters('Files', [
-      'shares',
+      'currentFileOutgoingCollaborators',
       'highlightedFile'
     ]),
     ...mapGetters(['user']),
@@ -136,14 +136,7 @@ export default {
   },
 
   methods: {
-    ...mapActions('Files', [
-      'shareSetOpen',
-      'loadShares',
-      'sharesClearState',
-      'addShare',
-      'deleteShare',
-      'changeShare'
-    ]),
+    ...mapActions('Files', ['addShare']),
 
     close () {
       this.$emit('close')
@@ -182,7 +175,7 @@ export default {
               }
             )
 
-            const exists = this.shares.find(existingCollaborator => {
+            const exists = this.currentFileOutgoingCollaborators.find(existingCollaborator => {
               return (
                 collaborator.value.shareWith === existingCollaborator.name &&
                 parseInt(collaborator.value.shareType, 10) === parseInt(existingCollaborator.info.share_type, 10)

--- a/apps/files/src/components/FileLinkSidebar.vue
+++ b/apps/files/src/components/FileLinkSidebar.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="uk-position-relative" id="oc-files-file-link">
     <div v-show="visiblePanel === PANEL_SHOW" :aria-hidden="visiblePanel !== PANEL_SHOW" :key="PANEL_SHOW">
-      <oc-loader v-if="linksLoading" :aria-label="$gettext('Loading list of file links')"/>
+      <oc-loader v-if="currentFileOutgoingSharesLoading" :aria-label="$gettext('Loading list of file links')"/>
       <template v-else>
         <section v-if="$_privateLinkOfHighlightedFile">
           <div class="uk-text-bold">
@@ -114,7 +114,7 @@ export default {
     }
   },
   computed: {
-    ...mapGetters('Files', ['highlightedFile', 'links', 'linksLoading', 'linksError']),
+    ...mapGetters('Files', ['highlightedFile', 'currentFileOutgoingLinks', 'currentFileOutgoingSharesLoading']),
     ...mapGetters(['getToken', 'capabilities']),
     ...mapState('Files', [
       'sharesTree'
@@ -146,7 +146,7 @@ export default {
     },
 
     $_links () {
-      return this.links.filter(link => {
+      return this.currentFileOutgoingLinks.filter(link => {
         return this.compareIds(link.itemSource, this.highlightedFile.id)
       })
     },
@@ -184,7 +184,7 @@ export default {
       }
 
       this.visiblePanel = PANEL_SHOW
-      this.loadLinks({
+      this.loadCurrentFileOutgoingShares({
         client: this.$client,
         path: this.highlightedFile.path,
         $gettext: this.$gettext
@@ -193,7 +193,7 @@ export default {
   },
   mounted () {
     if (this.highlightedFile && this.$_links.length === 0) {
-      this.loadLinks({
+      this.loadCurrentFileOutgoingShares({
         client: this.$client,
         path: this.highlightedFile.path,
         $gettext: this.$gettext
@@ -201,7 +201,7 @@ export default {
     }
   },
   methods: {
-    ...mapActions('Files', ['loadLinks', 'purgeLinks', 'removeLink']),
+    ...mapActions('Files', ['loadCurrentFileOutgoingShares', 'removeLink']),
     $_resetData () {
       this.params = {
         id: null,
@@ -214,7 +214,7 @@ export default {
     $_removePublicLink (link) {
       this.removeLink({
         client: this.$client,
-        id: link.id
+        share: link
       })
     },
     $_editPublicLink (link) {

--- a/apps/files/src/components/FileSharingSidebar.vue
+++ b/apps/files/src/components/FileSharingSidebar.vue
@@ -106,13 +106,11 @@ export default {
   computed: {
     ...mapGetters('Files', [
       'highlightedFile',
-      'shares',
-      'sharesError',
-      'sharesLoading'
+      'currentFileOutgoingCollaborators',
+      'currentFileOutgoingSharesLoading'
     ]),
     ...mapState('Files', [
       'incomingShares',
-      'incomingSharesError',
       'incomingSharesLoading',
       'sharesTree'
     ]),
@@ -121,7 +119,7 @@ export default {
       return this.highlightedFile
     },
     $_sharesLoading () {
-      return this.sharesLoading && this.incomingSharesLoading
+      return this.currentFileOutgoingSharesLoading && this.incomingSharesLoading
     },
 
     $_noCollaborators () {
@@ -218,7 +216,7 @@ export default {
 
     $_directOutgoingShares () {
       // direct outgoing shares
-      return this.shares
+      return this.currentFileOutgoingCollaborators
         .filter(this.$_isCollaboratorShare.bind(this))
         .sort(this.$_collaboratorsComparator.bind(this))
         .map(collaborator => {
@@ -277,7 +275,7 @@ export default {
   },
   methods: {
     ...mapActions('Files', [
-      'loadShares',
+      'loadCurrentFileOutgoingShares',
       'sharesClearState',
       'deleteShare',
       'loadIncomingShares',
@@ -324,13 +322,15 @@ export default {
       return collaborator.info.share_type === '1'
     },
     $_reloadShares () {
-      this.loadShares({
+      this.loadCurrentFileOutgoingShares({
         client: this.$client,
-        path: this.highlightedFile.path
+        path: this.highlightedFile.path,
+        $gettext: this.$gettext
       })
       this.loadIncomingShares({
         client: this.$client,
-        path: this.highlightedFile.path
+        path: this.highlightedFile.path,
+        $gettext: this.$gettext
       })
     },
     $_clearShares () {

--- a/apps/files/src/store/getters.js
+++ b/apps/files/src/store/getters.js
@@ -1,4 +1,5 @@
 import { fileSortFunctions } from '../fileSortFunctions.js'
+import { shareTypes } from '../helpers/shareTypes'
 
 export default {
   inProgress: state => {
@@ -55,14 +56,19 @@ export default {
   dropzone: state => {
     return state.dropzone
   },
-  shares: state => {
-    return state.shares
+  currentFileOutgoingCollaborators: state => {
+    const userShareTypes = [shareTypes.user, shareTypes.group, shareTypes.guest, shareTypes.remote]
+    return state.currentFileOutgoingShares.filter(share => {
+      return userShareTypes.includes(parseInt(share.shareType, 10))
+    })
   },
-  sharesError: state => {
-    return state.sharesError
+  currentFileOutgoingLinks: state => {
+    return state.currentFileOutgoingShares.filter(share => {
+      return parseInt(share.shareType, 10) === shareTypes.link
+    })
   },
-  sharesLoading: state => {
-    return state.sharesLoading
+  currentFileOutgoingSharesLoading: state => {
+    return state.currentFileOutgoingSharesLoading
   },
   sharesTree: state => state.sharesTree,
   sharesTreeLoading: state => state.sharesTreeLoading,
@@ -89,15 +95,6 @@ export default {
   },
   publicLinkPassword: state => {
     return state.publicLinkPassword
-  },
-  links: state => {
-    return state.links
-  },
-  linksError: state => {
-    return state.linksError
-  },
-  linksLoading: state => {
-    return state.linksLoading
   },
   uploaded: state => state.uploaded,
   renameDialogOpen: state => state.renameDialogOpen,

--- a/apps/files/src/store/mutations.js
+++ b/apps/files/src/store/mutations.js
@@ -1,6 +1,18 @@
 import Vue from 'vue'
 import _ from 'lodash'
 
+/**
+ * @param {Array.<Object>} shares array of shares
+ * @return {Array.<Integer>} array of share types
+ */
+function computeShareTypes (shares) {
+  const shareTypes = new Set()
+  shares.forEach(share => {
+    shareTypes.add(share.shareType)
+  })
+  return Array.from(shareTypes)
+}
+
 export default {
   UPDATE_FILE_PROGRESS (state, file) {
     const fileIndex = state.inProgress.findIndex((f) => {
@@ -80,6 +92,15 @@ export default {
   SET_SEARCH_TERM (state, searchTerm) {
     state.searchTermGlobal = searchTerm
   },
+  UPDATE_CURRENT_FILE_SHARE_TYPES (state) {
+    if (!state.highlightedFile) {
+      return
+    }
+    const fileIndex = state.files.findIndex((f) => {
+      return f.id === state.highlightedFile.id
+    })
+    state.files[fileIndex].shareTypes = computeShareTypes(state.currentFileOutgoingShares)
+  },
   RENAME_FILE (state, { file, newValue, newPath }) {
     const fileIndex = state.files.findIndex((f) => {
       return f.id === file.id
@@ -103,32 +124,32 @@ export default {
   DRAG_OVER (state, value) {
     state.dropzone = value
   },
-  SHARES_LOAD (state, shares) {
-    state.shares = shares
+  CURRENT_FILE_OUTGOING_SHARES_SET (state, shares) {
+    state.currentFileOutgoingShares = shares
   },
-  SHARES_ADD_SHARE (state, share) {
-    state.shares.push(share)
+  CURRENT_FILE_OUTGOING_SHARES_ADD (state, share) {
+    state.currentFileOutgoingShares.push(share)
   },
-  SHARES_REMOVE_SHARE (state, share) {
-    state.shares = state.shares.filter(i => ![share].includes(i))
+  CURRENT_FILE_OUTGOING_SHARES_REMOVE (state, share) {
+    state.currentFileOutgoingShares = state.currentFileOutgoingShares.filter(s => share.id !== s.id)
   },
-  SHARES_UPDATE_SHARE (state, share) {
-    const fileIndex = state.shares.findIndex((s) => {
+  CURRENT_FILE_OUTGOING_SHARES_UPDATE (state, share) {
+    const fileIndex = state.currentFileOutgoingShares.findIndex((s) => {
       return s.info.id === share.info.id
     })
     if (fileIndex >= 0) {
-      Vue.set(state.shares, fileIndex, share)
+      Vue.set(state.currentFileOutgoingShares, fileIndex, share)
     } else {
       // share was not present in the list while updating, add it instead
-      state.shares.push(share)
+      state.currentFileOutgoingShares.push(share)
     }
   },
-  SHARES_ERROR (state, error) {
-    state.shares = []
-    state.sharesError = error
+  CURRENT_FILE_OUTGOING_SHARES_ERROR (state, error) {
+    state.currentFileOutgoingShares = []
+    state.currentFileOutgoingSharesError = error
   },
-  SHARES_LOADING (state, loading) {
-    state.sharesLoading = loading
+  CURRENT_FILE_OUTGOING_SHARES_LOADING (state, loading) {
+    state.currentFileOutgoingSharesLoading = loading
   },
   INCOMING_SHARES_LOAD (state, shares) {
     state.incomingShares = shares
@@ -139,9 +160,6 @@ export default {
   },
   INCOMING_SHARES_LOADING (state, loading) {
     state.incomingSharesLoading = loading
-  },
-  SHARESTREE_CLEAR (state) {
-    state.sharesTree = {}
   },
   SHARESTREE_PRUNE_OUTSIDE_PATH (state, pathToKeep) {
     if (pathToKeep !== '' && pathToKeep !== '/') {
@@ -227,30 +245,6 @@ export default {
   },
   SET_PUBLIC_LINK_PASSWORD (state, password) {
     state.publicLinkPassword = password
-  },
-  LINKS_PURGE (state) {
-    state.links = []
-  },
-  LINKS_LOADING (state, loading) {
-    state.linksLoading = loading
-  },
-  LINKS_ERROR (state, error) {
-    state.linksError = error
-  },
-  LINKS_ADD (state, link) {
-    state.links.push(link)
-  },
-  LINKS_REMOVE (state, linkId) {
-    state.links = state.links.filter(link => link.id !== linkId)
-  },
-  LINKS_UPDATE (state, linkUpdated) {
-    state.links = state.links.map(link => {
-      if (link.id === linkUpdated.id) {
-        return linkUpdated
-      }
-
-      return link
-    })
   },
 
   ADD_ACTION_TO_PROGRESS (state, item) {

--- a/apps/files/src/store/state.js
+++ b/apps/files/src/store/state.js
@@ -24,11 +24,11 @@ export default {
   shareOpen: null,
 
   /**
-   * Outgoing shares from currently highlighted element
+   * Outgoing shares and links from currently highlighted element
    */
-  shares: [],
-  sharesError: null,
-  sharesLoading: false,
+  currentFileOutgoingShares: [],
+  currentFileOutgoingSharesError: null,
+  currentFileOutgoingSharesLoading: false,
 
   /**
    * Incoming shares from currently highlighted element
@@ -36,13 +36,6 @@ export default {
   incomingShares: [],
   incomingSharesError: null,
   incomingSharesLoading: false,
-
-  /**
-   * Link shares from currently highlighted element
-   */
-  links: [],
-  linksError: null,
-  linksLoading: false,
 
   /**
    * Shares from parent folders

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -296,6 +296,16 @@ Feature: Federation Sharing - sharing with users on other cloud storages
       | fileName      | expectedIndicators |
       | sub-folder    | user-indirect      |
 
+  @issue-2939
+  Scenario: sharing indicator for federated shares stays up to date
+    When the user shares folder "simple-folder" with remote user "user1" as "Editor" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName      | expectedIndicators |
+      | simple-folder | user-direct        |
+    When the user deletes "user1" as remote collaborator for the current file using the webUI
+    Then the following resources should not have share indicators on the webUI
+      | simple-folder |
+
   @skip @yetToImplement @issue-2897
   Scenario: sharing details inside folder shared using federated sharing
     Given user "user1" has created folder "/simple-folder/sub-folder"

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -275,6 +275,47 @@ Feature: Sharing files and folders with internal groups
       | fileName      | expectedIndicators |
       | sub-folder    | user-indirect      |
 
+  @issue-2939
+  Scenario: sharing indicator for group shares stays up to date
+    Given these groups have been created:
+      | groupname |
+      | grp2      |
+      | grp3      |
+      | grp4      |
+    When user "user1" has logged in using the webUI
+    Then the following resources should not have share indicators on the webUI
+      | simple-folder |
+    When the user shares folder "simple-folder" with group "grp2" as "Viewer" using the webUI
+    And the user shares folder "simple-folder" with group "grp3" as "Viewer" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName      | expectedIndicators |
+      | simple-folder | user-direct        |
+    When the user opens folder "simple-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName      | expectedIndicators |
+      | testimage.png | user-indirect      |
+    When the user shares file "testimage.png" with group "grp4" as "Viewer" using the webUI
+    # the indicator changes from user-indirect to user-direct to show the direct share
+    Then the following resources should have share indicators on the webUI
+      | fileName      | expectedIndicators |
+      | testimage.png | user-direct        |
+    # removing the last collaborator reverts the indicator to user-indirect
+    When the user deletes "grp4" as collaborator for the current file using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName      | expectedIndicators |
+      | testimage.png | user-indirect      |
+    When the user opens folder "" directly on the webUI
+    And the user opens the share dialog for folder "simple-folder" using the webUI
+    And the user deletes "grp3" as collaborator for the current file using the webUI
+    # because there is still another share left, the indicator stays
+    Then the following resources should have share indicators on the webUI
+      | fileName      | expectedIndicators |
+      | simple-folder | user-direct        |
+    # deleting the last collaborator removes the indicator
+    When the user deletes "grp2" as collaborator for the current file using the webUI
+    Then the following resources should not have share indicators on the webUI
+      | simple-folder |
+
   @skip @yetToImplement @issue-2897
   Scenario: sharing details of items inside a shared folder shared with user and group
     Given user "user3" has created folder "/simple-folder/sub-folder"

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -422,6 +422,44 @@ Feature: Sharing files and folders with internal users
       | fileName      | expectedIndicators |
       | sub-folder    | user-indirect      |
 
+  @issue-2939
+  Scenario: sharing indicator for user shares stays up to date
+    Given user "user3" has been created with default attributes
+    And user "user4" has been created with default attributes
+    When user "user1" has logged in using the webUI
+    Then the following resources should not have share indicators on the webUI
+      | simple-folder |
+    When the user shares folder "simple-folder" with user "User Two" as "Viewer" using the webUI
+    And the user shares folder "simple-folder" with user "User Three" as "Viewer" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName      | expectedIndicators |
+      | simple-folder | user-direct        |
+    When the user opens folder "simple-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName      | expectedIndicators |
+      | testimage.png | user-indirect      |
+    When the user shares file "testimage.png" with user "User Four" as "Viewer" using the webUI
+    # the indicator changes from user-indirect to user-direct to show the direct share
+    Then the following resources should have share indicators on the webUI
+      | fileName      | expectedIndicators |
+      | testimage.png | user-direct        |
+    # removing the last collaborator reverts the indicator to user-indirect
+    When the user deletes "User Four" as collaborator for the current file using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName      | expectedIndicators |
+      | testimage.png | user-indirect      |
+    When the user opens folder "" directly on the webUI
+    And the user opens the share dialog for folder "simple-folder" using the webUI
+    And the user deletes "User Three" as collaborator for the current file using the webUI
+    # because there is still another share left, the indicator stays
+    Then the following resources should have share indicators on the webUI
+      | fileName      | expectedIndicators |
+      | simple-folder | user-direct        |
+    # deleting the last collaborator removes the indicator
+    When the user deletes "User Two" as collaborator for the current file using the webUI
+    Then the following resources should not have share indicators on the webUI
+      | simple-folder |
+
   @issue-2897
   Scenario: sharing details of items inside a shared folder
     Given user "user3" has been created with default attributes

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -728,7 +728,7 @@ Feature: Share by public link
   Scenario: user removes the public link of a file using webUI
     Given user "user1" has logged in using the webUI
     And user "user1" has shared file "lorem.txt" with link with "read" permissions
-    When the user "user1" removes the public link named "{}" of file "lorem.txt" using the webUI
+    When the user removes the public link named "{}" of file "lorem.txt" using the webUI
     Then user "user1" should not have any public link
 
   @skip @yetToImplement
@@ -749,7 +749,7 @@ Feature: Share by public link
       | path       | lorem.txt        |
       | name       | third-name       |
     And user "user1" has logged in using the webUI
-    When the user "user1" removes the public link named "first-name" of file "lorem.txt" using the webUI
+    When the user removes the public link named "first-name" of file "lorem.txt" using the webUI
     Then public link named "first-name" should not be listed on the public links list on the webUI
     And a link named "second-name" should be listed with role "Viewer" in the public link list of file "lorem.txt" on the webUI
     And a link named "third-name" should be listed with role "Viewer" in the public link list of folder "lorem.txt" on the webUI
@@ -765,7 +765,7 @@ Feature: Share by public link
       | path       | lorem.txt        |
       | name       | third-name       |
     And user "user1" has logged in using the webUI
-    When the user "user1" removes the public link named "second-name" of file "lorem.txt" using the webUI
+    When the user removes the public link named "second-name" of file "lorem.txt" using the webUI
     Then public link named "second-name" should not be listed on the public links list on the webUI
     And a link named "first-name" should be listed with role "Viewer" in the public link list of file "lorem.txt" on the webUI
     And a link named "third-name" should be listed with role "Viewer" in the public link list of folder "lorem.txt" on the webUI
@@ -781,7 +781,7 @@ Feature: Share by public link
       | path       | lorem.txt        |
       | name       | third-name       |
     And user "user1" has logged in using the webUI
-    When the user "user1" removes the public link named "third-name" of file "lorem.txt" using the webUI
+    When the user removes the public link named "third-name" of file "lorem.txt" using the webUI
     Then public link named "third-name" should not be listed on the public links list on the webUI
     And a link named "first-name" should be listed with role "Viewer" in the public link list of file "lorem.txt" on the webUI
     And a link named "second-name" should be listed with role "Viewer" in the public link list of folder "lorem.txt" on the webUI
@@ -934,6 +934,50 @@ Feature: Share by public link
     When the public uses the webUI to access the last public link created by user "user2"
     Then the following resources should not have share indicators on the webUI
       | simple-empty-folder |
+
+  @issue-2939
+  Scenario: sharing indicator for link shares stays up to date
+    Given user "user2" has been created with default attributes
+    When user "user1" has logged in using the webUI
+    Then the following resources should not have share indicators on the webUI
+      | simple-folder |
+    When the user shares folder "simple-folder" with user "User Two" as "Viewer" using the webUI
+    And the user creates a new public link for resource "simple-folder" using the webUI with
+      | field | value  |
+      | name  | first |
+    And the user creates a new public link for resource "simple-folder" using the webUI with
+      | field | value  |
+      | name  | second |
+    Then the following resources should have share indicators on the webUI
+      | fileName      | expectedIndicators      |
+      | simple-folder | user-direct,link-direct |
+    When the user opens folder "simple-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName      | expectedIndicators          |
+      | testimage.png | user-indirect,link-indirect |
+    When the user creates a new public link for resource "testimage.png" using the webUI with
+      | field | value  |
+      | name  | third |
+    # the indicator changes from link-indirect to link-direct to show the direct share
+    Then the following resources should have share indicators on the webUI
+      | fileName      | expectedIndicators        |
+      | testimage.png | user-indirect,link-direct |
+    # removing the last link reverts the indicator to user-indirect
+    When the user removes the public link named "third" of resource "testimage.png" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName      | expectedIndicators          |
+      | testimage.png | user-indirect,link-indirect |
+    When the user opens folder "" directly on the webUI
+    And the user removes the public link named "second" of resource "simple-folder" using the webUI
+    # because there is still another link share left, the indicator stays
+    Then the following resources should have share indicators on the webUI
+      | fileName      | expectedIndicators      |
+      | simple-folder | user-direct,link-direct |
+    # deleting the last collaborator removes the indicator
+    When the user removes the public link named "first" of resource "simple-folder" using the webUI
+    Then the following resources should have share indicators on the webUI
+      | fileName      | expectedIndicators |
+      | simple-folder | user-direct        |
 
   @issue-2897
   Scenario: sharing details of indirect items inside a shared folder

--- a/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
@@ -171,12 +171,14 @@ module.exports = {
     },
     confirmShare: function () {
       return this.waitForElementPresent('@addShareSaveButton')
+        .initAjaxCounters()
         .click('@addShareSaveButton')
+        .waitForOutstandingAjaxCalls()
         .waitForElementNotPresent('@addShareSaveButton')
-        .waitForAjaxCallsToStartAndFinish()
     },
     saveCollaboratorPermission: function () {
       return this.waitForElementVisible('@saveShareButton')
+        .initAjaxCounters()
         .click('@saveShareButton')
         .waitForOutstandingAjaxCalls()
         .waitForElementNotPresent('@saveShareButton')
@@ -186,9 +188,11 @@ module.exports = {
      */
     clickCreateShare: function () {
       return this
+        .initAjaxCounters()
         .useXpath()
         .waitForElementVisible('@createShareButton')
         .click('@createShareButton')
+        .waitForOutstandingAjaxCalls()
         .waitForElementVisible('@createShareDialog')
         .waitForAnimationToFinish()
     },

--- a/tests/acceptance/stepDefinitions/publicLinkContext.js
+++ b/tests/acceptance/stepDefinitions/publicLinkContext.js
@@ -139,8 +139,8 @@ When('the user tries to edit expiration of the public link named {string} of fil
     )
   })
 
-When('the user {string} removes the public link named {string} of file/folder/resource {string} using the webUI',
-  async function (sharer, linkName, resource) {
+When('the user removes the public link named {string} of file/folder/resource {string} using the webUI',
+  async function (linkName, resource) {
     await client.page
       .FilesPageElement
       .filesList()

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -694,6 +694,11 @@ When('the user deletes {string} as collaborator for the current file/folder usin
   return client.page.FilesPageElement.sharingDialog().deleteShareWithUserGroup(user)
 })
 
+When('the user deletes {string} as remote collaborator for the current file/folder using the webUI', function (user) {
+  user = util.format('%s@%s', user, client.globals.remote_backend_url)
+  return client.page.FilesPageElement.sharingDialog().deleteShareWithUserGroup(user)
+})
+
 When(
   'the user changes the collaborator role of {string} for file/folder {string} to {string} using the webUI',
   async function (collaborator, resource, newRole) {


### PR DESCRIPTION
## Description
After making changes to shares or links in the share panel, the share indicators in the file list are now automatically updating.

Shares and links data structure used to be separated but they really come from the same API calls. In this PR we have merged the data structures together into a single state array, but kept the accessors to deliver filtered results to be able to split between user/group/remote shares and link shares.

## Related Issue
Fixes https://github.com/owncloud/phoenix/issues/2939

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- acceptance tests to confirm that the refactoring didn't break anything
- acceptance test for the indicator update ?
- manual test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] changelog
- [ ] merging shares and links into a single data structure
- [ ] recomputing share types in the highlighted file state
- [ ] add acceptance tests
