### PR TITLE
Splitted suite webUISharingFolderAdvancedPermissionsGroups

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -32,6 +32,7 @@ config = {
 				'webUISharingPermissionsUsers': 'SharingPermissionsUsers',
 				'webUISharingFilePermissionsGroups': 'SharingFilePermissionsGroups',
 				'webUISharingFolderPermissionsGroups': 'SharingFolderPermissionsGroups',
+				'webUISharingFolderAdvancedPermissionsGroups': 'SharingFolderAdvPermissionsGrp',
 				'webUIResharing': 'Resharing',
 				'webUISharingPublic': 'SharingPublic',
 				'webUITrashbin': 'Trashbin',

--- a/tests/acceptance/features/webUISharingFolderAdvancedPermissionsGroups/shareAdvancePermissionsGroup.feature
+++ b/tests/acceptance/features/webUISharingFolderAdvancedPermissionsGroups/shareAdvancePermissionsGroup.feature
@@ -1,0 +1,67 @@
+Feature: Sharing folders with internal groups with role as advanced permissions
+  As a user
+  I want to set different permissions on shared folders with groups
+  So that I can control the access on those folders by other users on the group
+
+  Background:
+    Given these users have been created with default attributes:
+      | username |
+      | user1    |
+      | user2    |
+      | user3    |
+    And these groups have been created:
+      | groupname |
+      | grp1      |
+    And user "user1" has been added to group "grp1"
+    And user "user2" has been added to group "grp1"
+
+  @issue-1837
+  Scenario Outline: share a folder with multiple users with role as advanced permissions and different extra permissions
+    Given group "grp2" has been created
+    And user "user2" has been added to group "grp2"
+    And user "user1" has logged in using the webUI
+    When the user opens the share dialog for folder "simple-folder" using the webUI
+    And the user opens the share creation dialog in the webUI
+    And the user selects the following collaborators for the share as "<role>" with "<extra-permissions>" permissions:
+      | collaborator | type  |
+      | grp1         | group |
+      | User Three   | user  |
+      | grp2         | group |
+    And the user removes "grp1" as a collaborator from the share
+    And the user removes "User One" as a collaborator from the share
+    And the user shares with the selected collaborators
+    Then custom permissions "<displayed-permissions>" should be set for user "grp2" for folder "simple-folder" on the webUI
+    And custom permissions "<displayed-permissions>" should be set for user "User Three" for folder "simple-folder" on the webUI
+    And group "grp2" should be listed as "<displayed-role>" in the collaborators list for folder "simple-folder" on the webUI
+    And user "User Three" should be listed as "<displayed-role>" in the collaborators list for folder "simple-folder" on the webUI
+    And user "user2" should have received a share with these details:
+      | field       | value                |
+      | uid_owner   | user1                |
+      | share_with  | grp2                 |
+      | file_target | /simple-folder (2)   |
+      | item_type   | folder               |
+      | permissions | <actual-permissions> |
+    And user "user3" should have received a share with these details:
+      | field       | value                |
+      | uid_owner   | user1                |
+      | share_with  | user3                |
+      | file_target | /simple-folder (2)   |
+      | item_type   | folder               |
+      | permissions | <actual-permissions> |
+    But user "User One" should not be listed in the collaborators list on the webUI
+    And group "grp1" should not be listed in the collaborators list on the webUI
+    And as "user1" folder "simple-folder (2)" should not exist
+    Examples:
+      | role                 | displayed-role          | extra-permissions             | displayed-permissions | actual-permissions           |
+      | Advanced permissions | Advanced permissions    | delete                        | delete                | read, delete                 |
+      | Advanced permissions | Advanced permissions    | update                        | update                | read, update                 |
+      | Advanced permissions | Advanced permissions    | create                        | create                | read, create                 |
+      | Advanced permissions | Advanced permissions    | share, delete                 | share, delete         | read, share, delete          |
+      | Advanced permissions | Advanced permissions    | share, update                 | share, update         | read, update, share          |
+      | Advanced permissions | Advanced permissions    | share, create                 | share, create         | read, share, create          |
+      | Advanced permissions | Advanced permissions    | delete, update                | delete, update        | read, delete, update         |
+      | Advanced permissions | Advanced permissions    | delete, create                | delete, create        | read, delete, create         |
+      | Advanced permissions | Advanced permissions    | update, create                | update, create        | read, update, create         |
+      | Advanced permissions | Advanced permissions    | share, delete, update         | share, delete, update | read, share, delete, update  |
+      | Advanced permissions | Advanced permissions    | share, create, delete         | share, create, delete | read, share, delete, create  |
+      | Advanced permissions | Advanced permissions    | share, update, create         | share, update, create | read, share, update, create  |

--- a/tests/acceptance/features/webUISharingFolderPermissionsGroups/sharePermissionsGroup.feature
+++ b/tests/acceptance/features/webUISharingFolderPermissionsGroups/sharePermissionsGroup.feature
@@ -1,4 +1,4 @@
-Feature: Sharing folders with internal groups with permissions
+Feature: Sharing folders with internal groups with different roles and permissions
   As a user
   I want to set different permissions on shared folders with groups
   So that I can control the access on those folders by other users on the group
@@ -59,17 +59,5 @@ Feature: Sharing folders with internal groups with permissions
     | Editor               | Editor                  | ,                             | ,                     | read, update, delete, create |
     | Advanced permissions | Viewer                  | ,                             | ,                     | read                         |
     | Advanced permissions | Viewer                  | share                         | share                 | read, share                  |
-    | Advanced permissions | Advanced permissions    | delete                        | delete                | read, delete                 |
-    | Advanced permissions | Advanced permissions    | update                        | update                | read, update                 |
-    | Advanced permissions | Advanced permissions    | create                        | create                | read, create                 |
-    | Advanced permissions | Advanced permissions    | share, delete                 | share, delete         | read, share, delete          |
-    | Advanced permissions | Advanced permissions    | share, update                 | share, update         | read, update, share          |
-    | Advanced permissions | Advanced permissions    | share, create                 | share, create         | read, share, create          |
-    | Advanced permissions | Advanced permissions    | delete, update                | delete, update        | read, delete, update         |
-    | Advanced permissions | Advanced permissions    | delete, create                | delete, create        | read, delete, create         |
-    | Advanced permissions | Advanced permissions    | update, create                | update, create        | read, update, create         |
-    | Advanced permissions | Advanced permissions    | share, delete, update         | share, delete, update | read, share, delete, update  |
-    | Advanced permissions | Advanced permissions    | share, create, delete         | share, create, delete | read, share, delete, create  |
-    | Advanced permissions | Advanced permissions    | share, update, create         | share, update, create | read, share, update, create  |
     | Advanced permissions | Editor                  | delete, update, create        | ,                     | read, delete, update, create |
     | Advanced permissions | Editor                  | share, delete, update, create | share                 | all                          |


### PR DESCRIPTION
## Description
Splitted suite webUISharingFolderAdvancedPermissionsGroups into following new suites:
- webUISharingFolderPermissionsGroups
- webUISharingFolderAdvancedPermissionsGroups

## Related Issue
Part of #2874

## Motivation and Context
Test for suite webUISharingFolderPermissionsGroups took longer than 45 minutes. So, to make the CI run faster the webUISharingFolderPermissionsGroups suite is splitted. 

## How Has This Been Tested?
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

