### PR TITLE
[Tests-Only] Refactored closeSidebar function from PO filesList to appSideBar

### DIFF
--- a/tests/acceptance/pageObjects/FilesPageElement/appSideBar.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/appSideBar.js
@@ -4,6 +4,22 @@ module.exports = {
       return this
         .waitForElementVisible(this.elements.sideBar)
         .waitForElementVisible(this.elements.sidebarThumbnail)
+    },
+    closeSidebar: function (timeout = null) {
+      if (timeout === null) {
+        timeout = this.api.globals.waitForConditionTimeout
+      } else {
+        timeout = parseInt(timeout, 10)
+      }
+      try {
+        this.click({
+          selector: '@sidebarCloseBtn',
+          timeout: timeout
+        })
+      } catch (e) {
+        // do nothing
+      }
+      return this.api.page.FilesPageElement.filesList()
     }
   },
   elements: {
@@ -12,6 +28,10 @@ module.exports = {
     },
     sidebarThumbnail: {
       selector: '.sidebar-title .oc-icon'
+    },
+    sidebarCloseBtn: {
+      selector: '//div[@class="sidebar-container"]//div[@class="action"]//button',
+      locateStrategy: 'xpath'
     }
   }
 }

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -222,22 +222,6 @@ module.exports = {
 
       return this.api.page.FilesPageElement.publicLinksDialog()
     },
-    closeSidebar: function (timeout = null) {
-      if (timeout === null) {
-        timeout = this.api.globals.waitForConditionTimeout
-      } else {
-        timeout = parseInt(timeout, 10)
-      }
-      try {
-        this.click({
-          selector: '@sidebarCloseBtn',
-          timeout: timeout
-        })
-      } catch (e) {
-        // do nothing
-      }
-      return this.api.page.FilesPageElement.filesList()
-    },
     /**
      *
      * @param {string} fromName
@@ -494,7 +478,8 @@ module.exports = {
       const resourceShareButtonXpath = resourceRowXpath + shareButtonXpath
       let isPresent = true
       await this
-        .closeSidebar(100)
+        .api.page.FilesPageElement.appSideBar().closeSidebar(100)
+      await this
         .api.elements(
           this.elements.shareButtonInFileRow.locateStrategy,
           resourceShareButtonXpath,
@@ -513,7 +498,7 @@ module.exports = {
     isSidebarTabPresent: async function (rowSelector, tabSelector) {
       let isPresent = true
       await this
-        .closeSidebar(100)
+        .api.page.FilesPageElement.appSideBar().closeSidebar(100)
         .useXpath()
         .click(rowSelector)
         .waitForElementVisible('@sidebar')
@@ -910,10 +895,6 @@ module.exports = {
     },
     linkToPublicLinksTag: {
       selector: '//div[@class="sidebar-container"]//a[normalize-space(.)="Links"]',
-      locateStrategy: 'xpath'
-    },
-    sidebarCloseBtn: {
-      selector: '//div[@class="sidebar-container"]//div[@class="action"]//button',
       locateStrategy: 'xpath'
     },
     sidebar: {

--- a/tests/acceptance/stepDefinitions/publicLinkContext.js
+++ b/tests/acceptance/stepDefinitions/publicLinkContext.js
@@ -10,7 +10,7 @@ When(
   'the user (tries to )create/creates a new public link for file/folder/resource {string} using the webUI',
   async function (resource) {
     await client.page.FilesPageElement
-      .filesList()
+      .appSideBar()
       .closeSidebar(100)
       .openPublicLinkDialog(resource)
     return client.page.FilesPageElement.publicLinksDialog()
@@ -23,7 +23,7 @@ When(
   async function (resource, settingsTable) {
     const settings = settingsTable.rowsHash()
     await client.page.FilesPageElement
-      .filesList()
+      .appSideBar()
       .closeSidebar(100)
       .openPublicLinkDialog(resource)
     return client.page.FilesPageElement.publicLinksDialog().addNewLink(settings)
@@ -103,7 +103,7 @@ When('the user edits the public link named {string} of file/folder/resource {str
   async function (linkName, resource, dataTable) {
     const editData = dataTable.rowsHash()
     await client.page.FilesPageElement
-      .filesList()
+      .appSideBar()
       .closeSidebar(100)
       .openPublicLinkDialog(resource)
     return client.page.FilesPageElement
@@ -115,7 +115,7 @@ When('the user edits the public link named {string} of file/folder/resource {str
   async function (linkName, resource, dataTable) {
     const editData = dataTable.rowsHash()
     await client.page.FilesPageElement
-      .filesList()
+      .appSideBar()
       .closeSidebar(100)
       .openPublicLinkDialog(resource)
     return client.page.FilesPageElement
@@ -127,7 +127,7 @@ When('the user edits the public link named {string} of file/folder/resource {str
 When('the user tries to edit expiration of the public link named {string} of file {string} to past date {string}',
   async function (linkName, resource, pastDate) {
     await client.page.FilesPageElement
-      .filesList()
+      .appSideBar()
       .closeSidebar(100)
       .openPublicLinkDialog(resource)
     const isDisabled = await client.page.FilesPageElement
@@ -143,7 +143,7 @@ When('the user removes the public link named {string} of file/folder/resource {s
   async function (linkName, resource) {
     await client.page
       .FilesPageElement
-      .filesList()
+      .appSideBar()
       .closeSidebar(100)
       .openPublicLinkDialog(resource)
     return client.page.FilesPageElement.publicLinksDialog()
@@ -163,7 +163,7 @@ Then('public link named {string} should not be listed on the public links list o
 
 async function findMatchingPublicLinkByName (name, role, resource, via = null) {
   await client.page.FilesPageElement
-    .filesList()
+    .appSideBar()
     .closeSidebar(100)
     .openPublicLinkDialog(resource)
 
@@ -208,13 +208,13 @@ Then('the user should see an error message on the public link share dialog sayin
 
 When('the user closes the public link details sidebar', function () {
   return client.page.FilesPageElement
-    .filesList()
+    .appSideBar()
     .closeSidebar(100)
 })
 
 When('the user copies the url of public link named {string} of file/folder/resource {string} using the webUI', async function (linkName, resource) {
   await client.page.FilesPageElement
-    .filesList()
+    .appSideBar()
     .closeSidebar(100)
     .openPublicLinkDialog(resource)
   return client.page.FilesPageElement.publicLinksDialog()

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -29,9 +29,10 @@ const userSharesFileOrFolderWithUserOrGroup = async function (
   const api = client.page
     .FilesPageElement
 
-  await api.filesList().closeSidebar(100)
-
-  await api.filesList().openSharingDialog(file)
+  await api
+    .appSideBar()
+    .closeSidebar(100)
+    .openSharingDialog(file)
 
   return api.sharingDialog().shareWithUserOrGroup(sharee, shareWithGroup, role, permissions, remote)
 }
@@ -466,9 +467,10 @@ When('the user sets custom permission for current role of collaborator {string} 
   const api = client.page
     .FilesPageElement
 
-  await api.filesList().closeSidebar(100)
-
-  await api.filesList().openSharingDialog(resource)
+  await api
+    .appSideBar()
+    .closeSidebar(100)
+    .openSharingDialog(resource)
 
   return api.sharingDialog().changeCustomPermissionsTo(user, permissions)
 })
@@ -477,9 +479,10 @@ When('the user disables all the custom permissions of collaborator {string} for 
   const api = client.page
     .FilesPageElement
 
-  await api.filesList().closeSidebar(100)
-
-  await api.filesList().openSharingDialog(resource)
+  await api
+    .appSideBar()
+    .closeSidebar(100)
+    .openSharingDialog(resource)
 
   return api.sharingDialog().disableAllCustomPermissions(collaborator)
 })
@@ -510,7 +513,7 @@ Then('custom permission/permissions {string} should be set for user {string} for
   async function (permissions, user, resource) {
     await client.page
       .FilesPageElement
-      .filesList()
+      .appSideBar()
       .closeSidebar(100)
       .openSharingDialog(resource)
     const currentSharePermissions = await client.page.FilesPageElement.sharingDialog()
@@ -522,7 +525,7 @@ Then('custom permission/permissions {string} should be set for user {string} for
 Then('no custom permissions should be set for collaborator {string} for file/folder {string} on the webUI', async function (user, resource) {
   await client.page
     .FilesPageElement
-    .filesList()
+    .appSideBar()
     .closeSidebar(100)
     .openSharingDialog(resource)
   const currentSharePermissions = await client.page.FilesPageElement.sharingDialog()
@@ -711,8 +714,10 @@ When(
   'the user changes the collaborator role of {string} for file/folder {string} to {string} using the webUI',
   async function (collaborator, resource, newRole) {
     const api = client.page.FilesPageElement
-
-    await api.filesList().openSharingDialog(resource)
+    await api
+      .appSideBar()
+      .closeSidebar(100)
+      .openSharingDialog(resource)
 
     return api.sharingDialog().changeCollaboratorRole(collaborator, newRole)
   }
@@ -744,13 +749,11 @@ Then('user {string} should be listed without additional info in the collaborator
 })
 
 Then('user {string} should be listed as {string} in the collaborators list for file/folder/resource {string} on the webUI', async function (user, role, resource) {
-  const api = client.page
+  await client.page
     .FilesPageElement
-    .filesList()
-
-  await api.closeSidebar(100)
-
-  await api.openSharingDialog(resource)
+    .appSideBar()
+    .closeSidebar(100)
+    .openSharingDialog(resource)
 
   return assertCollaboratorslistContains('user', user, role)
 })
@@ -764,13 +767,11 @@ Then('group {string} should be listed as {string} via {string} in the collaborat
 })
 
 Then('group {string} should be listed as {string} in the collaborators list for file/folder/resource {string} on the webUI', async function (group, role, resource) {
-  const api = client.page
+  await client.page
     .FilesPageElement
-    .filesList()
-
-  await api.closeSidebar(100)
-
-  await api.openSharingDialog(resource)
+    .appSideBar()
+    .closeSidebar(100)
+    .openSharingDialog(resource)
 
   return assertCollaboratorslistContains('group', group, role)
 })
@@ -806,7 +807,7 @@ Then('user {string} should have a share with these details:', function (user, ex
 Then('the user should not be able to share file/folder/resource {string} using the webUI', async function (resource) {
   await client.page
     .FilesPageElement
-    .filesList()
+    .appSideBar()
     .closeSidebar(100)
     .openSharingDialog(resource)
   const shareResponse = await client.page.FilesPageElement.sharingDialog()
@@ -823,10 +824,10 @@ Then('the user should not be able to share file/folder/resource {string} using t
 
 Then('the collaborators list for file/folder/resource {string} should be empty', async function (resource) {
   const api = client.page.FilesPageElement
-
-  await api.filesList().closeSidebar(100)
-
-  await api.filesList().openSharingDialog(resource)
+  await api
+    .appSideBar()
+    .closeSidebar(100)
+    .openSharingDialog(resource)
 
   const count = (await api
     .sharingDialog()


### PR DESCRIPTION
## Description
Function `closeSidebar()` is moved into appSideBar PageObject

## Related Issue
- Part of #2677

## Motivation and Context
appropriate placements for different PO methods and elements

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...