### PR TITLE
Separated navigation

### DIFF
--- a/apps/files/src/default.js
+++ b/apps/files/src/default.js
@@ -76,7 +76,7 @@ const navItems = [
     iconMaterial: appInfo.icon,
     route: {
       name: 'files-list',
-      path: '/'
+      path: `/${appInfo.id}/list`
     }
   },
   {

--- a/changelog/unreleased/2746
+++ b/changelog/unreleased/2746
@@ -1,0 +1,7 @@
+Change: Display only items for current extension in sidebar menu
+
+We've filtered out nav items in the sidebar menu. Now only items for current extension will be displayed.
+In case the extension has only one nav item, the sidebar menu is hidden and instead of menu button is displayed the name of extension.
+
+https://github.com/owncloud/phoenix/issues/2746
+https://github.com/owncloud/phoenix/pull/3013

--- a/src/components/ApplicationsMenu.vue
+++ b/src/components/ApplicationsMenu.vue
@@ -1,7 +1,15 @@
 <template>
   <div v-if="!!applicationsList.length">
     <oc-button id="_appSwitcherButton" icon="apps" variation="primary" class="oc-topbar-menu-burger uk-height-1-1"  aria-label="$gettext('Application Switcher')" ref="menubutton" />
-    <oc-drop toggle="#_appSwitcherButton" mode="click" :options="{pos:'bottom-right'}" class="uk-width-large" ref="menu">
+    <oc-drop
+      dropId="app-switcher-dropdown"
+      toggle="#_appSwitcherButton"
+      mode="click"
+      :options="{pos:'bottom-right', delayHide: 0}"
+      class="uk-width-large"
+      ref="menu"
+      closeOnClick
+    >
       <div class="uk-grid-small uk-text-center" uk-grid>
         <div class="uk-width-1-3" v-for="(n, nid) in $_applicationsList" :key="nid">
           <a v-if="n.url" key="external-link" target="_blank" :href="n.url">
@@ -36,14 +44,14 @@ export default {
   },
   computed: {
     $_applicationsList () {
-      return this.applicationsList.map((item) => {
+      return this.applicationsList.map(item => {
         const lang = this.$language.current
         // TODO: move language resolution to a common function
         // FIXME: need to handle logic for variants like en_US vs en_GB
-        let title = item.title.en
+        let title = item.title ? item.title.en : item.name
         let iconMaterial
         let iconUrl
-        if (item.title[lang]) {
+        if (item.title && item.title[lang]) {
           title = item.title[lang]
         }
 
@@ -64,10 +72,10 @@ export default {
 
         if (item.url) {
           app.url = item.url
-        }
-
-        if (item.path) {
+        } else if (item.path) {
           app.path = item.path
+        } else {
+          app.path = `/${item.id}`
         }
 
         return app

--- a/src/components/Top-Bar.vue
+++ b/src/components/Top-Bar.vue
@@ -1,9 +1,19 @@
 <template>
   <oc-navbar id="oc-topbar" tag="header" class="oc-topbar uk-position-relative uk-navbar">
     <oc-navbar-item position="left">
-      <oc-button v-if="hasAppNavigation" icon="menu" variation="primary" class="oc-topbar-menu-burger uk-height-1-1" aria-label="Menu" @click="$_onOpenAppNavigation" ref="menubutton">
+      <oc-button
+        v-if="hasAppNavigation"
+        key="extension-navigation-button"
+        icon="menu"
+        variation="primary"
+        class="oc-topbar-menu-burger uk-height-1-1"
+        :aria-label="$gettext('Menu')"
+        @click="toggleAppNavigationVisibility"
+        ref="menubutton"
+      >
         <span class="oc-topbar-menu-burger-label" v-translate>Menu</span>
       </oc-button>
+      <span v-else key="extension-title" class="topbar-current-extension-title uk-margin-left" v-text="currentExtensionName" />
     </oc-navbar-item>
     <oc-navbar-item position="center">
       <router-link to="/" class="oc-topbar-icon">ownCloud X</router-link>
@@ -17,6 +27,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import pluginHelper from '../mixins/pluginHelper.js'
 import ApplicationsMenu from './ApplicationsMenu.vue'
 import UserMenu from './UserMenu.vue'
@@ -59,14 +70,27 @@ export default {
     }
   },
   computed: {
+    ...mapGetters(['apps']),
+
     isPublicPage () {
       return !this.userId
+    },
+
+    currentExtensionName () {
+      return this.$gettext(this.apps[this.currentExtension].name)
     }
   },
   methods: {
-    $_onOpenAppNavigation () {
-      this.$emit('toggleAppNavigation')
+    toggleAppNavigationVisibility () {
+      this.$emit('toggleAppNavigationVisibility')
     }
   }
 }
 </script>
+
+TODO: Move to ODS and enable theming
+<style scoped>
+.topbar-current-extension-title {
+  color: white
+}
+</style>

--- a/src/phoenix.js
+++ b/src/phoenix.js
@@ -84,7 +84,7 @@ const supportedLanguages = {
 
 function loadApps () {
   let plugins = []
-  let navItems = []
+  let navItems = {}
   let translations = coreTranslations
 
   let routes = [{
@@ -122,7 +122,7 @@ function loadApps () {
       plugins.push(app.plugins)
     }
     if (app.navItems) {
-      navItems.push(app.navItems)
+      navItems[app.appInfo.id] = app.navItems
     }
     if (app.translations) {
       Object.keys(supportedLanguages).forEach((lang) => {
@@ -157,7 +157,6 @@ function loadApps () {
     silent: true
   })
 
-  navItems = navItems.flat()
   const OC = new Vue({
     el: '#owncloud',
     data: {

--- a/src/plugins/phoenix.js
+++ b/src/plugins/phoenix.js
@@ -5,7 +5,11 @@ export default {
     Vue.mixin({
       computed: {
         ...mapGetters(['getToken', 'isAuthenticated']),
-        ...mapGetters('Files', ['publicLinkPassword'])
+        ...mapGetters('Files', ['publicLinkPassword']),
+
+        currentExtension () {
+          return this.$route.path.split('/')[1]
+        }
       },
       methods: {
         ...mapActions('Files', ['addActionToProgress', 'removeActionFromProgress']),


### PR DESCRIPTION
## Description
In the sidebar is now only extension-specific navigation and into the apps switcher are automatically injected extensions which have at least one nav item. In the case that extension has only one nav item, the menu button is replaced by the name of the extension.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #2746

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/25989331/74324488-680fa180-4d87-11ea-93f6-edb008d3dd91.png)

![image](https://user-images.githubusercontent.com/25989331/74324501-6d6cec00-4d87-11ea-9c29-1660187150b6.png)

![image](https://user-images.githubusercontent.com/25989331/74324511-7231a000-4d87-11ea-80e9-6dcf0f894cf5.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 