### PR TITLE
Fix console warning about search query in public page

### DIFF
--- a/apps/files/src/components/FilesAppBar.vue
+++ b/apps/files/src/components/FilesAppBar.vue
@@ -301,8 +301,13 @@ export default {
     // TODO: Find a better solution
     $route (to, from) {
       this.actionsKey = Math.floor(Math.random() * 20)
-      this.$refs.mobileSearch.value = null
-      this.$refs.globalSearchBar.query = ''
+      // note: the search bars are not available on all views
+      if (this.$refs.mobileSearch) {
+        this.$refs.mobileSearch.value = null
+      }
+      if (this.$refs.globalSearchBar) {
+        this.$refs.globalSearchBar.query = ''
+      }
     }
   },
   methods: {

--- a/changelog/unreleased/3041
+++ b/changelog/unreleased/3041
@@ -1,0 +1,7 @@
+Bugfix: Fix console warning about search query in public page
+
+Fixed console warning about the search query attribute not being available
+whenever the search fields are not visible, for example when
+accessing a public link page.
+
+https://github.com/owncloud/phoenix/pull/3041


### PR DESCRIPTION
## Description
Fixed console warning about the search query attribute not being available
whenever the search fields are not visible, for example when
accessing a public link page.

## Related Issue
None raised

## Motivation and Context
No one likes console errors!

## How Has This Been Tested?
Open any public link and observe the console log while switching folders inside the public page.
Before: error shown about "query" param not being settable on undefined.
After: no errors :tada: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
