### PR TITLE
Add icons for public link expiration and password protection

### DIFF
--- a/apps/files/src/components/PublicLinksSidebar/PublicLinkListItem.vue
+++ b/apps/files/src/components/PublicLinksSidebar/PublicLinkListItem.vue
@@ -12,14 +12,16 @@
         <a :href="link.url" target="_blank" :uk-tooltip="$_tooltipTextLink" class="uk-text-bold uk-text-truncate oc-files-file-link-url">{{ link.name }}</a>
         <br>
         <span class="uk-text-meta uk-text-break">
-                      <span class="oc-files-file-link-role">{{ link.description }}</span>
-                      <template v-if="link.expiration"> |
-                        <span v-translate>Expires</span> {{ formDateFromNow(link.expiration) }}
-                      </template>
-                      <template v-if="link.password"> |
-                        <span v-translate>Password protected</span>
-                      </template>
-                    </span>
+          <span class="oc-files-file-link-role">{{ link.description }}</span>
+          <template v-if="link.expiration"> |
+            <oc-icon size="xsmall" name="text-calendar" class="fix-icon-baseline" :aria-hidden="true" />
+            <span v-translate>Expires</span> {{ formDateFromNow(link.expiration) }}
+          </template>
+          <template v-if="link.password"> |
+            <oc-icon size="xsmall" name="lock" class="fix-icon-baseline" :aria-hidden="true" />
+            <span v-translate>Password protected</span>
+          </template>
+        </span>
       </oc-table-cell>
       <oc-table-cell shrink class="uk-text-nowrap">
         <oc-button v-if="$_editButtonVisible" :aria-label="$_editButtonLabel" @click="$emit('onEdit', link)" variation="raw" class="oc-files-file-link-edit">
@@ -141,5 +143,8 @@ export default {
   }
   .files-file-links-link-via-label {
     max-width: 65%;
+  }
+  .fix-icon-baseline {
+    margin-bottom: -2px;
   }
 </style>


### PR DESCRIPTION
## Description
When showing the public link sidebar, the attribute lines about an active expiration date or password protection were only textual. Now they show xsmall icons as well.

## Motivation and Context
UI polishing

## Screenshots (if appropriate):
![Bildschirmfoto 2020-02-13 um 11 12 20](https://user-images.githubusercontent.com/3532843/74424157-b8533600-4e51-11ea-829f-afbf3a8a9cc9.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 