### PR TITLE
Fix malformed config.json.sample (removed double quote)

### DIFF
--- a/config.json.sample
+++ b/config.json.sample
@@ -21,7 +21,7 @@
     },
     {
       "title": {
-        "en": ""App living inside of Phoenix core SPA"
+        "en": "App living inside of Phoenix core SPA"
       },
       "icon": "info",
       "path": "/internal-app"


### PR DESCRIPTION
## Description
`config.json.sample` contains a double-double quote which doesn't belong there.

## Motivation and Context
Provide working sample config.
