### PR TITLE
Change layout and styling for upload progress

### DIFF
--- a/apps/files/src/components/FilesApp.vue
+++ b/apps/files/src/components/FilesApp.vue
@@ -1,7 +1,7 @@
   <template>
     <div id="files" class="uk-flex uk-flex-column">
       <files-app-bar />
-      <upload-progress v-show="inProgress.length" class="uk-padding-small uk-background-muted" />
+      <upload-progress v-show="$_uploadProgressVisible" class="uk-padding-small uk-background-muted" />
       <oc-grid class="uk-height-1-1 uk-flex-1 uk-overflow-auto">
         <div ref="filesListWrapper" tabindex="-1" class="uk-width-expand uk-overflow-auto uk-height-1-1" @dragover="$_ocApp_dragOver" :class="{ 'uk-visible@m' : _sidebarOpen }">
           <oc-loader id="files-list-progress" v-if="loadingFolder"></oc-loader>
@@ -100,6 +100,10 @@ export default {
 
     sharedList () {
       return this.$route.name === 'files-shared-with-me' || this.$route.name === 'files-shared-with-others'
+    },
+
+    $_uploadProgressVisible () {
+      return this.inProgress.length > 0
     },
 
     $_renameDialogPlaceholder () {

--- a/apps/files/src/components/UploadMenu.vue
+++ b/apps/files/src/components/UploadMenu.vue
@@ -1,23 +1,26 @@
 <template>
-  <ul class="uk-list uk-margin-remove">
-    <li v-for="(item, index) in items" :key="item.id">
-      <div class="uk-flex">
+  <ul class="uk-list uk-list-divider uk-margin-remove-left uk-margin-remove-right">
+    <li v-for="item in items" :key="item.id">
+      <div class="uk-flex uk-flex-middle">
         <oc-icon name="file_copy" class="uk-margin-small-right" />
         <div class="uk-width-expand">
-          <div class="uk-text-bold" v-text="$_truncateFileName(item.name)" />
-          <div class="uk-flex uk-flex-middle">
-            <span class="uk-margin-small-right uk-text-nowrap">{{ item.size | fileSize }}</span>
+          <div class="uk-flex">
+            <div class="uk-text-bold uk-width-expand uk-text-truncate">{{ item.name }}</div>
+            <div class="uk-width-auto uk-text-nowrap">{{ item.size | fileSize }}</div>
+          </div>
+          <div class="uk-margin-remove uk-position-relative uk-width-expand">
             <oc-progress
-              :value="item.progress | toInt"
+              :aria-hidden="true"
               :max="100"
-              class="uk-flex-1 uk-margin-remove"
+              :value="item.progress | toInt"
+              class="uk-width-expand uk-margin-remove"
             />
+            <span :aria-hidden="true" class="uk-position-center oc-progress-text">
+              {{ item.progress | roundNumber }} %
+            </span>
           </div>
         </div>
       </div>
-      <template v-if="index !== items.length - 1">
-        <hr class="uk-margin-bottom uk-margin-top" />
-      </template>
     </li>
   </ul>
 </template>
@@ -38,15 +41,6 @@ export default {
       type: Array,
       default: () => [],
       required: true
-    }
-  },
-  methods: {
-    $_truncateFileName (name) {
-      if (name.length > 15) {
-        return `${name.substr(0, 6)}...${name.substr(name.length - 6)}`
-      }
-
-      return name
     }
   }
 }

--- a/changelog/unreleased/3742
+++ b/changelog/unreleased/3742
@@ -1,0 +1,9 @@
+Change: Improve visual appearance of upload progress
+
+- Changed the layout of the upload progress to be a narrow standalone full width row below the app top bar.
+- Transformed textual information into a single row below the progress bar and made it very clear that it can be clicked to show upload progress details.
+- Changed layout of upload progress details list items, so that the progress bars always have the same width.
+- Changed visuals of all progress bars in upload context to have a narrow outline and the percentage numbers inside of the progress bars.
+- Fixed the calculation of the overall upload progress to be weighted by file sizes instead of just adding up percentages and dividing by number of uploads.
+
+https://github.com/owncloud/enterprise/issues/3742


### PR DESCRIPTION
## Description
- Changed the layout of the upload progress to be a narrow standalone full width row below the app top bar.
- Transformed textual information into a single row below the progress bar and made it very clear that it can be clicked to show upload progress details.
- Changed layout of upload progress details list items, so that the progress bars always have the same width.
- Changed visuals of all progress bars in upload context to have a narrow outline and the percentage numbers inside of the progress bars.
- Fixed the calculation of the overall upload progress to be weighted by file sizes instead of just adding up percentages and dividing by number of uploads.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/enterprise/issues/3742

## Motivation and Context
Improve upload UX

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally in chrome and firefox
- [ ] drone acceptance tests

## Screenshots (if appropriate):
### upload progress with collapsed details
![Bildschirmfoto 2020-02-12 um 19 05 45](https://user-images.githubusercontent.com/3532843/74363522-feb18200-4dca-11ea-9044-48e603fc7aa9.png)

### upload progress with expanded details
<img width="413" alt="Bildschirmfoto 2020-02-12 um 17 06 06" src="https://user-images.githubusercontent.com/3532843/74355043-8fcd2c80-4dbc-11ea-9073-58a64f0b43a3.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 