### PR TITLE
[Tests-Only] Use closeSideBar function of appSideBar page

### DIFF
--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -409,7 +409,7 @@ Then('the versions list for resource {string} should contain {int} entry/entries
     expectedNumber, count
   )
 
-  client.page.FilesPageElement.filesList().closeSidebar(100)
+  client.page.FilesPageElement.appSideBar().closeSidebar(100)
 
   return this
 })


### PR DESCRIPTION
## Description
This PR fixes the error arisen due to the call of the function closesidebar of appsidebar page from fileslist page

## Motivation and Context
There was an error due to the call of the function "closeSideBar" which does not exist on the filesList page but on the appSideBar page.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...