### PR TITLE
Fixed responsive buttons layout in app bar when multiple files are se…

### DIFF
--- a/changelog/unreleased/3011
+++ b/changelog/unreleased/3011
@@ -1,0 +1,6 @@
+Bugfix: Responsive buttons layout in app bar when multiple files are selected
+
+We've fixed the responsive buttons layout in files app bar when multiple files are selected where bulk actions where overlapping and height of the buttons was increased.
+
+https://github.com/owncloud/phoenix/issues/3011
+https://github.com/owncloud/phoenix/pull/3083


### PR DESCRIPTION
## Description
Moved the delete selected behind new and search button so it breaks to newline properly on smaller screens.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #3011

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually

## Screenshots (if appropriate):
![123 123 123 123_8300_index html(iPhone 5_SE)](https://user-images.githubusercontent.com/25989331/75145751-dcd4cb00-56f9-11ea-9466-6ad14fe5136d.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 