### PR TITLE
Resharers now visible on top of owner entry

### DIFF
--- a/apps/files/src/components/Collaborators/Collaborator.vue
+++ b/apps/files/src/components/Collaborators/Collaborator.vue
@@ -4,7 +4,7 @@
       <oc-table-cell shrink :colspan="firstColumn ? 2 : 1"></oc-table-cell>
       <oc-table-cell colspan="2">
         <div class="uk-text-meta uk-flex uk-flex-middle">
-          <oc-icon name="repeat" class="uk-preserve-width" />
+          <oc-icon name="repeat" class="uk-preserve-width oc-icon-xsmall" />
           <span class="uk-padding-remove uk-margin-xsmall-left uk-text-truncate files-collaborators-collaborator-reshare-information">{{ $_reshareInformation }}</span>
         </div>
       </oc-table-cell>
@@ -19,9 +19,9 @@
       </oc-table-cell>
       <oc-table-cell shrink>
         <div key="collaborator-avatar-loaded">
-          <avatar-image v-if="$_shareType === shareTypes.user" class="uk-margin-small-right" :width="48" :userid="collaborator.name" :userName="collaborator.displayName" />
+          <avatar-image v-if="collaborator.shareType === shareTypes.user" class="uk-margin-small-right" :width="48" :userid="collaborator.name" :userName="collaborator.displayName" />
           <div v-else key="collaborator-avatar-placeholder">
-            <oc-icon v-if="$_shareType === shareTypes.group" class="uk-margin-small-right" name="group" size="large" key="avatar-group" />
+            <oc-icon v-if="collaborator.shareType === shareTypes.group" class="uk-margin-small-right" name="group" size="large" key="avatar-group" />
             <oc-icon v-else class="uk-margin-small-right" name="person" size="large" key="avatar-generic-person" />
           </div>
         </div>
@@ -30,7 +30,7 @@
         <div class="uk-flex uk-flex-column uk-flex-center">
           <div class="oc-text">
             <span class="files-collaborators-collaborator-name uk-text-bold">{{ collaborator.displayName }}</span>
-            <span v-if="$_shareType === shareTypes.user && collaborator.info.share_with_additional_info.length > 0" class="uk-text-meta files-collaborators-collaborator-additional-info">({{ collaborator.info.share_with_additional_info }})</span>
+            <span v-if="collaborator.shareType === shareTypes.user && collaborator.info.share_with_additional_info.length > 0" class="uk-text-meta files-collaborators-collaborator-additional-info">({{ collaborator.info.share_with_additional_info }})</span>
             <translate
               v-if="collaborator.name === user.id"
               translate-comment="Indicator for current user in collaborators list"
@@ -116,15 +116,18 @@ export default {
     },
 
     $_reshareInformation () {
-      if (this.collaborator.role.name === 'owner' || this.collaborator.role.name === 'resharer' || this.user.id === this.collaborator.info.uid_owner) {
+      if (this.user.id === this.collaborator.info.uid_owner) {
+        return null
+      }
+
+      if (this.collaborator.role.name === 'owner') {
+        if (this.collaborator.resharers) {
+          return this.collaborator.resharers.map(share => share.displayName).join(', ')
+        }
         return null
       }
 
       return this.collaborator.info.displayname_owner
-    },
-
-    $_shareType () {
-      return parseInt(this.collaborator.info.share_type, 10)
     },
 
     $_viaLabel () {

--- a/apps/files/src/components/Collaborators/EditCollaborator.vue
+++ b/apps/files/src/components/Collaborators/EditCollaborator.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="files-collaborators-collaborator-edit-dialog">
-    <div v-if="user.id !== collaborator.info.uid_owner" class="uk-text-meta uk-flex uk-flex-middle uk-margin-small-bottom"><oc-icon name="repeat" class="uk-margin-small-right" /> {{ collaborator.info.displayname_owner }}</div>
+    <div v-if="user.id !== collaborator.owner.name" class="uk-text-meta uk-flex uk-flex-middle uk-margin-small-bottom"><oc-icon name="repeat" class="uk-margin-small-right" /> {{ collaborator.owner.displayName }}</div>
     <collaborator class="uk-width-expand" :collaborator="collaborator" :first-column="false" />
     <collaborators-edit-options
       :existingRole="$_originalRole"

--- a/apps/files/src/components/Collaborators/NewCollaborator.vue
+++ b/apps/files/src/components/Collaborators/NewCollaborator.vue
@@ -162,7 +162,7 @@ export default {
 
             const exists = this.currentFileOutgoingCollaborators.find(existingCollaborator => {
               return (
-                collaborator.value.shareWith === existingCollaborator.name &&
+                collaborator.value.shareWith === existingCollaborator.collaborator.name &&
                 parseInt(collaborator.value.shareType, 10) === existingCollaborator.shareType
               )
             })

--- a/apps/files/src/components/FileLinkSidebar.vue
+++ b/apps/files/src/components/FileLinkSidebar.vue
@@ -259,7 +259,7 @@ export default {
       const name2 = l2.name.toLowerCase().trim()
       // sorting priority 1: display name (lower case, ascending), 2: id (ascending)
       if (name1 === name2) {
-        return textUtils.naturalSortCompare(l1.info.id + '', l2.info.id + '')
+        return textUtils.naturalSortCompare(l1.id + '', l2.id + '')
       } else {
         return textUtils.naturalSortCompare(name1, name2)
       }

--- a/apps/files/src/components/FilesLists/StatusIndicators/DefaultIndicators.vue
+++ b/apps/files/src/components/FilesLists/StatusIndicators/DefaultIndicators.vue
@@ -77,7 +77,7 @@ export default {
           shares.forEach((share) => {
             // note: no distinction between incoming and outgoing shares as we display the same
             // indirect indicator for them
-            shareTypes[share.info.share_type] = true
+            shareTypes[share.shareType] = true
           })
         }
       })

--- a/apps/files/src/components/PublicLinksSidebar/PublicLinkListItem.vue
+++ b/apps/files/src/components/PublicLinksSidebar/PublicLinkListItem.vue
@@ -94,10 +94,10 @@ export default {
         return null
       }
       const translated = this.$gettext('Via %{folderName}')
-      return this.$gettextInterpolate(translated, { folderName: basename(this.link.info.path) }, true)
+      return this.$gettextInterpolate(translated, { folderName: basename(this.link.path) }, true)
     },
     $_viaRouterParams () {
-      const viaPath = this.link.info.path
+      const viaPath = this.link.path
       return {
         name: 'files-list',
         params: {

--- a/apps/files/src/store/actions.js
+++ b/apps/files/src/store/actions.js
@@ -225,7 +225,6 @@ function _buildLink (link, $gettext) {
     password: !!(link.share_with && link.share_with_displayname),
     expiration: (typeof link.expiration === 'string') ? moment(link.expiration).format('YYYY-MM-DD') : null,
     itemSource: link.item_source,
-    info: link,
     file: {
       parent: link.file_parent,
       source: link.file_source,
@@ -244,7 +243,6 @@ function _fixAdditionalInfo (data) {
 function _buildCollaboratorShare (s, file) {
   const share = {
     shareType: parseInt(s.share_type, 10),
-    info: s,
     id: s.id
   }
   switch (share.shareType) {
@@ -644,7 +642,7 @@ export default {
       })
     }
 
-    return client.shares.updateShare(share.info.id, params)
+    return client.shares.updateShare(share.id, params)
       .then((updatedShare) => {
         commit('CURRENT_FILE_OUTGOING_SHARES_UPDATE', _buildCollaboratorShare(updatedShare.shareInfo, getters.highlightedFile))
       })
@@ -684,7 +682,7 @@ export default {
       })
   },
   deleteShare (context, { client, share }) {
-    client.shares.deleteShare(share.info.id)
+    client.shares.deleteShare(share.id)
       .then(() => {
         context.commit('CURRENT_FILE_OUTGOING_SHARES_REMOVE', share)
         context.commit('UPDATE_CURRENT_FILE_SHARE_TYPES')

--- a/apps/files/src/store/actions.js
+++ b/apps/files/src/store/actions.js
@@ -234,6 +234,13 @@ function _buildLink (link, $gettext) {
   }
 }
 
+function _fixAdditionalInfo (data) {
+  if (typeof data !== 'string') {
+    return null
+  }
+  return data
+}
+
 function _buildCollaboratorShare (s, file) {
   const share = {
     shareType: parseInt(s.share_type, 10),
@@ -249,8 +256,22 @@ function _buildCollaboratorShare (s, file) {
     case (shareTypes.group): // group share
       share.role = bitmaskToRole(s.permissions, file.type === 'folder')
       share.permissions = s.permissions
-      share.name = s.share_with // this is the recipient userid, rename to uid or subject? add separate field userName?
-      share.displayName = s.share_with_displayname
+      // FIXME: SDK is returning empty object for additional info when empty
+      share.collaborator = {
+        name: s.share_with,
+        displayName: s.share_with_displayname,
+        additionalInfo: _fixAdditionalInfo(s.share_with_additional_info)
+      }
+      share.owner = {
+        name: s.uid_owner,
+        displayName: s.displayname_owner,
+        additionalInfo: _fixAdditionalInfo(s.additional_info_owner)
+      }
+      share.fileOwner = {
+        name: s.uid_file_owner,
+        displayName: s.displayname_file_owner,
+        additionalInfo: _fixAdditionalInfo(s.additional_info_file_owner)
+      }
       // TODO: Refactor to work with roles / prepare for roles API
       share.customPermissions = {
         update: s.permissions & permissionsBitmask.update,
@@ -266,6 +287,7 @@ function _buildCollaboratorShare (s, file) {
   if (typeof s.expiration === 'string' || s.expiration instanceof String) {
     share.expires = Date.parse(s.expiration)
   }
+  share.path = s.path
 
   return share
 }

--- a/apps/files/src/store/mutations.js
+++ b/apps/files/src/store/mutations.js
@@ -139,7 +139,7 @@ export default {
   },
   CURRENT_FILE_OUTGOING_SHARES_UPDATE (state, share) {
     const fileIndex = state.currentFileOutgoingShares.findIndex((s) => {
-      return s.info.id === share.info.id
+      return s.id === share.id
     })
     if (fileIndex >= 0) {
       Vue.set(state.currentFileOutgoingShares, fileIndex, share)

--- a/changelog/unreleased/3850
+++ b/changelog/unreleased/3850
@@ -1,0 +1,10 @@
+Bugfix: Moved resharers to the top of owner collaborator entry
+
+For received shares, the resharers user display names are now shown
+on top of the owner entry in the collaborators list, with a reshare
+icon, instead of having their own entry in the collaborators list.
+
+This makes the reshare situation more clear and removes the ambiguity
+about the formerly displayed "resharer" role which doesn't exist.
+
+https://github.com/owncloud/phoenix/issues/3850

--- a/tests/acceptance/features/webUIResharing/reshareUsers.feature
+++ b/tests/acceptance/features/webUIResharing/reshareUsers.feature
@@ -213,3 +213,26 @@ Feature: Resharing shared files with different permissions
     And the user shares file "lorem (2).txt" with user "User Three" as "Editor" using the webUI
     Then as "user3" folder "simple-folder (2)" should exist
     And as "user3" file "lorem (2).txt" should exist
+
+  Scenario: Resource owner sees resharer in collaborators list
+    Given user "user3" has been created with default attributes
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user2" has shared folder "simple-folder (2)" with user "user3"
+    When user "user1" has logged in using the webUI
+    And the user opens the share dialog for folder "simple-folder" using the webUI
+    Then user "User Two" should be listed as "Editor" in the collaborators list on the webUI
+    And user "User Three" should be listed as "Editor" reshared through "User Two" in the collaborators list on the webUI
+
+  Scenario: Share recipient sees resharer in collaborators list
+    Given user "user3" has been created with default attributes
+    And user "user4" has been created with default attributes
+    And group "user4grp" has been created
+    And user "user4" has been added to group "user4grp"
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user1" has shared folder "simple-folder" with user "user3"
+    And user "user2" has shared folder "simple-folder (2)" with user "user4"
+    And user "user3" has shared folder "simple-folder (2)" with group "user4grp"
+    When user "user4" has logged in using the webUI
+    And the user opens the share dialog for folder "simple-folder (2)" using the webUI
+    Then user "User One" should be listed as "Owner" reshared through "User Three, User Two" in the collaborators list on the webUI
+

--- a/tests/acceptance/features/webUIResharing/reshareUsers.feature
+++ b/tests/acceptance/features/webUIResharing/reshareUsers.feature
@@ -147,9 +147,8 @@ Feature: Resharing shared files with different permissions
     When the user shares folder "simple-folder (2)" with user "User Three" as "Advanced permissions" with permissions "share, delete" using the webUI
     And the user re-logs in as "user3" using the webUI
     And the user opens the share dialog for folder "simple-folder (2)" using the webUI
-    Then the current collaborators list should have order "User Two,User One,User Three"
-    And user "User Two" should be listed as "Owner" in the collaborators list on the webUI
-    And user "User One" should be listed as "Resharer" in the collaborators list on the webUI
+    Then the current collaborators list should have order "User Two,User Three"
+    And user "User Two" should be listed as "Owner" reshared through "User One" in the collaborators list on the webUI
     And user "user3" should have received a share with these details:
     | field       | value               |
     | uid_owner   | user1               |

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -336,6 +336,5 @@ Feature: Sharing files and folders with internal groups
     And user "user3" has logged in using the webUI
     And the user opens folder "simple-folder (2)" using the webUI
     When the user opens the share dialog for folder "simple-empty-folder" using the webUI
-    Then user "User One" should be listed as "Owner" via "simple-folder (2)" in the collaborators list on the webUI
-    And user "User Two" should be listed as "Resharer" via "simple-folder (2)" in the collaborators list on the webUI
-    And the current collaborators list should have order "User One,User Two,User Three"
+    Then user "User One" should be listed as "Owner" reshared through "User Two" via "simple-folder (2)" in the collaborators list on the webUI
+    And the current collaborators list should have order "User One,User Three"

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -512,9 +512,8 @@ Feature: Sharing files and folders with internal users
     And user "user2" has shared folder "simple-folder (2)" with user "user3"
     And user "user3" has logged in using the webUI
     When the user opens the share dialog for folder "simple-folder (2)" using the webUI
-    Then user "User One" should be listed as "Owner" in the collaborators list on the webUI
-    And user "User Two" should be listed as "Resharer" in the collaborators list on the webUI
-    And the current collaborators list should have order "User One,User Two,User Three"
+    Then user "User One" should be listed as "Owner" reshared through "User Two" in the collaborators list on the webUI
+    And the current collaborators list should have order "User One,User Three"
 
   @issue-2898
   Scenario: see resource owner of parent shares in collaborators list
@@ -524,9 +523,8 @@ Feature: Sharing files and folders with internal users
     And user "user3" has logged in using the webUI
     And the user opens folder "simple-folder (2)" using the webUI
     When the user opens the share dialog for folder "simple-empty-folder" using the webUI
-    Then user "User One" should be listed as "Owner" via "simple-folder (2)" in the collaborators list on the webUI
-    And user "User Two" should be listed as "Resharer" via "simple-folder (2)" in the collaborators list on the webUI
-    And the current collaborators list should have order "User One,User Two,User Three"
+    Then user "User One" should be listed as "Owner" reshared through "User Two" via "simple-folder (2)" in the collaborators list on the webUI
+    And the current collaborators list should have order "User One,User Three"
 
   @issue-2898
   Scenario: see resource owner for direct shares in "shared with me"

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -536,15 +536,6 @@ Feature: Sharing files and folders with internal users
     And the user opens the share dialog for folder "simple-folder (2)" using the webUI
     Then user "User One" should be listed as "Owner" in the collaborators list on the webUI
 
-  Scenario: resource owner sees resharer in collaborators list
-    Given user "user3" has been created with default attributes
-    And user "user1" has shared folder "simple-folder" with user "user2"
-    And user "user2" has shared folder "simple-folder (2)" with user "user3"
-    When user "user1" has logged in using the webUI
-    And the user opens the share dialog for folder "simple-folder" using the webUI
-    Then user "User Two" should be listed as "Editor" in the collaborators list on the webUI
-    And user "User Three" should be listed as "Editor" reshared through "User Two" in the collaborators list on the webUI
-
   Scenario Outline: collaborators list contains additional info when enabled
     Given the setting "user_additional_info_field" of app "core" has been set to "<additional-info-field>"
     And user "user1" has shared folder "simple-folder" with user "user2"

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -167,7 +167,7 @@ const createPublicLink = function (sharer, data) {
  * @param {string} role
  * @returns {Promise}
  */
-const assertCollaboratorslistContains = function (type, name, role = null, via = null, resharedThrough = null, additionalInfo = null) {
+const assertCollaboratorslistContains = function (type, name, { role = null, via = null, resharedThrough = null, additionalInfo = null }) {
   if (type !== 'user' && type !== 'group' && type !== 'remote user') {
     throw new Error(`illegal type "${type}"`)
   }
@@ -724,28 +724,32 @@ When(
 )
 
 Then('user {string} should be listed as {string} in the collaborators list on the webUI', function (user, role) {
-  return assertCollaboratorslistContains('user', user, role)
+  return assertCollaboratorslistContains('user', user, { role })
 })
 
 Then('remote user {string} should be listed as {string} via {string} in the collaborators list on the webUI', function (user, role, via) {
   user = util.format('%s@%s', user, client.globals.remote_backend_url)
-  return assertCollaboratorslistContains('remote user', user, role, via)
+  return assertCollaboratorslistContains('remote user', user, { role, via })
 })
 
 Then('user {string} should be listed as {string} via {string} in the collaborators list on the webUI', function (user, role, via) {
-  return assertCollaboratorslistContains('user', user, role, via)
+  return assertCollaboratorslistContains('user', user, { role, via })
 })
 
 Then('user {string} should be listed as {string} reshared through {string} in the collaborators list on the webUI', function (user, role, resharedThrough) {
-  return assertCollaboratorslistContains('user', user, role, null, resharedThrough)
+  return assertCollaboratorslistContains('user', user, { role, resharedThrough })
+})
+
+Then('user {string} should be listed as {string} reshared through {string} via {string} in the collaborators list on the webUI', function (user, role, resharedThrough, via) {
+  return assertCollaboratorslistContains('user', user, { role, resharedThrough, via })
 })
 
 Then('user {string} should be listed with additional info {string} in the collaborators list on the webUI', function (user, additionalInfo) {
-  return assertCollaboratorslistContains('user', user, null, null, null, additionalInfo)
+  return assertCollaboratorslistContains('user', user, { additionalInfo })
 })
 
 Then('user {string} should be listed without additional info in the collaborators list on the webUI', function (user) {
-  return assertCollaboratorslistContains('user', user, null, null, null, false)
+  return assertCollaboratorslistContains('user', user, { additionalInfo: false })
 })
 
 Then('user {string} should be listed as {string} in the collaborators list for file/folder/resource {string} on the webUI', async function (user, role, resource) {
@@ -755,15 +759,15 @@ Then('user {string} should be listed as {string} in the collaborators list for f
     .closeSidebar(100)
     .openSharingDialog(resource)
 
-  return assertCollaboratorslistContains('user', user, role)
+  return assertCollaboratorslistContains('user', user, { role })
 })
 
 Then('group {string} should be listed as {string} in the collaborators list on the webUI', function (group, role) {
-  return assertCollaboratorslistContains('group', group, role)
+  return assertCollaboratorslistContains('group', group, { role })
 })
 
 Then('group {string} should be listed as {string} via {string} in the collaborators list on the webUI', function (group, role, via) {
-  return assertCollaboratorslistContains('group', group, role, via)
+  return assertCollaboratorslistContains('group', group, { role, via })
 })
 
 Then('group {string} should be listed as {string} in the collaborators list for file/folder/resource {string} on the webUI', async function (group, role, resource) {
@@ -773,7 +777,7 @@ Then('group {string} should be listed as {string} in the collaborators list for 
     .closeSidebar(100)
     .openSharingDialog(resource)
 
-  return assertCollaboratorslistContains('group', group, role)
+  return assertCollaboratorslistContains('group', group, { role })
 })
 
 Then('user {string} should not be listed in the collaborators list on the webUI', function (user) {


### PR DESCRIPTION
## Description
For received shares, the resharers user display names are now shown
on top of the owner entry in the collaborators list, with a reshare
icon, instead of having their own entry in the collaborators list.

Moved reshare related tests to the reshare feature file.

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/3850

## Motivation and Context
Based on feedback after reviewing the feature.

## How Has This Been Tested?
- manual test
- acceptance test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
