### PR TITLE
Use `$ngettext` for pluralization in i18n

### DIFF
--- a/apps/files/src/components/FilesAppBar.vue
+++ b/apps/files/src/components/FilesAppBar.vue
@@ -525,14 +525,18 @@ export default {
     },
 
     $_ocTrashbin_deleteSelected () {
-      const translated = this.$gettext('%{numberOfFiles} items will be deleted immediately. You can’t undo this action.')
-      this.setTrashbinDeleteMessage(this.$gettextInterpolate(translated, { numberOfFiles: this.selectedFiles.length }, true))
+      const translated = this.$ngettext(
+        "%{numberOfFiles} item will be deleted immediately. You can't undo this action.",
+        "%{numberOfFiles} items will be deleted immediately. You can't undo this action.",
+        this.selectedFiles.length
+      )
+      this.setTrashbinDeleteMessage(this.$gettextInterpolate(translated, { numberOfFiles: this.selectedFiles.length }, false))
     },
 
     $_ocFiles_deleteSelected () {
-      const translated = this.$gettext('%{numberOfFiles} items will be deleted.')
+      const translated = this.$ngettext('%{numberOfFiles} item will be deleted.', '%{numberOfFiles} items will be deleted.', this.selectedFiles.length)
       this.promptFileDelete({
-        message: this.$gettextInterpolate(translated, { numberOfFiles: this.selectedFiles.length }, true),
+        message: this.$gettextInterpolate(translated, { numberOfFiles: this.selectedFiles.length }, false),
         items: this.selectedFiles
       })
     },

--- a/apps/files/src/components/Trashbin.vue
+++ b/apps/files/src/components/Trashbin.vue
@@ -79,7 +79,7 @@ export default {
       }
 
       translated = this.$gettext('Are you sure you want delete %{numberOfFiles} selected items?')
-      return this.$gettextInterpolate(translated, { numberOfFiles: files.length }, true)
+      return this.$gettextInterpolate(translated, { numberOfFiles: files.length }, false)
     },
 
     actions () {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Use `$ngettext` instead of `$gettext` for messages with pluralization. This allows to make messages context sensitive, like `delete 1 file` and `delete 42 files` in one translation. Apparently, there are only 2 occurrences in the whole files app, where this is relevant.
Checked in easygettext that `$ngettext` is supposed to be exported to transifex as well, so I expect no problems in that matter.
<!--- Describe your changes in detail -->

## Motivation and Context
Correct pluralization of messages.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Checked the two messages manually in the browser.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 