### PR TITLE
[Tests-Only] Moved clickCreateShare command into collaboratorsDialog

### DIFF
--- a/tests/acceptance/pageObjects/FilesPageElement/SharingDialog/collaboratorsDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/SharingDialog/collaboratorsDialog.js
@@ -3,11 +3,14 @@ const util = require('util')
 module.exports = {
   commands: {
     /**
-     *
+     * @param collaborator
      * @returns {Promise.<string[]>} Array of autocomplete webElementIds
      */
-    deleteShareWithUserGroup: function (item) {
-      const informationSelector = util.format(this.elements.collaboratorInformationByCollaboratorName.selector, item)
+    deleteShareWithUserGroup: function (collaborator) {
+      const informationSelector = util.format(
+        this.elements.collaboratorInformationByCollaboratorName.selector,
+        collaborator
+      )
       const deleteSelector = informationSelector + this.elements.deleteShareButton.selector
       return this
         .useXpath()
@@ -15,6 +18,19 @@ module.exports = {
         .waitForAnimationToFinish()
         .click(deleteSelector)
         .waitForElementNotPresent(informationSelector)
+    },
+    /**
+     * Clicks the button to add a new collaborator
+     */
+    clickCreateShare: function () {
+      return this
+        .initAjaxCounters()
+        .useXpath()
+        .waitForElementVisible('@createShareButton')
+        .click('@createShareButton')
+        .waitForOutstandingAjaxCalls()
+        .waitForElementVisible('@createShareDialog')
+        .waitForAnimationToFinish()
     }
   },
   elements: {
@@ -25,6 +41,14 @@ module.exports = {
     deleteShareButton: {
       // within collaboratorInformationByCollaboratorName
       selector: '//*[contains(@class, "files-collaborators-collaborator-delete")]',
+      locateStrategy: 'xpath'
+    },
+    createShareButton: {
+      selector: '//*[contains(@class, "files-collaborators-open-add-share-dialog-button")]',
+      locateStrategy: 'xpath'
+    },
+    createShareDialog: {
+      selector: '//*[contains(@class, "files-collaborators-collaborator-add-dialog")]',
       locateStrategy: 'xpath'
     }
   }

--- a/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
@@ -146,7 +146,7 @@ module.exports = {
      * @param {string} permissions
      */
     shareWithUserOrGroup: async function (sharee, shareWithGroup = false, role, permissions, remote = false) {
-      await this.clickCreateShare()
+      await this.api.page.FilesPageElement.SharingDialog.collaboratorsDialog().clickCreateShare()
       await this.selectCollaboratorForShare(sharee, shareWithGroup, remote)
       await this.selectRoleForNewCollaborator(role)
       if (permissions === undefined) {
@@ -184,28 +184,14 @@ module.exports = {
         .waitForElementNotPresent('@saveShareButton')
     },
     /**
-     * Clicks the button to add a new collaborator
-     */
-    clickCreateShare: function () {
-      return this
-        .initAjaxCounters()
-        .useXpath()
-        .waitForElementVisible('@createShareButton')
-        .click('@createShareButton')
-        .waitForOutstandingAjaxCalls()
-        .waitForElementVisible('@createShareDialog')
-        .waitForAnimationToFinish()
-    },
-    /**
      *
      * @param {string} collaborator
      */
     clickEditShare: function (collaborator) {
-      const informationSelector = util.format(this.api.page
-        .FilesPageElement
-        .SharingDialog
-        .collaboratorsDialog()
-        .elements.collaboratorInformationByCollaboratorName.selector, collaborator)
+      const informationSelector = util.format(
+        this.elements.collaboratorInformationByCollaboratorName.selector,
+        collaborator
+      )
       const editSelector = informationSelector + this.elements.editShareButton.selector
       return this
         .useXpath()
@@ -418,8 +404,14 @@ module.exports = {
       }
       if (filterDisplayName !== null) {
         informationSelector = {
-          selector: util.format(this.elements.collaboratorInformationByCollaboratorName.selector, filterDisplayName),
-          locateStrategy: this.elements.collaboratorInformationByCollaboratorName.locateStrategy,
+          selector: util.format(this.api.page.FilesPageElement
+            .SharingDialog
+            .collaboratorsDialog()
+            .elements.collaboratorInformationByCollaboratorName.selector, filterDisplayName),
+          locateStrategy: this.api.page.FilesPageElement
+            .SharingDialog
+            .collaboratorsDialog()
+            .elements.collaboratorInformationByCollaboratorName.locateStrategy,
           abortOnFailure: false
         }
       }
@@ -577,10 +569,6 @@ module.exports = {
       selector: '/a',
       locateStrategy: 'xpath'
     },
-    createShareButton: {
-      selector: '//*[contains(@class, "files-collaborators-open-add-share-dialog-button")]',
-      locateStrategy: 'xpath'
-    },
     editShareButton: {
       // within collaboratorInformationByCollaboratorName
       selector: '//*[contains(@class, "files-collaborators-collaborator-edit")]',
@@ -588,10 +576,6 @@ module.exports = {
     },
     cancelButton: {
       selector: '.files-collaborators-collaborator-cancel'
-    },
-    createShareDialog: {
-      selector: '//*[contains(@class, "files-collaborators-collaborator-add-dialog")]',
-      locateStrategy: 'xpath'
     },
     editShareDialog: {
       selector: '//*[contains(@class, "files-collaborators-collaborator-edit-dialog")]',

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -457,11 +457,11 @@ Given('the administrator has excluded group {string} from receiving shares', asy
 })
 
 When('the user opens the share creation dialog in the webUI', function () {
-  return client.page.FilesPageElement.sharingDialog().clickCreateShare()
+  return client.page.FilesPageElement.SharingDialog.collaboratorsDialog().clickCreateShare()
 })
 
 When('the user cancels the share creation dialog in the webUI', function () {
-  return client.page.FilesPageElement.sharingDialog().clickCancel()
+  return client.page.FilesPageElement.collaboratorsDialog().clickCancel()
 })
 
 When('the user types {string} in the share-with-field', function (input) {


### PR DESCRIPTION
## Description
Function `clickCreateShare` and related methods are moved from sharingDialog PageObject into collabratorsDialog.

## Related Issue
#2677 

## Motivation and Context
Appropriate placements for different PO methods and elements.

## How Has This Been Tested?
- locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
