### PR TITLE
[Tests-Only] Created versionsPanel PO & moved related commands/elements

### DIFF
--- a/tests/acceptance/pageObjects/FilesPageElement/appSideBar.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/appSideBar.js
@@ -5,6 +5,14 @@ module.exports = {
         .waitForElementVisible(this.elements.sideBar)
         .waitForElementVisible(this.elements.sidebarThumbnail)
     },
+    /**
+     * @returns {*}
+     */
+    openVersionsTab: function () {
+      return this
+        .waitForElementVisible('@sidebarVersionsTab')
+        .click('@sidebarVersionsTab')
+    },
     closeSidebar: function (timeout = null) {
       if (timeout === null) {
         timeout = this.api.globals.waitForConditionTimeout
@@ -75,6 +83,10 @@ module.exports = {
     },
     sidebarCollaboratorsTab: {
       selector: '//div[@class="sidebar-container"]//a[contains(text(),"Collaborators")]',
+      locateStrategy: 'xpath'
+    },
+    sidebarVersionsTab: {
+      selector: '//div//a[normalize-space(.)="Versions"]',
       locateStrategy: 'xpath'
     }
   }

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -319,12 +319,11 @@ module.exports = {
      */
     clickRow: async function (item) {
       await this.waitForFileVisible(item)
-
       await this.initAjaxCounters()
         .useXpath()
         // click in empty space in the tr using coordinates to avoid
         // clicking on other elements that might be in the front
-        .clickElementAt(this.getFileRowSelectorByFileName(item), 0, 0)
+        .clickElementAt(this.getFileRowSelectorByFileName(item), 1, 1)
         .waitForOutstandingAjaxCalls()
         .useCss()
 
@@ -582,19 +581,6 @@ module.exports = {
       await this
         .performFileAction(fileName, FileAction.deleteImmediately)
         .confirmDeletion()
-
-      return this
-    },
-    getVersions: async function (filename) {
-      const formattedFileRow = this.getFileRowSelectorByFileName(filename)
-
-      await this.waitForFileVisible(filename)
-
-      await this
-        .useXpath()
-        .click(formattedFileRow)
-        .waitForElementVisible('@versionsElement')
-        .click('@versionsElement')
 
       return this
     },
@@ -862,10 +848,6 @@ module.exports = {
     },
     sidebarPrivateLinkIconCopied: {
       selector: '#files-sidebar-private-link-icon-copied'
-    },
-    versionsElement: {
-      selector: '//div//a[normalize-space(.)="Versions"]',
-      locateStrategy: 'xpath'
     },
     collaboratorsList: {
       selector: '.files-collaborators-lists'

--- a/tests/acceptance/pageObjects/FilesPageElement/versionsDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/versionsDialog.js
@@ -1,0 +1,37 @@
+module.exports = {
+  commands: {
+    /**
+     * @returns {Promise<number>}
+     */
+    getVersionsCount: async function () {
+      let count = 0
+      await this
+        .api.elements(
+          '@versionsList',
+          function (result) {
+            count = result.value.length
+          })
+      return count
+    },
+    /**
+     * @returns {*}
+     */
+    restoreToPreviousVersion: function () {
+      return this
+        .initAjaxCounters()
+        .waitForElementVisible('@restorePreviousVersion')
+        .click('@restorePreviousVersion')
+        .waitForOutstandingAjaxCalls()
+    }
+  },
+  elements: {
+    versionsList: {
+      selector: '//div[@id="oc-file-versions-sidebar"]//tr[@class="file-row"]',
+      locateStrategy: 'xpath'
+    },
+    restorePreviousVersion: {
+      selector: '(//div[contains(@id,"oc-file-versions")]//tbody/tr[@class="file-row"])[1]//button[1]',
+      locateStrategy: 'xpath'
+    }
+  }
+}

--- a/tests/acceptance/pageObjects/filesPage.js
+++ b/tests/acceptance/pageObjects/filesPage.js
@@ -271,23 +271,6 @@ module.exports = {
     },
     checkForButtonDisabled: function () {
       return this.waitForElementVisible('@createFileOkButtonDisabled')
-    },
-    getVersionsCount: async function () {
-      let count = 0
-      await this
-        .api.elements(
-          '@versionsList',
-          function (result) {
-            count = result.value.length
-          })
-      return count
-    },
-    restoreToPreviousVersion: function () {
-      return this
-        .initAjaxCounters()
-        .waitForElementVisible('@restorePreviousVersion')
-        .click('@restorePreviousVersion')
-        .waitForOutstandingAjaxCalls()
     }
   },
   elements: {
@@ -394,14 +377,6 @@ module.exports = {
     },
     createFileOkButtonDisabled: {
       selector: "//div[@id='new-file-dialog']//button[@disabled='disabled']/span[contains(text(), 'Ok')]",
-      locateStrategy: 'xpath'
-    },
-    versionsList: {
-      selector: '//div[@id="oc-file-versions-sidebar"]//tr[@class="file-row"]',
-      locateStrategy: 'xpath'
-    },
-    restorePreviousVersion: {
-      selector: '(//div[contains(@id,"oc-file-versions")]//tbody/tr[@class="file-row"])[1]//button[1]',
       locateStrategy: 'xpath'
     },
     tabsInSideBar: {

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -123,8 +123,14 @@ Given('user {string} has uploaded file with content {string} to {string}', async
   await webdav.uploadFileWithContent(user, content, filename)
 })
 
-When('the user browses to display the {string} details of file {string}', function (versions, filename) {
-  return client.page.FilesPageElement.filesList().getVersions(filename)
+When('the user browses to display the {string} details of file {string}', async function (versions, filename) {
+  const api = client.page.FilesPageElement
+  await api
+    .filesList()
+    .clickRow(filename)
+  api.appSideBar()
+    .openVersionsTab()
+  return client
 })
 
 Given('user {string} has moved file/folder {string} to {string}', function (user, fromName, toName) {
@@ -395,15 +401,20 @@ Then('the deleted elements should not be listed on the webUI after a page reload
 })
 
 Then('the versions list should contain {int} entries', async function (expectedNumber) {
-  const count = await client.page.filesPage().getVersionsCount()
+  const count = await client.page.FilesPageElement.versionsDialog().getVersionsCount()
   return assert.strictEqual(
     expectedNumber, count
   )
 })
 
 Then('the versions list for resource {string} should contain {int} entry/entries', async function (resourceName, expectedNumber) {
-  await client.page.FilesPageElement.filesList().getVersions(resourceName)
-  const count = await client.page.filesPage().getVersionsCount()
+  const api = client.page.FilesPageElement
+  await api
+    .filesList()
+    .clickRow(resourceName)
+  api.appSideBar()
+    .openVersionsTab()
+  const count = await api.versionsDialog().getVersionsCount()
 
   assert.strictEqual(
     expectedNumber, count
@@ -423,7 +434,7 @@ Then('the content of file {string} for user {string} should be {string}', async 
 })
 
 When('the user restores the file to last version using the webUI', function () {
-  return client.page.filesPage().restoreToPreviousVersion()
+  return client.page.FilesPageElement.versionsDialog().restoreToPreviousVersion()
 }
 )
 


### PR DESCRIPTION
## Description
1. Separate page-object for versions dialog box is created
2. related commands/elements are placed in versionsDialog

## Related Issue
- Part of #2677

## Motivation and Context
Appropriate placements for different PO methods and elements

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :rabbit: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...