### PR TITLE
Fix broken aria labels

### DIFF
--- a/apps/files/src/components/FileOpenActions.vue
+++ b/apps/files/src/components/FileOpenActions.vue
@@ -5,7 +5,7 @@
         icon="close"
         class="uk-position-top-right uk-position-absolute uk-margin-top uk-margin-right"
         @click="closeActions"
-        aria-label="$_closeActionsButtonLabel"
+        :aria-label="$gettext('Close file actions menu')"
       />
       <div v-text="$_label" class="uk-margin-small-bottom" />
       <ul class="uk-nav">
@@ -40,10 +40,6 @@ export default {
     $_label () {
       const translated = this.$gettext('Open %{fileName} in')
       return this.$gettextInterpolate(translated, { fileName: this.filename }, true)
-    },
-
-    $_closeActionsButtonLabel () {
-      return this.$gettext('Close file actions menu')
     }
   },
   watch: {

--- a/changelog/unreleased/3039
+++ b/changelog/unreleased/3039
@@ -1,0 +1,5 @@
+Bugfix: Fix accessible labels that said $gettext
+
+Fixed three accessible aria labels that were saying "$gettext" instead of their actual translated text.
+
+https://github.com/owncloud/phoenix/pull/3039

--- a/src/components/ApplicationsMenu.vue
+++ b/src/components/ApplicationsMenu.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="!!applicationsList.length">
-    <oc-button id="_appSwitcherButton" icon="apps" variation="primary" class="oc-topbar-menu-burger uk-height-1-1"  aria-label="$gettext('Application Switcher')" ref="menubutton" />
+    <oc-button id="_appSwitcherButton" icon="apps" variation="primary" class="oc-topbar-menu-burger uk-height-1-1" :aria-label="$gettext('Application Switcher')" ref="menubutton" />
     <oc-drop
       dropId="app-switcher-dropdown"
       toggle="#_appSwitcherButton"

--- a/src/components/UserMenu.vue
+++ b/src/components/UserMenu.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <oc-button id="_userMenuButton" class="oc-topbar-personal uk-height-1-1" variation="primary" aria-label="$gettext('User Menu')" ref="menuButton">
+    <oc-button id="_userMenuButton" class="oc-topbar-personal uk-height-1-1" variation="primary" :aria-label="$gettext('User Menu')" ref="menuButton">
       <oc-grid gutter="small">
         <avatar-image class="oc-topbar-personal-avatar" :width="32" :userid="userId" :userName="userDisplayName"/>
         <div class="oc-topbar-personal-label">{{ userDisplayName }}</div>


### PR DESCRIPTION
## Description
Some aria labels were set to static text while using $gettext() inside,
fixed by adding a colon in front.

## Related Issue
None raised

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manual test by evaluating the aria-label attributes in the UI in the affected places

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

