### PR TITLE
[Tests-Only] Refactored copyPrivateLink command into publicLinksDialog

### DIFF
--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -558,30 +558,11 @@ module.exports = {
       }
       return visible
     },
-    copyPrivateLink: function () {
-      const appSideBar = this.api.page.FilesPageElement.appSideBar()
-      const sidebarLinksTabXpath = appSideBar.elements.sidebarLinksTab.selector
-      const sidebarCss = appSideBar.elements.sideBar.selector
-
-      return this
-        .waitForElementVisible(sidebarCss)
-        .useXpath()
-        .waitForElementVisible(sidebarLinksTabXpath)
-        .click(sidebarLinksTabXpath)
-        .waitForElementVisible('@sidebarPrivateLinkLabel')
-        .click('@sidebarPrivateLinkLabel')
-        .waitForElementNotPresent('@sidebarPrivateLinkLabel')
-        .waitForElementVisible('@sidebarPrivateLinkIconCopied')
-        .waitForElementNotPresent('@sidebarPrivateLinkIconCopied')
-        .waitForElementVisible('@sidebarPrivateLinkLabel')
-        .useCss()
-    },
     deleteImmediately: async function (fileName) {
       await this.waitForFileVisible(fileName)
       await this
         .performFileAction(fileName, FileAction.deleteImmediately)
         .confirmDeletion()
-
       return this
     },
     countFilesAndFolders: async function () {
@@ -842,12 +823,6 @@ module.exports = {
     linkToPublicLinksTag: {
       selector: '//div[@class="sidebar-container"]//a[normalize-space(.)="Links"]',
       locateStrategy: 'xpath'
-    },
-    sidebarPrivateLinkLabel: {
-      selector: '#files-sidebar-private-link-label'
-    },
-    sidebarPrivateLinkIconCopied: {
-      selector: '#files-sidebar-private-link-icon-copied'
     },
     collaboratorsList: {
       selector: '.files-collaborators-lists'

--- a/tests/acceptance/pageObjects/FilesPageElement/publicLinksDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/publicLinksDialog.js
@@ -460,6 +460,24 @@ module.exports = {
       return this
         .waitForElementVisible(copyBtnSelector)
         .click(copyBtnSelector)
+    },
+    copyPrivateLink: function () {
+      const appSideBarElements = this.api.page.FilesPageElement.appSideBar().elements
+      const sidebarLinksTabXpath = appSideBarElements.sidebarLinksTab.selector
+      const sidebarCss = appSideBarElements.sideBar.selector
+
+      return this
+        .waitForElementVisible(sidebarCss)
+        .useXpath()
+        .waitForElementVisible(sidebarLinksTabXpath)
+        .click(sidebarLinksTabXpath)
+        .waitForElementVisible('@sidebarPrivateLinkLabel')
+        .click('@sidebarPrivateLinkLabel')
+        .waitForElementNotPresent('@sidebarPrivateLinkLabel')
+        .waitForElementVisible('@sidebarPrivateLinkIconCopied')
+        .waitForElementNotPresent('@sidebarPrivateLinkIconCopied')
+        .waitForElementVisible('@sidebarPrivateLinkLabel')
+        .useCss()
     }
   },
   elements: {
@@ -579,6 +597,12 @@ module.exports = {
     dateTimeCancelButton: {
       selector: '//div[@class="vdatetime-popup__actions"]/div[.="Cancel"]',
       locateStrategy: 'xpath'
+    },
+    sidebarPrivateLinkLabel: {
+      selector: '#files-sidebar-private-link-label'
+    },
+    sidebarPrivateLinkIconCopied: {
+      selector: '#files-sidebar-private-link-icon-copied'
     }
   }
 }

--- a/tests/acceptance/stepDefinitions/privateLinksContext.js
+++ b/tests/acceptance/stepDefinitions/privateLinksContext.js
@@ -3,11 +3,10 @@ const { When } = require('cucumber')
 const webdav = require('../helpers/webdavHelper')
 
 When('the user copies the private link of the file/folder {string} using the webUI', async function (resource) {
-  const api = client.page.FilesPageElement.filesList()
-  await api
-    .clickRow(resource)
+  const api = client.page.FilesPageElement
+  await api.filesList().clickRow(resource)
 
-  return api.copyPrivateLink()
+  return api.publicLinksDialog().copyPrivateLink()
 })
 
 When('the user navigates to the copied private/public link using the webUI', function () {


### PR DESCRIPTION
## Description
Function `copyPrivateLink()` with related methods/elements are moved from filesList to publicLinksDialog pageObject

## Related Issue
- Part of #2677

## Motivation and Context
Appropriate placements for different PO methods and elements

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...