### PR TITLE
Improve collaborators and owner columns in shared file lists

### DIFF
--- a/apps/files/src/components/FilesLists/StatusIndicators/DefaultIndicators.vue
+++ b/apps/files/src/components/FilesLists/StatusIndicators/DefaultIndicators.vue
@@ -35,7 +35,7 @@ export default {
     },
     parentPath: {
       type: String,
-      required: true
+      required: false
     }
   },
 
@@ -61,6 +61,9 @@ export default {
     },
 
     shareTypesIndirect () {
+      if (!this.parentPath) {
+        return []
+      }
       const parentPaths = getParentPaths(this.parentPath, true)
       if (parentPaths.length === 0) {
         return []
@@ -87,8 +90,19 @@ export default {
   },
 
   methods: {
+    $_shareTypes (item) {
+      if (typeof item.shareTypes !== 'undefined') {
+        return item.shareTypes
+      }
+
+      if (item.shares) {
+        return Array.from(new Set(item.shares.map(share => parseInt(share.type, 10))))
+      }
+      return []
+    },
+
     isDirectUserShare (item) {
-      return (intersection(userShareTypes, item.shareTypes).length > 0)
+      return (intersection(userShareTypes, this.$_shareTypes(item)).length > 0)
     },
 
     isIndirectUserShare (item) {
@@ -96,7 +110,7 @@ export default {
     },
 
     isDirectLinkShare (item) {
-      return (item.shareTypes.indexOf(shareTypes.link) >= 0)
+      return (this.$_shareTypes(item).indexOf(shareTypes.link) >= 0)
     },
 
     isIndirectLinkShare () {

--- a/apps/files/src/components/FilesLists/StatusIndicators/StatusIndicators.vue
+++ b/apps/files/src/components/FilesLists/StatusIndicators/StatusIndicators.vue
@@ -37,7 +37,7 @@ export default {
     },
     parentPath: {
       type: String,
-      required: true
+      required: false
     }
   },
 

--- a/changelog/unreleased/2924
+++ b/changelog/unreleased/2924
@@ -1,0 +1,10 @@
+Enhancement: Improved collaborators column in shared file lists
+
+Fixed issue with the collaborators column where only one was being displayed in the "shared with you" file list.
+This is done by properly aggregating all share entries under each file entry for the list, which now
+also includes group shares and link shares.
+
+Improved the look of the collaborators by adding avatars and icons there for the shares in the collaborators and owner columns.
+
+https://github.com/owncloud/phoenix/issues/2924
+https://github.com/owncloud/phoenix/pull/3049

--- a/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
@@ -243,23 +243,6 @@ Feature: deleting files and folders
     And the deleted elements should not be listed on the webUI
     And the deleted elements should not be listed on the webUI after a page reload
 
-  Scenario: Delete multiple files at once from shared with me page
-    Given user "user2" has been created with default attributes
-    And user "user2" has shared folder "simple-folder" with user "user1"
-    And user "user2" has shared file "lorem.txt" with user "user1"
-    And user "user2" has shared file "data.zip" with user "user1"
-    And the user has browsed to the shared-with-me page
-    When the user batch deletes these files using the webUI
-      | name              |
-      | data (2).zip      |
-      | lorem (2).txt     |
-      | simple-folder (2) |
-    Then as "user1" file "data.zip (2)" should not exist
-    And as "user1" file "lorem (2).txt" should not exist
-    And as "user1" folder "simple-folder (2)" should not exist
-    And the deleted elements should not be listed on the webUI
-    And the deleted elements should not be listed on the webUI after a page reload
-
   Scenario: Try to delete file and folder from favorites page
     Given user "user1" has favorited element "simple-folder"
     And user "user1" has favorited element "lorem.txt"

--- a/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
+++ b/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
@@ -37,10 +37,9 @@ Feature: accept/decline shares coming from internal users
     When the user shares folder "simple-folder (2)" with group "grp1" as "Viewer" using the webUI
     And the user unshares folder "simple-folder (2)" using the webUI
     And the user browses to the shared-with-me page using the webUI
-    Then folder "simple-folder" shared by "User One" should be in "Declined" state on the webUI
-    And folder "simple-folder" shared by "User Two" should be in "Pending" state on the webUI
-   # And folder "simple-folder" shared by "User Two" should not be listed in the webUI
-    And folder "simple-folder (2)" should not be listed on the webUI
+    Then folder "simple-folder (2)" shared by "User One" should be in "Declined" state on the webUI
+    And folder "simple-folder" shared by "User Two" should not be listed in the webUI
+    And folder "simple-folder" should not be listed on the webUI
 
   @smokeTest
   Scenario: unshare an accepted share on the "All files" page
@@ -59,8 +58,8 @@ Feature: accept/decline shares coming from internal users
     Then folder "simple-folder (2)" should not be listed on the webUI
     And file "testimage (2).jpg" should not be listed on the webUI
     When the user browses to the shared-with-me page using the webUI
-    Then folder "simple-folder" shared by "User One" should be in "Declined" state on the webUI
-    And file "testimage.jpg" shared by "User One" should be in "Declined" state on the webUI
+    Then folder "simple-folder (2)" shared by "User One" should be in "Declined" state on the webUI
+    And file "testimage (2).jpg" shared by "User One" should be in "Declined" state on the webUI
 
   @smokeTest
   Scenario: Auto-accept shares
@@ -92,8 +91,8 @@ Feature: accept/decline shares coming from internal users
     Then folder "simple-folder (2)" should not be listed on the webUI
     And file "testimage (2).jpg" should not be listed on the webUI
     When the user browses to the shared-with-me page using the webUI
-    Then folder "simple-folder" shared by "User One" should be in "Declined" state on the webUI
-    And file "testimage.jpg" shared by "User One" should be in "Declined" state on the webUI
+    Then folder "simple-folder (2)" shared by "User One" should be in "Declined" state on the webUI
+    And file "testimage (2).jpg" shared by "User One" should be in "Declined" state on the webUI
 
   Scenario: unshare auto-accepted shares
     Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes"
@@ -110,8 +109,8 @@ Feature: accept/decline shares coming from internal users
     Then folder "simple-folder (2)" should not be listed on the webUI
     And file "testimage (2).jpg" should not be listed on the webUI
     When the user browses to the shared-with-me page using the webUI
-    Then folder "simple-folder" shared by "User One" should be in "Declined" state on the webUI
-    And file "testimage.jpg" shared by "User One" should be in "Declined" state on the webUI
+    Then folder "simple-folder (2)" shared by "User One" should be in "Declined" state on the webUI
+    And file "testimage (2).jpg" shared by "User One" should be in "Declined" state on the webUI
 
   Scenario: unshare renamed shares
     Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes"
@@ -121,7 +120,7 @@ Feature: accept/decline shares coming from internal users
     When the user unshares folder "simple-folder-renamed" using the webUI
     Then folder "simple-folder-renamed" should not be listed on the webUI
     When the user browses to the shared-with-me page using the webUI
-    Then folder "simple-folder" shared by "User One" should be in "Declined" state on the webUI
+    Then folder "simple-folder-renamed" shared by "User One" should be in "Declined" state on the webUI
 
   Scenario: unshare moved shares
     Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes"
@@ -132,7 +131,7 @@ Feature: accept/decline shares coming from internal users
     And the user unshares folder "shared" using the webUI
     Then folder "shared" should not be listed on the webUI
     When the user browses to the shared-with-me page using the webUI
-    Then folder "simple-folder" shared by "User One" should be in "Declined" state on the webUI
+    Then folder "shared" shared by "User One" should be in "Declined" state on the webUI
 
   Scenario: unshare renamed shares, accept it again
     Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes"
@@ -141,7 +140,7 @@ Feature: accept/decline shares coming from internal users
     And the user has reloaded the current page of the webUI
     When the user unshares folder "simple-folder-renamed" using the webUI
     And the user browses to the shared-with-me page using the webUI
-    And the user accepts share "simple-folder" offered by user "User One" using the webUI
+    And the user accepts share "simple-folder-renamed" offered by user "User One" using the webUI
     Then folder "simple-folder-renamed" shared by "User One" should be in "Accepted" state on the webUI
     When the user browses to the files page
     Then folder "simple-folder-renamed" should be listed on the webUI
@@ -278,15 +277,37 @@ Feature: accept/decline shares coming from internal users
     Then file "lorem (2).txt" should not be listed on the webUI
     And file "testimage (2).jpg" should not be listed on the webUI
     When the user browses to the shared-with-me page using the webUI
-    Then file "lorem.txt" shared by "User One" should be in "Declined" state on the webUI
+    Then file "lorem (2).txt" shared by "User One" should be in "Declined" state on the webUI
     And file "testimage.jpg" shared by "User One" should be in "Pending" state on the webUI
 
-  Scenario:  shared file status is changed to declined when user deletes the file
+  @issue-3101 @skip
+  Scenario: Delete multiple accepted shares at once from shared with me page
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And user "user1" has been created with default attributes
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user1" has shared file "lorem.txt" with user "user2"
+    And user "user1" has shared file "data.zip" with user "user2"
+    And the user has browsed to the shared-with-me page
+    And the user accepts share "lorem.txt" offered by user "User One" using the webUI
+    When the user batch deletes these files using the webUI
+      | name          |
+      | data.zip      |
+      | lorem (2).txt |
+      | simple-folder |
+    Then file "data.zip" should not be listed on the webUI
+    And file "lorem (2).txt" should not be listed on the webUI
+    And folder "simple-folder" should not be listed on the webUI
+    When the user has reloaded the current page of the webUI
+    Then file "data.zip" shared by "User One" should be in "Declined" state on the webUI
+    And file "lorem (2).txt" shared by "User One" should be in "Declined" state on the webUI
+    And folder "simple-folder" shared by "User One" should be in "Declined" state on the webUI
+
+  Scenario: shared file status is changed to declined when user deletes the file
     Given user "user1" has shared file "lorem.txt" with user "user2"
     And the user has reloaded the current page of the webUI
     When the user deletes file "lorem (2).txt" using the webUI
     And the user browses to the shared-with-me page
-    Then file "lorem.txt" shared by "User One" should be in "Declined" state on the webUI
+    Then file "lorem (2).txt" shared by "User One" should be in "Declined" state on the webUI
 
   Scenario: the deleted shared file is restored back to all files list when accepted from the shared with me file list
     Given user "user1" has shared file "lorem.txt" with user "user2"
@@ -294,7 +315,7 @@ Feature: accept/decline shares coming from internal users
       | name          |
       | lorem (2).txt |
     And the user has browsed to the shared-with-me page
-    When the user accepts share "lorem.txt" offered by user "User One" using the webUI
+    When the user accepts share "lorem (2).txt" offered by user "User One" using the webUI
     Then the file "lorem (2).txt" shared by "User One" should not be in "Declined" state
     When the user browses to the files page
     Then file "lorem (2).txt" should be listed on the webUI

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -338,3 +338,13 @@ Feature: Sharing files and folders with internal groups
     When the user opens the share dialog for folder "simple-empty-folder" using the webUI
     Then user "User One" should be listed as "Owner" reshared through "User Two" via "simple-folder (2)" in the collaborators list on the webUI
     And the current collaborators list should have order "User One,User Three"
+
+  Scenario: share a folder with other group and then it should be listed on Shared with Others page
+    Given user "user1" has logged in using the webUI
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user1" has shared folder "simple-folder" with group "grp1"
+    When the user browses to the shared-with-others page
+    Then the following resources should have the following collaborators
+      | fileName            | expectedCollaborators |
+      | simple-folder       | User Two, grp1        |
+

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -146,12 +146,16 @@ Feature: Sharing files and folders with internal users
     And folder "new-simple-folder" should be listed on the webUI
 
   Scenario: share a folder with other user and then it should be listed on Shared with Others page
-    Given user "user2" has logged in using the webUI
+    Given user "user3" has been created with default attributes
+    And user "user2" has logged in using the webUI
     And user "user2" has shared file "lorem.txt" with user "user1"
     And user "user2" has shared folder "simple-folder" with user "user1"
+    And user "user2" has shared folder "simple-folder" with user "user3"
     When the user browses to the shared-with-others page
-    Then file "lorem.txt" should be listed on the webUI
-    And folder "simple-folder" should be listed on the webUI
+    Then the following resources should have the following collaborators
+      | fileName            | expectedCollaborators |
+      | lorem.txt           | User One              |
+      | simple-folder       | User One, User Three  |
 
   @issue-2480 @yetToImplement
   Scenario: check file with same name but different paths are displayed correctly in shared with others page

--- a/tests/acceptance/features/webUISharingNotifications/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingNotifications/shareWithGroups.feature
@@ -33,3 +33,4 @@ Feature: Sharing files and folders with internal groups
       | title                                        |
       | "User Three" shared "simple-folder" with you |
       | "User Three" shared "data.zip" with you      |
+

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -34,7 +34,9 @@ Feature: Share by public link
     Given user "user1" has logged in using the webUI
     And user "user1" has shared folder "simple-folder" with link with "read" permissions
     When the user browses to the shared-with-others page using the webUI
-    Then folder "simple-folder" should be listed on the webUI
+    Then the following resources should have the following collaborators
+      | fileName            | expectedCollaborators |
+      | simple-folder       | Public                |
     But file "data.zip" should not be listed on the webUI
 
   Scenario: opening public-link page of the files-drop link protected with password should redirect to files-drop page

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -380,6 +380,9 @@ module.exports = {
       await this
         .useXpath()
         .getAttribute(linkSelector, 'filename', function (result) {
+          if (result.value.error) {
+            this.assert.fail(result.value.error)
+          }
           this.assert.strictEqual(result.value, fileName, 'displayed file name not as expected')
         })
         .useCss()
@@ -744,6 +747,28 @@ module.exports = {
       return this.useCss()
     },
 
+    getCollaboratorsForResource: async function (fileName) {
+      const resourceRowXpath = this.getFileRowSelectorByFileName(fileName)
+      const collaboratorsXpath = resourceRowXpath + this.elements.collaboratorsInFileRow.selector
+      const collaborators = []
+
+      await this.waitForFileVisible(fileName)
+
+      await this
+        .api.elements(
+          this.elements.collaboratorsInFileRow.locateStrategy,
+          collaboratorsXpath,
+          (result) => {
+            result.value.forEach(element => {
+              return this.api.elementIdText(element.ELEMENT, (attr) => {
+                collaborators.push(attr.value)
+              })
+            })
+          }
+        )
+      return collaborators
+    },
+
     /**
      * Returns original string with replaced target character
      * @param   {string} string     String in which will be the target character replaced
@@ -839,6 +864,10 @@ module.exports = {
     },
     markedFavoriteInFileRow: {
       selector: '//span[contains(@class, "oc-star-shining")]',
+      locateStrategy: 'xpath'
+    },
+    collaboratorsInFileRow: {
+      selector: '//*[contains(@class, "file-row-collaborator-name")]',
       locateStrategy: 'xpath'
     },
     shareIndicatorsInFileRow: {

--- a/tests/acceptance/pageObjects/sharedWithMePage.js
+++ b/tests/acceptance/pageObjects/sharedWithMePage.js
@@ -37,7 +37,7 @@ module.exports = {
             if (result.status === 0) {
               status = result.value === '' ? 'Accepted' : result.value
             } else {
-              throw new Error(`Expected: share status of the resource but found unexpected response: ${result}`)
+              throw new Error(`Expected: share status of the resource but found unexpected response: ${result.value.error}`)
             }
           }
         )
@@ -53,10 +53,10 @@ module.exports = {
      */
     declineAcceptFile: function (action, filename, user) {
       const actionLocatorButton = {
-        locateStrategy: this.elements.actionOnFileRow.locateStrategy,
+        locateStrategy: this.elements.shareStatusActionOnFileRow.locateStrategy,
         selector: this.api.page.FilesPageElement.filesList().getFileRowSelectorByFileName(filename) +
                   util.format(this.elements.getSharedFromUserName.selector, user) +
-                  util.format(this.elements.actionOnFileRow.selector, action)
+                  util.format(this.elements.shareStatusActionOnFileRow.selector, action)
       }
       return this
         .initAjaxCounters()
@@ -100,19 +100,19 @@ module.exports = {
   },
   elements: {
     shareStatusOnFileRow: {
-      selector: "/../..//div[@class='uk-text-nowrap uk-width-small']/span",
+      selector: "/../..//*[contains(@class,'file-row-share-status-text')]",
       locateStrategy: 'xpath'
     },
     getSharedFromUserName: {
-      selector: '//div[normalize-space(.)="%s"]',
+      selector: '//*[contains(@class,"file-row-owner-name")][normalize-space(.)="%s"]',
       locateStrategy: 'xpath'
     },
     sharedFrom: {
-      selector: "//div[@class='uk-text-meta uk-text-nowrap uk-width-small']/div",
+      selector: "//*[contains(@class,'file-row-owner-name')]",
       locateStrategy: 'xpath'
     },
-    actionOnFileRow: {
-      selector: '/../..//a[.="%s"]',
+    shareStatusActionOnFileRow: {
+      selector: '/../..//*[contains(@class,"file-row-share-status-action")][normalize-space(.)="%s"]',
       locateStrategy: 'xpath'
     }
   }

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -914,3 +914,16 @@ Then('user {string} should not have created any shares', async function (user) {
   const shares = await sharingHelper.getAllSharesSharedByUser(user)
   assert.strictEqual(shares.length, 0, 'There should not be any share, but there are')
 })
+
+Then('the following resources should have the following collaborators', async function (dataTable) {
+  for (const { fileName, expectedCollaborators } of dataTable.hashes()) {
+    const collaboratorsArray = await client
+      .page.FilesPageElement.filesList().getCollaboratorsForResource(fileName)
+
+    const expectedCollaboratorsArray = expectedCollaborators.split(',').map(s => s.trim())
+    assert.ok(
+      _.intersection(collaboratorsArray, expectedCollaboratorsArray).length === expectedCollaboratorsArray.length,
+      `Expected collaborators to be the same for "${fileName}": expected [` + expectedCollaboratorsArray.join(', ') + '] got [' + collaboratorsArray.join(', ') + ']'
+    )
+  }
+})


### PR DESCRIPTION
## Description
       
When sharing with multiple targets, they must all be listed there instead of a single entry. This is fixed by replacing the code that make share entries unique into an aggregation that has been inspired by the one used in OC core.
Also includes group shares and link shares now.
Added avatars and icons for the displayed collaborators in the column.

## Related Issue
Fixes https://github.com/owncloud/phoenix/issues/2924

## Motivation and Context
Just doing a bugfix was too boring, but also the column contents didn't look very nice, so adding avatars there was a good move IMO.

## How Has This Been Tested?
Manual test
Acceptance tests

## Screenshots (if appropriate):
### Shared with others
<img width="960" alt="image" src="https://user-images.githubusercontent.com/277525/75354565-742e4f80-58ad-11ea-852a-137c3a74bd00.png">

### Shared with you
<img width="960" alt="image" src="https://user-images.githubusercontent.com/277525/75354584-7ee8e480-58ad-11ea-8057-34173a490c8d.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [x] test first!!!
- [x] add test for the group cases
- [x] implement the actual fix
- [x] changelog
