### PR TITLE
Upgrade ODS to most recent version

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "node-fetch": "^2.6.0",
     "npm-run-all": "^4.1.5",
     "oidc-client": "^1.9.1",
-    "owncloud-design-system": "^1.0.0-1113",
+    "owncloud-design-system": "^1.0.0-1116",
     "owncloud-sdk": "^1.0.0-490",
     "p-limit": "^2.2.1",
     "parse-json": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6391,10 +6391,10 @@ os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
-owncloud-design-system@^1.0.0-1113:
-  version "1.0.0-1114"
-  resolved "https://registry.yarnpkg.com/owncloud-design-system/-/owncloud-design-system-1.0.0-1114.tgz#c81009b7c95b775f3a242bb14fa71e40c84ffab0"
-  integrity sha512-wuQn4rFBURRjkNGqCT8m7juz1cKgPhc19Z7mPVHmL2Ib5Bz/GLah3/cUAN8vcPkApTUUzh1M5aA2aQet2Jbubg==
+owncloud-design-system@^1.0.0-1116:
+  version "1.0.0-1116"
+  resolved "https://registry.yarnpkg.com/owncloud-design-system/-/owncloud-design-system-1.0.0-1116.tgz#2f05fc1c7064d043cb3cbcf8580d86a985bc8320"
+  integrity sha512-h0bQK1Fr4iiyfqLFGLkiS8IVZPQItRPAIvdbd8KcA5QyhRk/D/RR8J3kiqB5qriK260wGBTK1n6tLANgvL7EGQ==
   dependencies:
     lodash "^4.17.11"
     mini-css-extract-plugin "^0.7.0"


### PR DESCRIPTION
## Description
Upgrade ODS to most recent version so that auto-clear of input field in collaborators add view can be used. Bonus: this slightly speeds up some tests, because they were waiting for collaborator results for concatenated inputs, finding none, waiting, clearing the input field and re-enter the search. Example: `tests/acceptance/features/webUISharingFilePermissionsGroups/sharePermissionsGroup.feature:62`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- manually in Chrome and Firefox on autocomplete-field in NewCollaborators component.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 