### PR TITLE
[Tests-only] Uploading a file with a name with same folder name exist

### DIFF
--- a/tests/acceptance/features/webUIUpload/uploadEdgecases.feature
+++ b/tests/acceptance/features/webUIUpload/uploadEdgecases.feature
@@ -101,7 +101,7 @@ Feature: File Upload
     And as "user1" the content of "simple-folder/0" should be the same as the local "0"
 
   @issue-3015
-  Scenario: Upload a file with a name with same folder name exist
+  Scenario: Upload a file with the same name as already existing folder
     Given the user has created folder "new-lorem.txt"
     And the user has reloaded the current page of the webUI
     When the user uploads overwriting file "new-lorem.txt" using the webUI

--- a/tests/acceptance/features/webUIUpload/uploadEdgecases.feature
+++ b/tests/acceptance/features/webUIUpload/uploadEdgecases.feature
@@ -100,8 +100,18 @@ Feature: File Upload
     Then file "0" should be listed on the webUI
     And as "user1" the content of "simple-folder/0" should be the same as the local "0"
 
-  @issue-2480
+  @issue-3015
   Scenario: Upload a file with a name with same folder name exist
-    Given the user has created folder "new.txt"
-    When the user uploads overwriting file "new.txt" using the webUI
-    #Then an error message "PUT is not allowed on non-files." should be visible
+    Given the user has created folder "new-lorem.txt"
+    And the user has reloaded the current page of the webUI
+    When the user uploads overwriting file "new-lorem.txt" using the webUI
+    Then the following error message should be displayed on the webUI
+      """
+      File upload failed…
+      PUT is not allowed on non-files.
+      """
+    # Then the following error message should be displayed on the webUI
+    #   """
+    #   (Any nice error message)
+    #   """
+

--- a/tests/acceptance/features/webUIUpload/uploadEdgecases.feature
+++ b/tests/acceptance/features/webUIUpload/uploadEdgecases.feature
@@ -99,3 +99,9 @@ Feature: File Upload
     And the user uploads a created file "0" using the webUI
     Then file "0" should be listed on the webUI
     And as "user1" the content of "simple-folder/0" should be the same as the local "0"
+
+  @issue-2480
+  Scenario: Upload a file with a name with same folder name exist
+    Given the user has created folder "new.txt"
+    When the user uploads overwriting file "new.txt" using the webUI
+    #Then an error message "PUT is not allowed on non-files." should be visible

--- a/tests/acceptance/stepDefinitions/generalContext.js
+++ b/tests/acceptance/stepDefinitions/generalContext.js
@@ -44,6 +44,13 @@ Then('the success/error message {string} should be displayed on the webUI', func
     .expect.element('@message').text.to.equal(message)
 })
 
+Then('the following success/error message should be displayed on the webUI', function (message) {
+  return client
+    .page.phoenixPage()
+    .waitForElementVisible('@messages')
+    .expect.element('@messages').text.to.equal(message)
+})
+
 Then('the error message {string} should be displayed on the webUI dialog prompt', function (message) {
   return client
     .page.phoenixPage()


### PR DESCRIPTION
## Description
Upload file when a folder with same name already exists

## Related Issue
https://github.com/owncloud/phoenix/issues/3015

## Motivation and Context
Bug reproduce for the issue https://github.com/owncloud/phoenix/issues/3015

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
