### PR TITLE
[Tests-Only] Moved deleteShareWithUserGroup command into collabratorsDialog

### DIFF
--- a/tests/acceptance/pageObjects/FilesPageElement/SharingDialog/collaboratorsDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/SharingDialog/collaboratorsDialog.js
@@ -1,0 +1,31 @@
+const util = require('util')
+
+module.exports = {
+  commands: {
+    /**
+     *
+     * @returns {Promise.<string[]>} Array of autocomplete webElementIds
+     */
+    deleteShareWithUserGroup: function (item) {
+      const informationSelector = util.format(this.elements.collaboratorInformationByCollaboratorName.selector, item)
+      const deleteSelector = informationSelector + this.elements.deleteShareButton.selector
+      return this
+        .useXpath()
+        .waitForElementVisible(deleteSelector)
+        .waitForAnimationToFinish()
+        .click(deleteSelector)
+        .waitForElementNotPresent(informationSelector)
+    }
+  },
+  elements: {
+    collaboratorInformationByCollaboratorName: {
+      selector: '//*[contains(@class, "files-collaborators-collaborator-name") and .="%s"]/ancestor::*[contains(concat(" ", @class, " "), " files-collaborators-collaborator ")]',
+      locateStrategy: 'xpath'
+    },
+    deleteShareButton: {
+      // within collaboratorInformationByCollaboratorName
+      selector: '//*[contains(@class, "files-collaborators-collaborator-delete")]',
+      locateStrategy: 'xpath'
+    }
+  }
+}

--- a/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
@@ -201,7 +201,11 @@ module.exports = {
      * @param {string} collaborator
      */
     clickEditShare: function (collaborator) {
-      const informationSelector = util.format(this.elements.collaboratorInformationByCollaboratorName.selector, collaborator)
+      const informationSelector = util.format(this.api.page
+        .FilesPageElement
+        .SharingDialog
+        .collaboratorsDialog()
+        .elements.collaboratorInformationByCollaboratorName.selector, collaborator)
       const editSelector = informationSelector + this.elements.editShareButton.selector
       return this
         .useXpath()
@@ -375,20 +379,6 @@ module.exports = {
     },
     /**
      *
-     * @returns {Promise.<string[]>} Array of autocomplete webElementIds
-     */
-    deleteShareWithUserGroup: function (item) {
-      const informationSelector = util.format(this.elements.collaboratorInformationByCollaboratorName.selector, item)
-      const deleteSelector = informationSelector + this.elements.deleteShareButton.selector
-      return this
-        .useXpath()
-        .waitForElementVisible(deleteSelector)
-        .waitForAnimationToFinish()
-        .click(deleteSelector)
-        .waitForElementNotPresent(informationSelector)
-    },
-    /**
-     *
      * @param {string} collaborator
      * @param {string} newRole
      * @returns {Promise}
@@ -554,13 +544,13 @@ module.exports = {
       // addresses users and groups
       selector: '.files-collaborators-collaborator'
     },
-    collaboratorInformationByCollaboratorName: {
-      selector: '//*[contains(@class, "files-collaborators-collaborator-name") and .="%s"]/ancestor::*[contains(concat(" ", @class, " "), " files-collaborators-collaborator ")]',
-      locateStrategy: 'xpath'
-    },
     collaboratorInformationSubName: {
       // within collaboratorsInformation
       selector: '.files-collaborators-collaborator-name'
+    },
+    collaboratorInformationByCollaboratorName: {
+      selector: '//*[contains(@class, "files-collaborators-collaborator-name") and .="%s"]/ancestor::*[contains(concat(" ", @class, " "), " files-collaborators-collaborator ")]',
+      locateStrategy: 'xpath'
     },
     collaboratorInformationSubRole: {
       // within collaboratorsInformation
@@ -594,11 +584,6 @@ module.exports = {
     editShareButton: {
       // within collaboratorInformationByCollaboratorName
       selector: '//*[contains(@class, "files-collaborators-collaborator-edit")]',
-      locateStrategy: 'xpath'
-    },
-    deleteShareButton: {
-      // within collaboratorInformationByCollaboratorName
-      selector: '//*[contains(@class, "files-collaborators-collaborator-delete")]',
       locateStrategy: 'xpath'
     },
     cancelButton: {

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -702,12 +702,12 @@ When('the user opens the link share dialog for file/folder/resource {string} usi
 })
 
 When('the user deletes {string} as collaborator for the current file/folder using the webUI', function (user) {
-  return client.page.FilesPageElement.sharingDialog().deleteShareWithUserGroup(user)
+  return client.page.FilesPageElement.SharingDialog.collaboratorsDialog().deleteShareWithUserGroup(user)
 })
 
 When('the user deletes {string} as remote collaborator for the current file/folder using the webUI', function (user) {
   user = util.format('%s@%s', user, client.globals.remote_backend_url)
-  return client.page.FilesPageElement.sharingDialog().deleteShareWithUserGroup(user)
+  return client.page.FilesPageElement.SharingDialog.collaboratorsDialog().deleteShareWithUserGroup(user)
 })
 
 When(


### PR DESCRIPTION
## Description

Function `deleteShareWithUserGroup` and related methods are moved from sharingDialog PageObject into collabratorsDialog.
## Related Issue
#2677 

## Motivation and Context
Appropriate placements for different PO methods and elements

## How Has This Been Tested?
- locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
