### PR TITLE
[Tests-Only] Moved isSidebarLinksTabPresent command into appSideBar

### DIFF
--- a/tests/acceptance/pageObjects/FilesPageElement/appSideBar.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/appSideBar.js
@@ -20,6 +20,42 @@ module.exports = {
         // do nothing
       }
       return this.api.page.FilesPageElement.filesList()
+    },
+    /**
+     * checks if the given tabs are present on the files-page-sidebar
+     *
+     * @param {string} tabSelectorXpath
+     * @returns {Promise<boolean>}
+     */
+    isTabPresentOnCurrentSidebar: async function (tabSelectorXpath) {
+      let isPresent = true
+      await this
+        .useXpath()
+        .waitForElementVisible('@sideBar') // sidebar is expected to be opened and visible
+        .api.elements(
+          'xpath',
+          tabSelectorXpath,
+          (result) => {
+            isPresent = result.value.length > 0
+          })
+        .useCss()
+      return isPresent
+    },
+    /**
+     * @returns {Promise<boolean>}
+     */
+    isLinksTabPresentOnCurrentSidebar: function () {
+      return this.isTabPresentOnCurrentSidebar(
+        this.elements.sidebarLinksTab.selector
+      )
+    },
+    /**
+     * @returns {Promise<boolean>}
+     */
+    isCollaboratorsTabPresentOnCurrentSidebar: function () {
+      return this.isTabPresentOnCurrentSidebar(
+        this.elements.sidebarCollaboratorsTab.selector
+      )
     }
   },
   elements: {
@@ -31,6 +67,14 @@ module.exports = {
     },
     sidebarCloseBtn: {
       selector: '//div[@class="sidebar-container"]//div[@class="action"]//button',
+      locateStrategy: 'xpath'
+    },
+    sidebarLinksTab: {
+      selector: '//div[@class="sidebar-container"]//a[contains(text(),"Links")]',
+      locateStrategy: 'xpath'
+    },
+    sidebarCollaboratorsTab: {
+      selector: '//div[@class="sidebar-container"]//a[contains(text(),"Collaborators")]',
       locateStrategy: 'xpath'
     }
   }

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -54,7 +54,7 @@ module.exports = {
       return this.initAjaxCounters()
         .useXpath()
         .waitForElementVisible(fileActionsBtnSelector)
-        .click(fileActionsBtnSelector)
+        .angryClick(fileActionsBtnSelector)
         .waitForElementVisible(btnSelector)
         .click(btnSelector)
         .useCss()
@@ -190,6 +190,7 @@ module.exports = {
      * @param {string} fileName
      */
     openSharingDialog: async function (fileName, targetTab = 'collaborators') {
+      const sidebarLinksTabXpath = this.api.page.FilesPageElement.appSideBar().elements.sidebarLinksTab.selector
       await this.waitForFileVisible(fileName)
 
       await this
@@ -200,11 +201,23 @@ module.exports = {
 
       if (targetTab === 'links') {
         await this
-          .waitForElementVisible('@sidebarLinksTab')
-          .click('@sidebarLinksTab')
+          .useXpath()
+          .waitForElementVisible(sidebarLinksTabXpath)
+          .click(sidebarLinksTabXpath)
+          .useCss()
       }
 
       return this.api.page.FilesPageElement.sharingDialog()
+    },
+    /**
+     * opens sidebar for given resource
+     *
+     * @param {string} resource
+     * @returns {*}
+     */
+    openSideBar: async function (resource) {
+      await this.clickRow(resource)
+      return this.api.page.FilesPageElement.appSideBar()
     },
     /**
      *
@@ -504,51 +517,6 @@ module.exports = {
       return isPresent
     },
     /**
-     * checks if the given tabs are present on the files-page-sidebar
-     *
-     * @param {string} rowSelector xpath for given resource row selector
-     * @param {string} tabSelector xpath for given tab
-     * @returns {Promise<boolean>}
-     */
-    isSidebarTabPresent: async function (rowSelector, tabSelector) {
-      let isPresent = true
-      await this
-        .api.page.FilesPageElement.appSideBar().closeSidebar(100)
-        .useXpath()
-        .click(rowSelector)
-        .waitForElementVisible('@sidebar')
-        .api.elements(
-          'xpath',
-          tabSelector,
-          (result) => {
-            isPresent = result.value.length > 0
-          })
-        .useCss()
-      return isPresent
-    },
-    /**
-     *
-     * @param {string} fileName
-     * @returns {Promise<boolean>}
-     */
-    isSidebarLinksTabPresent: function (fileName) {
-      return this.isSidebarTabPresent(
-        this.getFileRowSelectorByFileName(fileName),
-        this.elements.sidebarLinksTab.selector
-      )
-    },
-    /**
-     *
-     * @param {string} fileName
-     * @returns {Promise<boolean>}
-     */
-    isSidebarCollaboratorsTabPresent: function (fileName) {
-      return this.isSidebarTabPresent(
-        this.getFileRowSelectorByFileName(fileName),
-        this.elements.sidebarCollaboratorsTab.selector
-      )
-    },
-    /**
      * returns the disabled state of given action
      *
      * @param {string} action
@@ -621,16 +589,22 @@ module.exports = {
       })
     },
     copyPrivateLink: function () {
+      const appSideBar = this.api.page.FilesPageElement.appSideBar()
+      const sidebarLinksTabXpath = appSideBar.elements.sidebarLinksTab.selector
+      const sidebarCss = appSideBar.elements.sideBar.selector
+
       return this
-        .waitForElementVisible('@sidebar')
-        .waitForElementVisible('@sidebarLinksTab')
-        .click('@sidebarLinksTab')
+        .waitForElementVisible(sidebarCss)
+        .useXpath()
+        .waitForElementVisible(sidebarLinksTabXpath)
+        .click(sidebarLinksTabXpath)
         .waitForElementVisible('@sidebarPrivateLinkLabel')
         .click('@sidebarPrivateLinkLabel')
         .waitForElementNotPresent('@sidebarPrivateLinkLabel')
         .waitForElementVisible('@sidebarPrivateLinkIconCopied')
         .waitForElementNotPresent('@sidebarPrivateLinkIconCopied')
         .waitForElementVisible('@sidebarPrivateLinkLabel')
+        .useCss()
     },
     deleteImmediately: async function (fileName) {
       await this.waitForFileVisible(fileName)
@@ -912,22 +886,11 @@ module.exports = {
       selector: '//div[@class="sidebar-container"]//a[normalize-space(.)="Links"]',
       locateStrategy: 'xpath'
     },
-    sidebar: {
-      selector: '#files-sidebar'
-    },
     sidebarPrivateLinkLabel: {
       selector: '#files-sidebar-private-link-label'
     },
     sidebarPrivateLinkIconCopied: {
       selector: '#files-sidebar-private-link-icon-copied'
-    },
-    sidebarLinksTab: {
-      selector: '//div[@class="sidebar-container"]//a[contains(text(),"Links")]',
-      locateStrategy: 'xpath'
-    },
-    sidebarCollaboratorsTab: {
-      selector: '//div[@class="sidebar-container"]//a[contains(text(),"Collaborators")]',
-      locateStrategy: 'xpath'
     },
     versionsElement: {
       selector: '//div//a[normalize-space(.)="Versions"]',

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -46,6 +46,8 @@ module.exports = {
      *
      * @param {string} fileName
      * @param {string} action delete|share|rename|download
+
+     * @throws Error
      * @returns {*}
      */
     performFileAction: function (fileName, action, elementType = 'file') {
@@ -53,8 +55,13 @@ module.exports = {
         this.getFileRowButtonSelectorsByFileName(fileName, action, elementType)
       return this.initAjaxCounters()
         .useXpath()
-        .waitForElementVisible(fileActionsBtnSelector)
-        .angryClick(fileActionsBtnSelector)
+        .waitForElementVisible(fileActionsBtnSelector, (result) => {
+          if (!result.value) {
+            throw new Error('Expected: File action button to be visible but found:' +
+              result.value.toString())
+          }
+        })
+        .click(fileActionsBtnSelector)
         .waitForElementVisible(btnSelector)
         .click(btnSelector)
         .useCss()

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -539,26 +539,21 @@ When('the user shares file/folder/resource {string} with group {string} as {stri
 When('the user shares file/folder/resource {string} with remote user {string} as {string} using the webUI', userSharesFileOrFolderWithRemoteUser)
 
 Then('it should not be possible to share file/folder {string} using the webUI', async function (resource) {
-  const state = await client.page
-    .FilesPageElement
-    .filesList()
-    .isSharingBtnPresent(resource)
+  const appSideBar = client.page.FilesPageElement.appSideBar()
+  const filesList = client.page.FilesPageElement.filesList()
+  // assumes current webUI state as no sidebar open for any resource
+  const state = await filesList.isSharingBtnPresent(resource)
   assert.ok(
     !state,
     `Error: Sharing button for resource ${resource} is not in disabled state`
   )
-  const sidebarLinkTabState = await client.page
-    .FilesPageElement
-    .filesList()
-    .isSidebarLinksTabPresent(resource)
+  await filesList.openSideBar(resource)
+  const sidebarLinkTabState = await appSideBar.isLinksTabPresentOnCurrentSidebar()
   assert.ok(
     !sidebarLinkTabState,
     `Error: Sidebar 'Links' tab for resource ${resource} is present`
   )
-  const sidebarCollaboratorsTabState = await client.page
-    .FilesPageElement
-    .filesList()
-    .isSidebarCollaboratorsTabPresent(resource)
+  const sidebarCollaboratorsTabState = await appSideBar.isCollaboratorsTabPresentOnCurrentSidebar()
   assert.ok(
     !sidebarCollaboratorsTabState,
     `Error: Sidebar 'Collaborators' tab for resource ${resource} is present`


### PR DESCRIPTION
## Description
Function `isSidebarTabPresent` and related methods/elements are moved into appSideBar PageObject

## Related Issue
- Part of #2677

## Motivation and Context
Appropriate placements for different PO methods and elements

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...