### PR TITLE
[Tests-Only] Restore files and folder from trashbin with same name

### DIFF
--- a/tests/acceptance/features/webUITrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinRestore.feature
@@ -115,3 +115,39 @@ Feature: Restore deleted files/folders
     And as "user1" file "simple-folder-renamed/file-to-delete-and-restore" should not exist
     #And as "user1" file "simple-folder-renamed/file-to-delete-and-restore" should exist
     And as "user1" file "simple-folder/file-to-delete-and-restore" should not exist
+
+  @issue-1723
+  Scenario: Delete and restore a file that has the same name like a deleted folder
+    Given the following files have been deleted by user "user1"
+      | name      |
+      | lorem.txt |
+    And the user has created folder "lorem.txt"
+    And the following folders have been deleted by user "user1"
+      | name      |
+      | lorem.txt |
+    When the user browses to the trashbin page
+    And the user restores file "lorem.txt" from the trashbin using the webUI
+    Then the success message "lorem.txt was restored successfully" should be displayed on the webUI
+    And file "lorem.txt" should not be listed on the webUI
+    And folder "lorem.txt" should be listed on the webUI
+    When the user browses to the files page using the webUI
+    Then file "lorem.txt" should be listed on the webUI
+    And folder "lorem.txt" should not be listed on the webUI
+
+  Scenario: Delete and restore a folder that has the same name like a deleted file
+    Given the user has created file "lorem.txt"
+    And the following files have been deleted by user "user1"
+      | name      |
+      | lorem.txt |
+    And the user has created folder "lorem.txt"
+    And the following folders have been deleted by user "user1"
+      | name      |
+      | lorem.txt |
+    When the user browses to the trashbin page
+    And the user restores folder "lorem.txt" from the trashbin using the webUI
+    Then the success message "lorem.txt was restored successfully" should be displayed on the webUI
+    And folder "lorem.txt" should not be listed on the webUI
+    And file "lorem.txt" should be listed on the webUI
+    When the user browses to the files page using the webUI
+    Then folder "lorem.txt" should be listed on the webUI
+    And file "lorem.txt" should not be listed on the webUI

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -340,11 +340,18 @@ Then('there should be no files/folders/resources listed on the webUI', async fun
   assert.ok(allRowsResult.value.length === 0, `No resources are listed, ${allRowsResult.length} found`)
 })
 
-Then('file/folder {string} should be listed on the webUI', function (folder) {
+Then('file {string} should be listed on the webUI', function (folder) {
   return client
     .page
     .FilesPageElement.filesList()
-    .waitForFileVisible(folder)
+    .waitForFileVisible(folder, 'file')
+})
+
+Then('folder {string} should be listed on the webUI', (folder) => {
+  return client
+    .page
+    .FilesPageElement.filesList()
+    .waitForFileVisible(folder, 'folder')
 })
 
 Then('file/folder with path {string} should be listed in the favorites page on the webUI', function (path) {
@@ -364,8 +371,15 @@ Then('the last uploaded folder should be listed on the webUI', async function ()
   return client
 })
 
-Then('file/folder {string} should not be listed on the webUI', async function (folder) {
-  const state = await client.page.FilesPageElement.filesList().isElementListed(folder)
+Then('file {string} should not be listed on the webUI', async function (folder) {
+  const state = await client.page.FilesPageElement.filesList().isElementListed(folder, 'file')
+  return client.assert.ok(
+    !state, `Error: Resource ${folder} is listed on the filesList`
+  )
+})
+
+Then('folder {string} should not be listed on the webUI', async (folder) => {
+  const state = await client.page.FilesPageElement.filesList().isElementListed(folder, 'folder')
   return client.assert.ok(
     !state, `Error: Resource ${folder} is listed on the filesList`
   )
@@ -666,8 +680,8 @@ const assertDeletedElementsAreListed = function () {
   return assertElementsAreListed(deletedElements)
 }
 
-When('the user restores file/folder {string} from the trashbin using the webUI', function (element) {
-  return client.page.FilesPageElement.filesList().restoreFile(element)
+When(/^the user restores (file|folder) "([^"]*)" from the trashbin using the webUI$/, function (elementType, element) {
+  return client.page.FilesPageElement.filesList().restoreFile(element, elementType)
 })
 
 Then('the following files/folders/resources should be listed on the webUI', function (table) {


### PR DESCRIPTION
## Description

- Restore files from trashbin with same name as folder
- Restore folder from trashbin with same name as file

## Related Issue
https://github.com/owncloud/phoenix/issues/1723

## Motivation and Context

- To restore file from trashbin with same name as folder
- To restore folder from trashbin with same name as file

## How Has This Been Tested?
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

