### PR TITLE
Display decimals only for MB and higher

### DIFF
--- a/apps/files/src/mixins.js
+++ b/apps/files/src/mixins.js
@@ -11,11 +11,16 @@ export default {
       if (int < 0) {
         return ''
       }
+
       if (isNaN(int)) {
         return '?'
       }
+
+      const mb = 1048576
+
+      // TODO: Pass current language as locale to display correct separator
       return filesize(int, {
-        round: 2
+        round: int < mb ? 0 : 1
       })
     },
 

--- a/changelog/unreleased/2986
+++ b/changelog/unreleased/2986
@@ -1,0 +1,7 @@
+Enhancement: Display decimals in resource size column only for MBs or higher
+
+We've stopped displaying decimals in resource size column for sizes smaller than 1 MB.
+We've also started displaying only one decimal.
+
+https://github.com/owncloud/phoenix/issues/2986
+https://github.com/owncloud/phoenix/pull/3051


### PR DESCRIPTION
## Description
Display decimals in resource size column only for MBs or higher and display only once decimal instead of two.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #2986

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/25989331/74667105-02fee600-51a3-11ea-8fb3-b8fa845abb2e.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 