### PR TITLE
[Tests-Only] Added pageObject for fileActionsMenu

### DIFF
--- a/tests/acceptance/pageObjects/FilesPageElement/fileActionsMenu.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/fileActionsMenu.js
@@ -1,0 +1,206 @@
+module.exports = {
+  commands: {
+    /**
+     * @enum {string}
+     * @readonly
+     */
+    FileAction: Object.freeze({
+      download: 'download',
+      delete: 'delete',
+      restore: 'restore',
+      share: 'share',
+      rename: 'rename',
+      deleteImmediately: 'deleteImmediately'
+    }),
+
+    /**
+     * Action button selector
+     *
+     * @param {string} action
+     * @returns {string}
+     */
+    getActionSelector: function (action) {
+      const actionsDropdownSelector = this.elements.itemActionsDropdown.selector
+      const actionSelector = this.elements[action + 'ButtonInFileRow'].selector
+
+      return `${actionsDropdownSelector}${actionSelector}`
+    },
+    /**
+     * perform one of the main file actions
+     *
+     * @param {string} action delete|share|rename|download
+
+     * @throws Error
+     * @returns {*}
+     */
+    performFileAction: function (action) {
+      const fileActionBtnSelectorXpath = this.getActionSelector(action)
+      return this
+        .useXpath()
+        .waitForElementVisible(fileActionBtnSelectorXpath)
+        .click(fileActionBtnSelectorXpath)
+        .useCss()
+    },
+    /**
+     * returns the disabled state of given action
+     *
+     * @param {string} action
+     * @returns {Promise<boolean>}
+     */
+    getActionDisabledAttr: async function (action) {
+      let disabledState
+      const btnSelector = this.getActionSelector(action)
+      await this
+        .api.element('xpath', btnSelector, result => {
+          // action is disabled when not visible in dropdown menu
+          disabledState = result.status === -1
+        })
+
+      return disabledState
+    },
+    /**
+     * deletes resource using fileActions 'delete' button
+     * @returns {Promise<*>}
+     */
+    delete: async function () {
+      this.performFileAction(this.FileAction.delete)
+      await this.api.page.FilesPageElement.filesList().confirmDeletion()
+      return this
+    },
+    /**
+     * @param {string} toName
+     * @param {boolean} expectToSucceed
+     * @return {*}
+     */
+    rename: async function (toName, expectToSucceed = true) {
+      await this.initAjaxCounters()
+        .useXpath()
+        .performFileAction(this.FileAction.rename)
+        .waitForElementVisible('@renameFileConfirmationBtn')
+        .waitForAnimationToFinish()
+        .clearValue('@renameFileInputField')
+        .setValue('@renameFileInputField', toName)
+        .click('@renameFileConfirmationBtn')
+        .waitForOutstandingAjaxCalls()
+        .useCss()
+
+      if (expectToSucceed) {
+        await this.waitForElementNotVisible('@renameFileConfirmationDialog')
+      }
+
+      return this
+    },
+    /**
+     * opens sharing dialog for given resource
+     * assumes filesAction menu for the resource to be opened
+     * @return {*}
+     */
+    openCollaboratorsDialog: function () {
+      const api = this.api.page.FilesPageElement
+      api.appSideBar().closeSidebar(500)
+      this
+        .useXpath()
+        .performFileAction(this.FileAction.share)
+        .waitForElementVisible('@sharingSideBar')
+        .useCss()
+      return api.sharingDialog()
+    },
+    /**
+     * checks whether sharing button of given file-row is present
+     *
+     * @returns {Promise<boolean>}
+     */
+    isSharingBtnPresent: async function () {
+      const shareButtonXpath = this.elements.shareButtonInFileRow.selector
+      let isPresent = true
+      await this
+        .api.page.FilesPageElement.appSideBar().closeSidebar(100)
+      await this
+        .api.elements(
+          this.elements.shareButtonInFileRow.locateStrategy,
+          shareButtonXpath,
+          (result) => {
+            isPresent = result.value.length > 0
+          })
+      return isPresent
+    },
+    /**
+     * @return {Promise<module.exports.commands>}
+     */
+    restore: async function () {
+      await this
+        .initAjaxCounters()
+        .useXpath()
+        .performFileAction(this.FileAction.restore)
+        .waitForOutstandingAjaxCalls()
+        .useCss()
+      return this
+    },
+    /**
+     * @return {Promise<module.exports.commands>}
+     */
+    download: async function () {
+      await this
+        .initAjaxCounters()
+        .performFileAction(this.FileAction.download)
+        .waitForOutstandingAjaxCalls()
+      return this
+    },
+    /**
+     * @return {Promise<module.exports.commands>}
+     */
+    deleteResourceImmediately: async function () {
+      this.performFileAction(this.FileAction.deleteImmediately)
+      await this.api.page.FilesPageElement.filesList().confirmDeletion()
+
+      return this
+    }
+  },
+  elements: {
+    sharingSideBar: {
+      selector: '#oc-files-sharing-sidebar'
+    },
+    itemActionsDropdown: {
+      selector: '//div[@id="files-list-row-actions-dropdown"]',
+      locateStrategy: 'xpath'
+    },
+    deleteButtonInFileRow: {
+      selector: '//button[@aria-label="Delete"]',
+      locateStrategy: 'xpath'
+    },
+    downloadButtonInFileRow: {
+      selector: '//button[@aria-label="Download"]',
+      locateStrategy: 'xpath'
+    },
+    restoreButtonInFileRow: {
+      selector: '//button[@aria-label="Restore"]',
+      locateStrategy: 'xpath'
+    },
+    renameFileConfirmationDialog: {
+      selector: '#change-file-dialog'
+    },
+    renameButtonInFileRow: {
+      selector: '//button[@aria-label="Rename"]',
+      locateStrategy: 'xpath'
+    },
+    renameFileInputField: {
+      selector: '//div[@id="change-file-dialog"]//input',
+      locateStrategy: 'xpath'
+    },
+    renameFileConfirmationBtn: {
+      selector: '#oc-dialog-rename-confirm'
+    },
+    fileActionsButtonInFileRow: {
+      selector: '//button[contains(@class, "files-list-row-show-actions")]',
+      locateStrategy: 'xpath'
+    },
+    shareButtonInFileRow: {
+      selector: '//button[@aria-label="Collaborators"]',
+      locateStrategy: 'xpath'
+    },
+    deleteImmediatelyButtonInFileRow: {
+      selector: '//button[@aria-label="Delete"]',
+      locateStrategy: 'xpath'
+    }
+  }
+}

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -3,83 +3,138 @@ const path = require('path')
 const xpathHelper = require('../../helpers/xpath')
 const { join } = require('../../helpers/path')
 
-/**
- * @enum {string}
- * @readonly
- */
-const FileAction = Object.freeze({
-  download: 'download',
-  delete: 'delete',
-  restore: 'restore',
-  share: 'share',
-  rename: 'rename',
-  deleteImmediately: 'deleteImmediately'
-})
 module.exports = {
   commands: {
     /**
-     * Action button selector
-     *
-     * @param {string} action
-     * @param {string} fileName
-     * @returns {string}
-     */
-    getActionSelector: function (action) {
-      const actionsDropdownSelector = this.elements.itemActionsDropdown.selector
-      const actionSelector = this.elements[action + 'ButtonInFileRow'].selector
-
-      return `${actionsDropdownSelector}${actionSelector}`
-    },
-    /**
      * Get Selector for File Actions expander
      *
-     * @param fileName
-     * @returns {string}
+     * @param {string} fileName
+     * @param {string} elementType
+     * @returns {string} file action button selector
      */
     getFileActionBtnSelector: function (fileName, elementType = 'file') {
       return this.getFileRowSelectorByFileName(fileName, elementType) +
-        this.elements.fileActionsButtonInFileRow.selector
+        this.api.page.FilesPageElement.fileActionsMenu().elements
+          .fileActionsButtonInFileRow.selector
     },
     /**
-     * perform one of the main file actions
-     * this method does find out itself if the file-action burger has to be clicked or not
-     *
      * @param {string} fileName
-     * @param {string} action delete|share|rename|download
-
-     * @throws Error
-     * @returns {*}
+     * @return {Promise<*>}
      */
-    performFileAction: function (fileName, action, elementType = 'file') {
-      const { btnSelector, fileActionsBtnSelector } =
-        this.getFileRowButtonSelectorsByFileName(fileName, action, elementType)
-      return this.initAjaxCounters()
-        .useXpath()
-        .waitForElementVisible(fileActionsBtnSelector, (result) => {
-          if (!result.value) {
-            throw new Error('Expected: File action button to be visible but found:' +
-              result.value.toString())
-          }
-        })
-        .click(fileActionsBtnSelector)
-        .waitForElementVisible(btnSelector)
-        .click(btnSelector)
-        .useCss()
-    },
-    /**
-     *
-     * @param {string} fileName
-     */
-    deleteFile: async function (fileName) {
+    openSharingDialog: async function (fileName) {
       await this.waitForFileVisible(fileName)
-
-      await this
+      return this.openFileActionsMenu(fileName)
+        .openCollaboratorsDialog()
+    },
+    /**
+     * opens links dialog for given resource
+     * assumes fileActionsMenu to be opened, as the its moves to links tab from file-actions share option
+     *
+     * @return {*}
+     */
+    openLinksDialog: function () {
+      const api = this.api.page.FilesPageElement
+      const sidebarLinksTabXpath = api.appSideBar().elements.sidebarLinksTab.selector
+      api.fileActionsMenu()
+        .openCollaboratorsDialog()
         .useXpath()
-        .performFileAction(fileName, FileAction.delete)
-        .confirmDeletion()
-
+        .waitForElementVisible(sidebarLinksTabXpath)
+        .click(sidebarLinksTabXpath)
+        .useCss()
+      return api.publicLinksDialog()
+    },
+    /**
+     * @param {string} fileName
+     * @return {Promise<*>}
+     */
+    openPublicLinkDialog: async function (fileName) {
+      await this.waitForFileVisible(fileName)
+      await this.openFileActionsMenu(fileName)
+      return this.openLinksDialog()
+    },
+    /**
+     * @param {string} resource
+     * @return {Promise<module.exports.commands>}
+     */
+    deleteFile: async function (resource) {
+      await this.waitForFileVisible(resource)
+      await this
+        .openFileActionsMenu(resource)
+        .delete()
       return this
     },
+    /**
+     * @param {string} fromName
+     * @param {string} toName
+     * @param {boolean} expectToSucceed
+     * @return {Promise<module.exports.commands>}
+     */
+    renameFile: async function (fromName, toName, expectToSucceed = true) {
+      await this.waitForFileVisible(fromName)
+      await this
+        .openFileActionsMenu(fromName)
+        .rename(toName, expectToSucceed)
+      return this
+    },
+    /**
+     * @param {string} element
+     * @param {string} elementType
+     * @return {Promise<module.exports.commands>}
+     */
+    restoreFile: async function (element, elementType) {
+      await this.waitForFileWithPathVisible(element, elementType)
+      await this
+        .openFileActionsMenu(element, elementType)
+        .restore()
+      return this
+    },
+    /**
+     * @param {string} resource
+     * @return {Promise<module.exports.commands>}
+     */
+    deleteImmediately: async function (resource) {
+      await this.waitForFileVisible(resource)
+      await this
+        .openFileActionsMenu(resource)
+        .deleteResourceImmediately(resource)
+      return this
+    },
+    /**
+     * @param {string} action
+     * @param {string} resource
+     * @return {Promise<boolean>}
+     */
+    isActionAttributeDisabled: async function (action, resource) {
+      await this.waitForFileVisible(resource)
+      return this
+        .openFileActionsMenu(resource)
+        .getActionDisabledAttr('delete')
+    },
+    /**
+     * @param {string} resource
+     * @return {Promise<module.exports.commands>}
+     */
+    downloadFile: async function (resource) {
+      await this.waitForFileVisible(resource)
+      await this
+        .openFileActionsMenu(resource)
+        .download()
+      return this
+    },
+    /**
+     * @param {string} resource
+     * @return {Promise<module.exports.commands>}
+     */
+    isSharingButtonPresent: async function (resource) {
+      await this.waitForFileVisible(resource)
+      await this
+        .openFileActionsMenu(resource)
+        .isSharingBtnPresent()
+      return this
+    },
+    /**
+     * @return {Promise<*>}
+     */
     confirmDeletion: async function () {
       const clickAction = function () {
         return this.initAjaxCounters()
@@ -140,21 +195,6 @@ module.exports = {
     },
     /**
      *
-     * @param {string} fileName
-     * @param {string} elementType
-     * @returns {Promise<void>}
-     */
-    restoreFile: async function (fileName, elementType = 'file') {
-      await this
-        .initAjaxCounters()
-        .waitForFileWithPathVisible(fileName, elementType)
-        .useXpath()
-        .performFileAction(fileName, FileAction.restore, elementType)
-        .waitForOutstandingAjaxCalls()
-        .useCss()
-    },
-    /**
-     *
      * @param {string} folder
      */
     navigateToFolder: async function (folder) {
@@ -168,31 +208,6 @@ module.exports = {
 
       return this
     },
-
-    /**
-     *
-     * @param {string} fileName
-     */
-    openSharingDialog: async function (fileName, targetTab = 'collaborators') {
-      const sidebarLinksTabXpath = this.api.page.FilesPageElement.appSideBar().elements.sidebarLinksTab.selector
-      await this.waitForFileVisible(fileName)
-
-      await this
-        .useXpath()
-        .performFileAction(fileName, FileAction.share)
-        .waitForElementVisible('@sharingSideBar')
-        .useCss()
-
-      if (targetTab === 'links') {
-        await this
-          .useXpath()
-          .waitForElementVisible(sidebarLinksTabXpath)
-          .click(sidebarLinksTabXpath)
-          .useCss()
-      }
-
-      return this.api.page.FilesPageElement.sharingDialog()
-    },
     /**
      * opens sidebar for given resource
      *
@@ -204,59 +219,23 @@ module.exports = {
       return this.api.page.FilesPageElement.appSideBar()
     },
     /**
+     * opens file-actions menu for given resource
      *
-     * @param {string} fileName
+     * @param {string} resource name
+     * @param {string} resource type (file|folder)
+     *
+     * @returns {*}
      */
-    openPublicLinkDialog: async function (fileName) {
-      await this.waitForFileVisible(fileName)
-
-      await this
+    openFileActionsMenu: function (resource, elementType = 'file') {
+      const fileActionsBtnSelector = this.getFileActionBtnSelector(resource, elementType)
+      this
         .useXpath()
-        .performFileAction(fileName, FileAction.share)
-        .waitForElementVisible('@linkToPublicLinksTag')
-        .click('@linkToPublicLinksTag')
-        .waitForElementVisible('@publicLinkSideBar')
+        .waitForElementVisible(fileActionsBtnSelector)
+        .click(fileActionsBtnSelector)
         .useCss()
-
-      return this.api.page.FilesPageElement.publicLinksDialog()
+      return this.api.page.FilesPageElement.fileActionsMenu()
     },
-    /**
-     *
-     * @param {string} fromName
-     * @param {string} toName
-     * @param {boolean} expectToSucceed
-     */
-    renameFile: async function (fromName, toName, expectToSucceed = true) {
-      await this.waitForFileVisible(fromName)
 
-      await this.initAjaxCounters()
-        .useXpath()
-        .performFileAction(fromName, FileAction.rename)
-        .waitForElementVisible('@renameFileConfirmationBtn')
-        .waitForAnimationToFinish()
-        .clearValue('@renameFileInputField')
-        .setValue('@renameFileInputField', toName)
-        .click('@renameFileConfirmationBtn')
-        .waitForOutstandingAjaxCalls()
-        .useCss()
-
-      if (expectToSucceed) {
-        await this.waitForElementNotVisible('@renameFileConfirmationDialog')
-      }
-
-      return this
-    },
-    /**
-     *
-     * @param {string} fromName
-     */
-    downloadFile: async function (fromName) {
-      await this.waitForFileVisible(fromName)
-
-      await this.initAjaxCounters()
-        .performFileAction(fromName, FileAction.download)
-        .waitForOutstandingAjaxCalls()
-    },
     /**
      *
      * @param {string} path
@@ -374,9 +353,8 @@ module.exports = {
 
       await this.waitForElementPresent('@filesTableContainer')
       await this.filesListScrollToTop()
-      await this.findItemInFilesList(fileName)
-
       // Find the item in files list if it's not in the view
+      await this.findItemInFilesList(fileName)
       await this
         .useXpath()
         .getAttribute(linkSelector, 'filename', function (result) {
@@ -406,19 +384,6 @@ module.exports = {
           this.assert.strictEqual(result.value.trim(), path, 'displayed file name not as expected')
         })
         .useCss()
-    },
-    /**
-     *
-     * @param {string} fileName
-     * @param {string} action
-     * @param {string} elementType
-     * @returns {{btnSelector: string, fileActionsBtnSelector: string}}
-     */
-    getFileRowButtonSelectorsByFileName: function (fileName, action, elementType = 'file') {
-      const btnSelector = this.getActionSelector(action)
-      const fileActionsBtnSelector = this.getFileActionBtnSelector(fileName, elementType)
-
-      return { btnSelector, fileActionsBtnSelector }
     },
     /**
      *
@@ -481,51 +446,6 @@ module.exports = {
       return isListed
     },
     /**
-     * checks whether sharing button of given file-row is present
-     *
-     * @param {string} fileName
-     * @returns {Promise<boolean>}
-     */
-    isSharingBtnPresent: async function (fileName) {
-      const resourceRowXpath = this.getFileRowSelectorByFileName(fileName)
-      const shareButtonXpath = this.elements.shareButtonInFileRow.selector
-      const resourceShareButtonXpath = resourceRowXpath + shareButtonXpath
-      let isPresent = true
-      await this
-        .api.page.FilesPageElement.appSideBar().closeSidebar(100)
-      await this
-        .api.elements(
-          this.elements.shareButtonInFileRow.locateStrategy,
-          resourceShareButtonXpath,
-          (result) => {
-            isPresent = result.value.length > 0
-          })
-      return isPresent
-    },
-    /**
-     * returns the disabled state of given action
-     *
-     * @param {string} action
-     * @param {string} fileName
-     * @returns {Promise<boolean>}
-     */
-    getActionDisabledAttr: async function (action, fileName) {
-      const btnSelector = this.getActionSelector(action, fileName)
-      const fileActionsBtnSelector = this.getFileActionBtnSelector(fileName)
-      let disabledState
-      await this
-        .useXpath()
-        .click(fileActionsBtnSelector)
-      await this.api
-        .element('xpath', btnSelector, result => {
-          // action is disabled when not visible in dropdown menu
-          disabledState = result.status === -1
-        })
-        .useCss()
-
-      return disabledState
-    },
-    /**
      * @returns {Array} array of files/folders element
      */
     allFileRows: async function () {
@@ -560,13 +480,6 @@ module.exports = {
         })
       }
       return visible
-    },
-    deleteImmediately: async function (fileName) {
-      await this.waitForFileVisible(fileName)
-      await this
-        .performFileAction(fileName, FileAction.deleteImmediately)
-        .confirmDeletion()
-      return this
     },
     countFilesAndFolders: async function () {
       let filesCount = 0
@@ -784,29 +697,9 @@ module.exports = {
     filesListNoContentMessage: {
       selector: '#files-list-container .files-list-no-content-message'
     },
-    fileActionsButtonInFileRow: {
-      selector: '//button[contains(@class, "files-list-row-show-actions")]',
-      locateStrategy: 'xpath'
-    },
     deleteFileConfirmationDialog: {
       selector: '#delete-file-confirmation-dialog',
       locateStrategy: 'css selector'
-    },
-    deleteButtonInFileRow: {
-      selector: '//button[@aria-label="Delete"]',
-      locateStrategy: 'xpath'
-    },
-    downloadButtonInFileRow: {
-      selector: '//button[@aria-label="Download"]',
-      locateStrategy: 'xpath'
-    },
-    restoreButtonInFileRow: {
-      selector: '//button[@aria-label="Restore"]',
-      locateStrategy: 'xpath'
-    },
-    deleteImmediatelyButtonInFileRow: {
-      selector: '//button[@aria-label="Delete"]',
-      locateStrategy: 'xpath'
     },
     deleteFileConfirmationBtn: {
       selector: '#oc-dialog-delete-confirm'
@@ -814,20 +707,6 @@ module.exports = {
     shareButtonInFileRow: {
       selector: '//button[@aria-label="Collaborators"]',
       locateStrategy: 'xpath'
-    },
-    renameFileConfirmationDialog: {
-      selector: '#change-file-dialog'
-    },
-    renameButtonInFileRow: {
-      selector: '//button[@aria-label="Rename"]',
-      locateStrategy: 'xpath'
-    },
-    renameFileInputField: {
-      selector: '//div[@id="change-file-dialog"]//input',
-      locateStrategy: 'xpath'
-    },
-    renameFileConfirmationBtn: {
-      selector: '#oc-dialog-rename-confirm'
     },
     fileRowByName: {
       selector: '//span[@class="oc-file-name"][text()=%s and not(../span[@class="oc-file-extension"])]/../../../../../div[@data-is-visible="true"]'
@@ -854,9 +733,6 @@ module.exports = {
       selector: '//*[contains(@class, "file-row-share-indicator")]',
       locateStrategy: 'xpath'
     },
-    sharingSideBar: {
-      selector: '#oc-files-sharing-sidebar'
-    },
     publicLinkSideBar: {
       selector: '#oc-files-file-link'
     },
@@ -877,10 +753,6 @@ module.exports = {
     },
     collaboratorsList: {
       selector: '.files-collaborators-lists'
-    },
-    itemActionsDropdown: {
-      selector: '//div[@id="files-list-row-actions-dropdown"]',
-      locateStrategy: 'xpath'
     },
     foldersCount: {
       selector: '#files-list-count-folders'

--- a/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
@@ -369,6 +369,7 @@ module.exports = {
         this.elements.roleButtonInDropdown.selector, newRole.toLowerCase()
       )
       return this
+        .initAjaxCounters()
         .useXpath()
         .waitForElementVisible('@selectRoleButtonInCollaboratorInformation')
         .click('@selectRoleButtonInCollaboratorInformation')

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -160,10 +160,11 @@ When('the user creates a folder with the invalid name {string} using the webUI',
 Given('the user has opened folder {string}', (folder) => client.page.FilesPageElement.filesList().navigateToFolder(folder))
 When('the user opens folder {string} using the webUI', (folder) => client.page.FilesPageElement.filesList().navigateToFolder(folder))
 
-Given('the user has opened the share dialog for file/folder {string}', async function (fileName) {
-  await client.page.FilesPageElement.filesList().openSharingDialog(fileName)
-
-  return client
+Given('the user has opened the share dialog for file/folder {string}', function (fileName) {
+  return client.page.FilesPageElement
+    .appSideBar()
+    .closeSidebar(100)
+    .openSharingDialog(fileName)
 })
 
 When('the user browses to folder {string} using the breadcrumb on the webUI', (resource) =>
@@ -312,6 +313,7 @@ When('the user renames the following file/folder using the webUI', async functio
         toName
       )
   }
+  return client
 })
 
 Given('the user has marked file/folder {string} as favorite using the webUI', function (path) {
@@ -785,7 +787,10 @@ When('the user browses to the folder {string} on the files page', (folderName) =
     .navigateAndWaitTillLoaded(targetFolder)
 })
 When('the user copies the permalink of the file/folder/resource {string} using the webUI', async function (file) {
-  await client.page.FilesPageElement.filesList().openSharingDialog(file, 'links')
+  await client.page.FilesPageElement
+    .appSideBar()
+    .closeSidebar(100)
+    .openPublicLinkDialog(file)
   await client.page.filesPage().copyPermalinkFromFilesAppBar()
   return client
 })
@@ -815,14 +820,14 @@ When('the user deletes the file {string} from the deleted files list', function 
 Then('it should not be possible to delete file/folder {string} using the webUI', async function (resource) {
   const state = await client.page.FilesPageElement
     .filesList()
-    .getActionDisabledAttr('delete', resource)
+    .isActionAttributeDisabled('delete', resource)
   assert.ok(state, `expected property disabled of ${resource} to be 'true' but found ${state}`)
 })
 
 Then('it should not be possible to rename file/folder {string} using the webUI', async function (resource) {
   const state = await client.page.FilesPageElement
     .filesList()
-    .getActionDisabledAttr('rename', resource)
+    .isActionAttributeDisabled('rename', resource)
   assert.ok(state, `expected property disabled of ${resource} to be 'true' but found ${state}`)
 })
 

--- a/tests/acceptance/stepDefinitions/publicLinkContext.js
+++ b/tests/acceptance/stepDefinitions/publicLinkContext.js
@@ -215,14 +215,16 @@ When('the user closes the public link details sidebar', function () {
     .closeSidebar(100)
 })
 
-When('the user copies the url of public link named {string} of file/folder/resource {string} using the webUI', async function (linkName, resource) {
-  await client.page.FilesPageElement
-    .appSideBar()
-    .closeSidebar(100)
-    .openPublicLinkDialog(resource)
-  return client.page.FilesPageElement.publicLinksDialog()
-    .copyPublicLinkURI(linkName)
-})
+When('the user copies the url of public link named {string} of file/folder/resource {string} using the webUI',
+  async function (linkName, resource) {
+    await client.page.FilesPageElement
+      .appSideBar()
+      .closeSidebar(100)
+      .openPublicLinkDialog(resource)
+    return client.page.FilesPageElement.publicLinksDialog()
+      .copyPublicLinkURI(linkName)
+  })
+
 Then('the tokens should be unique for each public links on the webUI', async function () {
   const publicLinkUrls = await client.page.FilesPageElement.publicLinksDialog().getPublicLinkUrls()
   const isUnique = publicLinkUrls.length === (new Set(publicLinkUrls).size)

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -468,29 +468,30 @@ When('the user types {string} in the share-with-field', function (input) {
   return client.page.FilesPageElement.sharingDialog().enterAutoComplete(input)
 })
 
-When('the user sets custom permission for current role of collaborator {string} for folder/file {string} to {string} using the webUI', async function (user, resource, permissions) {
-  const api = client.page
-    .FilesPageElement
+When('the user sets custom permission for current role of collaborator {string} for folder/file {string} to {string} using the webUI',
+  async function (user, resource, permissions) {
+    const api = client.page
+      .FilesPageElement
 
-  await api
-    .appSideBar()
-    .closeSidebar(100)
-    .openSharingDialog(resource)
+    await api
+      .appSideBar()
+      .closeSidebar(100)
+      .openSharingDialog(resource)
 
-  return api.sharingDialog().changeCustomPermissionsTo(user, permissions)
-})
+    return api.sharingDialog().changeCustomPermissionsTo(user, permissions)
+  })
 
-When('the user disables all the custom permissions of collaborator {string} for file/folder {string} using the webUI', async function (collaborator, resource) {
-  const api = client.page
-    .FilesPageElement
+When('the user disables all the custom permissions of collaborator {string} for file/folder {string} using the webUI',
+  async function (collaborator, resource) {
+    const api = client.page
+      .FilesPageElement
 
-  await api
-    .appSideBar()
-    .closeSidebar(100)
-    .openSharingDialog(resource)
+    await api.appSideBar()
+      .closeSidebar(100)
+      .openSharingDialog(resource)
 
-  return api.sharingDialog().disableAllCustomPermissions(collaborator)
-})
+    return api.sharingDialog().disableAllCustomPermissions(collaborator)
+  })
 
 const assertSharePermissions = async function (currentSharePermissions, permissions = undefined) {
   let expectedPermissionArray
@@ -535,7 +536,6 @@ Then('no custom permissions should be set for collaborator {string} for file/fol
     .openSharingDialog(resource)
   const currentSharePermissions = await client.page.FilesPageElement.sharingDialog()
     .getDisplayedPermission(user)
-
   return assertSharePermissions(currentSharePermissions)
 })
 
@@ -547,7 +547,7 @@ Then('it should not be possible to share file/folder {string} using the webUI', 
   const appSideBar = client.page.FilesPageElement.appSideBar()
   const filesList = client.page.FilesPageElement.filesList()
   // assumes current webUI state as no sidebar open for any resource
-  const state = await filesList.isSharingBtnPresent(resource)
+  const state = await filesList.isSharingButtonPresent(resource)
   assert.ok(
     !state,
     `Error: Sharing button for resource ${resource} is not in disabled state`
@@ -694,11 +694,11 @@ Then('{string} {string} should be listed in the autocomplete list on the webUI',
 })
 
 When('the user opens the share dialog for file/folder/resource {string} using the webUI', function (file) {
-  return client.page.FilesPageElement.filesList().openSharingDialog(file, 'collaborators')
+  return client.page.FilesPageElement.filesList().openSharingDialog(file)
 })
 
 When('the user opens the link share dialog for file/folder/resource {string} using the webUI', function (file) {
-  return client.page.FilesPageElement.filesList().openSharingDialog(file, 'links')
+  return client.page.FilesPageElement.filesList().openPublicLinkDialog(file)
 })
 
 When('the user deletes {string} as collaborator for the current file/folder using the webUI', function (user) {
@@ -752,15 +752,16 @@ Then('user {string} should be listed without additional info in the collaborator
   return assertCollaboratorslistContains('user', user, { additionalInfo: false })
 })
 
-Then('user {string} should be listed as {string} in the collaborators list for file/folder/resource {string} on the webUI', async function (user, role, resource) {
-  await client.page
-    .FilesPageElement
-    .appSideBar()
-    .closeSidebar(100)
-    .openSharingDialog(resource)
+Then('user {string} should be listed as {string} in the collaborators list for file/folder/resource {string} on the webUI',
+  async function (user, role, resource) {
+    await client.page
+      .FilesPageElement
+      .appSideBar()
+      .closeSidebar(100)
+      .openSharingDialog(resource)
 
-  return assertCollaboratorslistContains('user', user, { role })
-})
+    return assertCollaboratorslistContains('user', user, { role })
+  })
 
 Then('group {string} should be listed as {string} in the collaborators list on the webUI', function (group, role) {
   return assertCollaboratorslistContains('group', group, { role })
@@ -770,15 +771,15 @@ Then('group {string} should be listed as {string} via {string} in the collaborat
   return assertCollaboratorslistContains('group', group, { role, via })
 })
 
-Then('group {string} should be listed as {string} in the collaborators list for file/folder/resource {string} on the webUI', async function (group, role, resource) {
-  await client.page
-    .FilesPageElement
-    .appSideBar()
-    .closeSidebar(100)
-    .openSharingDialog(resource)
-
-  return assertCollaboratorslistContains('group', group, { role })
-})
+Then('group {string} should be listed as {string} in the collaborators list for file/folder/resource {string} on the webUI',
+  async function (group, role, resource) {
+    await client.page
+      .FilesPageElement
+      .appSideBar()
+      .closeSidebar(100)
+      .openSharingDialog(resource)
+    return assertCollaboratorslistContains('group', group, { role })
+  })
 
 Then('user {string} should not be listed in the collaborators list on the webUI', function (user) {
   return assertCollaboratorslistDoesNotContain('user', user)
@@ -809,12 +810,13 @@ Then('user {string} should have a share with these details:', function (user, ex
 })
 
 Then('the user should not be able to share file/folder/resource {string} using the webUI', async function (resource) {
-  await client.page
-    .FilesPageElement
+  const api = client.page.FilesPageElement
+  await api
     .appSideBar()
     .closeSidebar(100)
     .openSharingDialog(resource)
-  const shareResponse = await client.page.FilesPageElement.sharingDialog()
+  const shareResponse = await api
+    .sharingDialog()
     .getSharingPermissionMsg()
   const noSharePermissionsMsgFormat = "You don't have permission to share this %s."
   const noSharePermissionsFileMsg = util.format(noSharePermissionsMsgFormat, 'file')


### PR DESCRIPTION
## Description
Moved `fileActions` commands and related elements to separate PO `fileActionsMenu`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of #2677

## Motivation and Context
Appropriate placements for different PO methods and elements

## How Has This Been Tested?
- :robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...