### PR TITLE
Collaborator panel tweaks

### DIFF
--- a/apps/files/src/components/Collaborators/Collaborator.vue
+++ b/apps/files/src/components/Collaborators/Collaborator.vue
@@ -1,7 +1,7 @@
 <template>
   <oc-table middle class="files-collaborators-collaborator">
     <oc-table-row v-if="$_reshareInformation" class="files-collaborators-collaborator-table-row-top">
-      <oc-table-cell shrink colspan="2"></oc-table-cell>
+      <oc-table-cell shrink :colspan="firstColumn ? 2 : 1"></oc-table-cell>
       <oc-table-cell colspan="2">
         <div class="uk-text-meta uk-flex uk-flex-middle">
           <oc-icon name="repeat" class="uk-preserve-width" />
@@ -10,7 +10,7 @@
       </oc-table-cell>
     </oc-table-row>
     <oc-table-row class="files-collaborators-collaborator-table-row-info">
-      <oc-table-cell shrink>
+      <oc-table-cell shrink v-if="firstColumn">
         <oc-button v-if="$_deleteButtonVisible" :ariaLabel="$gettext('Delete share')" @click="$_removeShare" variation="raw" class="files-collaborators-collaborator-delete">
           <oc-icon name="close" />
         </oc-button>
@@ -43,7 +43,7 @@
       </oc-table-cell>
     </oc-table-row>
     <oc-table-row v-if="$_viaLabel" class="files-collaborators-collaborator-table-row-bottom">
-      <oc-table-cell shrink colspan="2"></oc-table-cell>
+      <oc-table-cell shrink :colspan="firstColumn ? 2 : 1"></oc-table-cell>
       <oc-table-cell colspan="2">
         <div class="uk-text-meta">
           <router-link :to="$_viaRouterParams" :aria-label="$gettext('Navigate to parent')"
@@ -76,6 +76,10 @@ export default {
     modifiable: {
       type: Boolean,
       default: false
+    },
+    firstColumn: {
+      type: Boolean,
+      default: true
     }
   },
   data: function () {

--- a/apps/files/src/components/Collaborators/CollaboratorsEditOptions.vue
+++ b/apps/files/src/components/Collaborators/CollaboratorsEditOptions.vue
@@ -6,17 +6,14 @@
       :selectedRole="role"
       @roleSelected="selectRole"
     />
-    <div v-if="$_ocCollaborators_currentRoleDescription" class="uk-text-muted" v-text="$_ocCollaborators_currentRoleDescription"></div>
-    <hr v-if="$_ocCollaborators_hasAdditionalPermissions" class="divider" />
     <label class="oc-label" v-if="$_ocCollaborators_hasAdditionalPermissions">
-      <translate>Additional permissions</translate>
+      <translate>Additional permissions:</translate>
     </label>
     <additional-permissions
       :availablePermissions="role.additionalPermissions"
       :collaboratorsPermissions="collaboratorsPermissions"
       @permissionChecked="checkAdditionalPermissions"
     />
-    <hr v-if="$_ocCollaborators_expirationSupported" class="divider" />
     <oc-grid v-if="$_ocCollaborators_expirationSupported" gutter="small">
       <div class="uk-width-1-1">
           <label class="oc-label" for="files-collaborators-new-collaborator-expiration">
@@ -67,13 +64,6 @@ export default {
   computed: {
     $_ocCollaborators_expirationSupported () {
       return false
-    },
-
-    $_ocCollaborators_currentRoleDescription () {
-      if (this.selectedRole && this.selectedRole.name !== 'advancedRole') {
-        return this.selectedRole.description
-      }
-      return ''
     },
 
     $_ocCollaborators_hasAdditionalPermissions () {

--- a/apps/files/src/components/Collaborators/EditCollaborator.vue
+++ b/apps/files/src/components/Collaborators/EditCollaborator.vue
@@ -1,10 +1,7 @@
 <template>
   <div class="files-collaborators-collaborator-edit-dialog">
     <div v-if="user.id !== collaborator.info.uid_owner" class="uk-text-meta uk-flex uk-flex-middle uk-margin-small-bottom"><oc-icon name="repeat" class="uk-margin-small-right" /> {{ collaborator.info.displayname_owner }}</div>
-    <div class="uk-flex uk-flex-wrap uk-flex-middle">
-      <collaborator class="uk-width-expand" :collaborator="collaborator" />
-    </div>
-    <hr class="divider" />
+    <collaborator class="uk-width-expand" :collaborator="collaborator" :first-column="false" />
     <collaborators-edit-options
       :existingRole="$_originalRole"
       :collaboratorsPermissions="$_originalPermissions"
@@ -14,14 +11,16 @@
     <hr class="divider" />
     <oc-grid gutter="small" class="uk-margin-bottom">
       <div>
-        <oc-button class="files-collaborators-collaborator-cancel" :disabled="saving" @click="$_ocCollaborators_cancelChanges">
+        <oc-button :disabled="saving" @click="$_ocCollaborators_cancelChanges" class="files-collaborators-collaborator-cancel" key="edit-collaborator-cancel-button">
           <translate>Cancel</translate>
         </oc-button>
-        <oc-button v-if="saving" :disabled="true">
+        <oc-button :disabled="true" key="edit-collaborator-saving-button" v-if="saving">
           <oc-spinner :aria-label="$gettext('Saving Share')" class="uk-position-small uk-position-center-left" size="xsmall"/>
           <span :aria-hidden="true" class="uk-margin-small-left" v-translate>Saving Share</span>
         </oc-button>
-        <oc-button v-else variation="primary" :disabled="!$_hasChanges" :aria-label="$gettext('Save Share')" @click="$_ocCollaborators_saveChanges">
+        <oc-button :aria-label="$gettext('Save Share')" :disabled="!$_hasChanges" @click="$_ocCollaborators_saveChanges" id="files-collaborators-collaborator-save-share-button"
+                   key="edit-collaborator-saving-button" v-else
+                   variation="primary">
           <translate>Save Share</translate>
         </oc-button>
       </div>

--- a/apps/files/src/components/FilesLists/StatusIndicators/DefaultIndicators.vue
+++ b/apps/files/src/components/FilesLists/StatusIndicators/DefaultIndicators.vue
@@ -22,10 +22,8 @@
 <script>
 import intersection from 'lodash/intersection'
 import { mapGetters } from 'vuex'
-import { shareTypes } from '../../../helpers/shareTypes'
+import { shareTypes, userShareTypes } from '../../../helpers/shareTypes'
 import { getParentPaths } from '../../../helpers/path'
-
-const userShareTypes = [shareTypes.user, shareTypes.group, shareTypes.guest, shareTypes.remote]
 
 export default {
   name: 'StatusIndicators',

--- a/apps/files/src/components/PublicLinksSidebar/EditPublicLink.vue
+++ b/apps/files/src/components/PublicLinksSidebar/EditPublicLink.vue
@@ -9,17 +9,16 @@
         </div>
       </transition>
       <div class="uk-margin">
-        <label class="oc-label"><span v-translate>Name</span>:</label>
+        <label class="oc-label"><span v-translate>Name:</span></label>
         <input class="uk-input" id="oc-files-file-link-name" v-model="name"/>
       </div>
       <oc-grid childWidth="1-1" gutter="small">
         <roles-select :roles="$_roles" :selectedRole="$_selectedRole" @roleSelected="$_selectRole" mode="file-link"/>
-        <div class="uk-text-muted" v-if="$_selectedRole_description" v-text="$_selectedRole_description"></div>
       </oc-grid>
       <div class="uk-margin uk-grid-small uk-flex uk-flex-middle" uk-grid>
         <div class="uk-width-1-1 uk-width-2-5@m" v-if="$_expirationDate">
           <label class="oc-label" for="oc-files-file-link-expire-date">
-            <span v-translate>Expiration date</span>:<em class="uk-margin-small-left" v-if="$_expirationDate.enforced">(<span v-translate>required</span>)</em>
+            <span v-translate>Expiration date:</span><em class="uk-margin-small-left" v-if="$_expirationDate.enforced">(<span v-translate>required</span>)</em>
           </label>
           <div class="uk-position-relative">
             <oc-datepicker :class="{ 'uk-form-danger': !$_expirationIsValid }" :date="expireDate" :key="'oc-datepicker-' + expireDate"
@@ -31,7 +30,7 @@
         </div>
         <div class="uk-width-1-1 uk-width-3-5@m">
           <label class="oc-label" for="oc-files-file-link-password">
-            <span v-translate>Password</span>:<em class="uk-margin-small-left" v-if="$_passwordEnforced">(<span v-translate>required</span>)</em>
+            <span v-translate>Password:</span><em class="uk-margin-small-left" v-if="$_passwordEnforced">(<span v-translate>required</span>)</em>
           </label>
           <div class="uk-position-relative">
             <input :class="{ 'uk-form-danger': !$_passwordIsValid }" :placeholder="hasPassword && password === null? '********' : placeholder.password"
@@ -167,10 +166,6 @@ export default {
         }
       }
       return this.$_roles.viewer
-    },
-
-    $_selectedRole_description () {
-      return this.$_selectedRole ? this.$_selectedRole.description : ''
     },
 
     $_expirationDate () {

--- a/apps/files/src/components/Roles/RoleItem.vue
+++ b/apps/files/src/components/Roles/RoleItem.vue
@@ -1,0 +1,25 @@
+<template>
+  <div class="roles-select-role-item">
+    <span class="uk-text-bold" v-text="role.label" />
+    <p class="uk-text-meta uk-margin-remove" v-text="role.description" />
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'RoleItem',
+  props: {
+    role: {
+      type: Object,
+      required: true
+    }
+  }
+}
+</script>
+
+<style>
+  /* FIXME: move into ODS? */
+  .roles-select-role-item {
+    text-transform: none;
+  }
+</style>

--- a/apps/files/src/components/Roles/RolesSelect.vue
+++ b/apps/files/src/components/Roles/RolesSelect.vue
@@ -1,13 +1,14 @@
 <template>
   <div>
     <label class="oc-label">
-      <translate>Role</translate>:
+      <translate>Role:</translate>
     </label>
     <oc-button
       :id="`files-${mode}-role-button`"
       :class="`uk-width-1-1 files-${mode}-role-button`"
-      v-text="selectedRole.label"
-    />
+    >
+      <role-item :role="selectedRole" class="uk-margin-small-bottom" />
+    </oc-button>
     <oc-drop
       closeOnClick
       :dropId="`files-${mode}-roles-dropdown`"
@@ -26,11 +27,7 @@
           :class="{ 'oc-autocomplete-suggestion-selected': role.name === selectedRole.name }"
           @click="selectRole(role)"
         >
-          <span class="uk-text-bold" v-text="role.label" />
-          <p
-            class="uk-text-meta uk-margin-remove"
-            v-text="role.description"
-          />
+          <role-item :role="role" />
         </li>
       </ul>
     </oc-drop>
@@ -38,8 +35,10 @@
 </template>
 
 <script>
+const RoleItem = () => import('./RoleItem.vue')
 export default {
   name: 'RolesSelect',
+  components: { RoleItem },
   props: {
     mode: {
       type: String,

--- a/apps/files/src/helpers/shareTypes.js
+++ b/apps/files/src/helpers/shareTypes.js
@@ -9,3 +9,5 @@ export const shareTypes = {
   guest: 4,
   remote: 6
 }
+
+export const userShareTypes = [shareTypes.user, shareTypes.group, shareTypes.guest, shareTypes.remote]

--- a/apps/files/src/store/getters.js
+++ b/apps/files/src/store/getters.js
@@ -1,5 +1,5 @@
 import { fileSortFunctions } from '../fileSortFunctions.js'
-import { shareTypes } from '../helpers/shareTypes'
+import { shareTypes, userShareTypes } from '../helpers/shareTypes'
 
 export default {
   inProgress: state => {
@@ -57,14 +57,13 @@ export default {
     return state.dropzone
   },
   currentFileOutgoingCollaborators: state => {
-    const userShareTypes = [shareTypes.user, shareTypes.group, shareTypes.guest, shareTypes.remote]
     return state.currentFileOutgoingShares.filter(share => {
-      return userShareTypes.includes(parseInt(share.shareType, 10))
+      return userShareTypes.includes(share.shareType)
     })
   },
   currentFileOutgoingLinks: state => {
     return state.currentFileOutgoingShares.filter(share => {
-      return parseInt(share.shareType, 10) === shareTypes.link
+      return share.shareType === shareTypes.link
     })
   },
   currentFileOutgoingSharesLoading: state => {

--- a/changelog/unreleased/1186-1
+++ b/changelog/unreleased/1186-1
@@ -1,0 +1,10 @@
+Change: Improve UI/UX of collaborator forms
+
+Applied several UI/UX improvements to the collaborator forms (adding and editing).
+- Showing avatars for selected collaborators on a new share and fixed styling/layouting of said collaborators in the list.
+- Added sensible margins on text about missing permissions for re-sharing in the sharing sidebar.
+- Fixed alignment of displayed collaborator in editing view for collaborators.
+- Removed separators from the forms that were cluttering the view.
+- Moved role description on role selection (links and collaborators) into the form element. Not shown below the form element anymore.
+
+https://github.com/owncloud/phoenix/issues/1186

--- a/changelog/unreleased/1186-2
+++ b/changelog/unreleased/1186-2
@@ -1,0 +1,7 @@
+Bugfix: Fix collaborator selection on new collaborator shares
+
+When typing text into the search box for new collaborators, selecting a user and a group with identical names was not possible.
+This was due to the fact that when one (group or user) got selected, the other was excluded because of a matching name. Fixed by
+including the share type (group or user) in matching.
+
+https://github.com/owncloud/phoenix/issues/1186

--- a/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
@@ -616,8 +616,7 @@ module.exports = {
       selector: '#files-collaborators-collaborator-save-new-share-button'
     },
     saveShareButton: {
-      selector: '//button[@aria-label="Save Share"]',
-      locateStrategy: 'xpath'
+      selector: '#files-collaborators-collaborator-save-share-button'
     },
     newCollaboratorSelectRoleButton: {
       selector: '#files-collaborators-role-button'
@@ -632,10 +631,10 @@ module.exports = {
       selector: '#files-collaborators-role-editor'
     },
     newCollaboratorItems: {
-      selector: "//div[@id='oc-files-sharing-sidebar']//span[contains(@class, 'oc-icon-danger')]/ancestor::div[position()=1 and contains(., '%s')]"
+      selector: "//div[@id='oc-files-sharing-sidebar']//table[contains(@class, 'files-collaborators-collaborator-autocomplete-item')]//div[contains(., '%s')]/ancestor::tr[position()=1]"
     },
     newCollaboratorRemoveButton: {
-      selector: "//span[contains(@class, 'oc-icon-danger')]"
+      selector: "//button[contains(@class, 'files-collaborators-collaborator-autocomplete-item-remove')]"
     },
     newCollaboratorRoleAdvancedPermissions: {
       selector: '#files-collaborators-role-advancedRole'

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -811,7 +811,7 @@ Then('the user should not be able to share file/folder/resource {string} using t
     .openSharingDialog(resource)
   const shareResponse = await client.page.FilesPageElement.sharingDialog()
     .getSharingPermissionMsg()
-  const noSharePermissionsMsgFormat = "You don't have permission to share this %s"
+  const noSharePermissionsMsgFormat = "You don't have permission to share this %s."
   const noSharePermissionsFileMsg = util.format(noSharePermissionsMsgFormat, 'file')
   const noSharePermissionsFolderMsg = util.format(noSharePermissionsMsgFormat, 'folder')
   return assert.ok(


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
This fixes the remaining UI/UX issues from the linked issue.
- Showing avatars for selected collaborators on a new share and fixed styling/layouting of said collaborators in the list.
- Added sensible margins on text about missing permissions for re-sharing in the sharing sidebar.
- Fixed alignment of displayed collaborator in editing view for collaborators.
- Removed separators from the forms that were cluttering the view.
- Moved role description on role selection (links and collaborators) into the form element. Not shown below the form element anymore.
- Fixed margins on spacers between sections in both sidebar panels.
- Removed animations for the initial loading of a links or shares list. Only the changes (adding or removing a share/link) have a transition now.
- Introduced sorting by name for public links
- Cleaned up code in the `FileLinkSidebar` (e.g. removed unnecessary filtering)

And one bugfix as well:
When typing text into the search box for new collaborators, selecting a user and a group with identical names was not possible.
This was due to the fact that when one (group or user) got selected, the other was excluded because of a matching name. Fixed by
including the share type (group or user) in matching.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/phoenix/issues/1186

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally with Chrome and Firefox
- [ ] drone acceptance tests

## Screenshots (if appropriate):
![Bildschirmfoto 2020-02-08 um 11 30 47](https://user-images.githubusercontent.com/3532843/74084653-64bba380-4a71-11ea-9362-2c61a75ae4e4.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 