### PR TITLE
[Tests-Only]Unskip test for copy permalinks

### DIFF
--- a/tests/acceptance/features/webUIFiles/copyPrivateLinks.feature
+++ b/tests/acceptance/features/webUIFiles/copyPrivateLinks.feature
@@ -1,7 +1,6 @@
-@skip
-Feature: copy current path as a permanent link
+Feature: copy path as a permanent link
   As a user
-  I want to copy the permanent link to the current folder
+  I want to copy the permanent link of a resource
   So that I can share it with other users
 
   Background:
@@ -10,10 +9,9 @@ Feature: copy current path as a permanent link
     And the user has browsed to the files page
 
   Scenario Outline: Copy permalink to clipboard
-    When the user browses to the folder <folder_name> on the files page
-    And the user copies the permalink of the current folder using the webUI
-    Then the clipboard content should match permalink of resource <folder_name>
+    When the user copies the permalink of the resource <resource_name> using the webUI
+    Then the clipboard content should match permalink of resource <resource_name>
     Examples:
-      | folder_name     |
-      | "/"             |
+      | resource_name   |
+      | "lorem.txt"     |
       | "simple-folder" |

--- a/tests/acceptance/pageObjects/filesPage.js
+++ b/tests/acceptance/pageObjects/filesPage.js
@@ -310,7 +310,7 @@ module.exports = {
       locateStrategy: 'xpath'
     },
     permalinkCopyButton: {
-      selector: '#files-permalink-copy'
+      selector: '#files-sidebar-private-link-label'
     },
     breadcrumb: {
       selector: '#files-breadcrumb li:nth-of-type(2)'

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -784,8 +784,10 @@ When('the user browses to the folder {string} on the files page', (folderName) =
     .page.filesPage()
     .navigateAndWaitTillLoaded(targetFolder)
 })
-When('the user copies the permalink of the current folder using the webUI', function () {
-  return client.page.filesPage().copyPermalinkFromFilesAppBar()
+When('the user copies the permalink of the file/folder/resource {string} using the webUI', async function (file) {
+  await client.page.FilesPageElement.filesList().openSharingDialog(file, 'links')
+  await client.page.filesPage().copyPermalinkFromFilesAppBar()
+  return client
 })
 Then('the clipboard content should match permalink of resource {string}', async function (folderName) {
   const folderData = await webdav.getProperties(folderName, client.globals.currentUser, ['oc:privatelink'])

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -698,7 +698,7 @@ When('the user opens the share dialog for file/folder/resource {string} using th
 })
 
 When('the user opens the link share dialog for file/folder/resource {string} using the webUI', function (file) {
-  return client.page.FilesPageElement.filesList().openSharingDialog(file, 'link')
+  return client.page.FilesPageElement.filesList().openSharingDialog(file, 'links')
 })
 
 When('the user deletes {string} as collaborator for the current file/folder using the webUI', function (user) {


### PR DESCRIPTION
## Description
Acceptance test for 'copy current path as a permanent link' which was previously under skip tag has been unskipped.

## Related Issue
Fixes issue https://github.com/owncloud/phoenix/issues/3072

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
