### PR TITLE
[Tests-Only] Acceptance test for deleting file from search list

### DIFF
--- a/tests/acceptance/features/webUIFiles/search.feature
+++ b/tests/acceptance/features/webUIFiles/search.feature
@@ -153,3 +153,16 @@ Feature: Search
     And the user searches for "favorite" using the webUI
     Then folder "favorite folder" should be listed on the webUI
     And folder "not favorite folder" should be listed on the webUI
+
+  @issue-3044
+  Scenario: Delete file from search list
+    Given the following files have been deleted by user "user1"
+      | name          |
+      | lorem-big.txt |
+    And user "user1" has uploaded file with content "uploaded content" to "lorem-big.txt"
+    When the user searches for "lorem-big" using the webUI
+    And the user deletes file "lorem-big.txt" using the webUI
+    Then file "lorem-big.txt" should be listed on the webUI
+    #Then file "lorem-big.txt" should not be listed on the webUI
+    And as "user1" file "lorem-big.txt" should not exist
+    And as "user1" the file with original path "lorem-big.txt" should exist in trash


### PR DESCRIPTION
## Description
Search a file in 'All Files' that has same name as a deleted file in trashbin 

## Related Issue
#3044 

## Motivation and Context
- Bug reproduced for issue https://github.com/owncloud/phoenix/issues/3044
- To search for a file in 'All Files' and delete it, which has same name as a deleted file in trashbin. 

## How Has This Been Tested?
- :robot:  

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

