### PR TITLE
[Tests-Only] Moved clickEditShare command into collaboratorsDialog 

### DIFF
--- a/tests/acceptance/pageObjects/FilesPageElement/SharingDialog/collaboratorsDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/SharingDialog/collaboratorsDialog.js
@@ -3,7 +3,7 @@ const util = require('util')
 module.exports = {
   commands: {
     /**
-     * @param collaborator
+     * @param {string} collaborator
      * @returns {Promise.<string[]>} Array of autocomplete webElementIds
      */
     deleteShareWithUserGroup: function (collaborator) {
@@ -31,6 +31,24 @@ module.exports = {
         .waitForOutstandingAjaxCalls()
         .waitForElementVisible('@createShareDialog')
         .waitForAnimationToFinish()
+        .useCss()
+    },
+    /**
+     *
+     * @param {string} collaborator
+     */
+    clickEditShare: function (collaborator) {
+      const informationSelector = util.format(
+        this.elements.collaboratorInformationByCollaboratorName.selector,
+        collaborator
+      )
+      const editSelector = informationSelector + this.elements.editShareButton.selector
+      return this
+        .useXpath()
+        .waitForElementVisible(editSelector)
+        .click(editSelector)
+        .waitForElementVisible('@editShareDialog')
+        .useCss()
     }
   },
   elements: {
@@ -49,6 +67,15 @@ module.exports = {
     },
     createShareDialog: {
       selector: '//*[contains(@class, "files-collaborators-collaborator-add-dialog")]',
+      locateStrategy: 'xpath'
+    },
+    editShareButton: {
+      // within collaboratorInformationByCollaboratorName
+      selector: '//*[contains(@class, "files-collaborators-collaborator-edit")]',
+      locateStrategy: 'xpath'
+    },
+    editShareDialog: {
+      selector: '//*[contains(@class, "files-collaborators-collaborator-edit-dialog")]',
       locateStrategy: 'xpath'
     }
   }

--- a/tests/acceptance/pageObjects/FilesPageElement/SharingDialog/collaboratorsDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/SharingDialog/collaboratorsDialog.js
@@ -3,11 +3,14 @@ const util = require('util')
 module.exports = {
   commands: {
     /**
-     *
+     * @param collaborator
      * @returns {Promise.<string[]>} Array of autocomplete webElementIds
      */
-    deleteShareWithUserGroup: function (item) {
-      const informationSelector = util.format(this.elements.collaboratorInformationByCollaboratorName.selector, item)
+    deleteShareWithUserGroup: function (collaborator) {
+      const informationSelector = util.format(
+        this.elements.collaboratorInformationByCollaboratorName.selector,
+        collaborator
+      )
       const deleteSelector = informationSelector + this.elements.deleteShareButton.selector
       return this
         .useXpath()
@@ -15,6 +18,19 @@ module.exports = {
         .waitForAnimationToFinish()
         .click(deleteSelector)
         .waitForElementNotPresent(informationSelector)
+    },
+    /**
+     * Clicks the button to add a new collaborator
+     */
+    clickCreateShare: function () {
+      return this
+        .initAjaxCounters()
+        .useXpath()
+        .waitForElementVisible('@createShareButton')
+        .click('@createShareButton')
+        .waitForOutstandingAjaxCalls()
+        .waitForElementVisible('@createShareDialog')
+        .waitForAnimationToFinish()
     }
   },
   elements: {
@@ -25,6 +41,14 @@ module.exports = {
     deleteShareButton: {
       // within collaboratorInformationByCollaboratorName
       selector: '//*[contains(@class, "files-collaborators-collaborator-delete")]',
+      locateStrategy: 'xpath'
+    },
+    createShareButton: {
+      selector: '//*[contains(@class, "files-collaborators-open-add-share-dialog-button")]',
+      locateStrategy: 'xpath'
+    },
+    createShareDialog: {
+      selector: '//*[contains(@class, "files-collaborators-collaborator-add-dialog")]',
       locateStrategy: 'xpath'
     }
   }

--- a/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
@@ -146,7 +146,7 @@ module.exports = {
      * @param {string} permissions
      */
     shareWithUserOrGroup: async function (sharee, shareWithGroup = false, role, permissions, remote = false) {
-      await this.clickCreateShare()
+      await this.api.page.FilesPageElement.SharingDialog.collaboratorsDialog().clickCreateShare()
       await this.selectCollaboratorForShare(sharee, shareWithGroup, remote)
       await this.selectRoleForNewCollaborator(role)
       if (permissions === undefined) {
@@ -184,28 +184,14 @@ module.exports = {
         .waitForElementNotPresent('@saveShareButton')
     },
     /**
-     * Clicks the button to add a new collaborator
-     */
-    clickCreateShare: function () {
-      return this
-        .initAjaxCounters()
-        .useXpath()
-        .waitForElementVisible('@createShareButton')
-        .click('@createShareButton')
-        .waitForOutstandingAjaxCalls()
-        .waitForElementVisible('@createShareDialog')
-        .waitForAnimationToFinish()
-    },
-    /**
      *
      * @param {string} collaborator
      */
     clickEditShare: function (collaborator) {
-      const informationSelector = util.format(this.api.page
-        .FilesPageElement
-        .SharingDialog
-        .collaboratorsDialog()
-        .elements.collaboratorInformationByCollaboratorName.selector, collaborator)
+      const informationSelector = util.format(
+        this.elements.collaboratorInformationByCollaboratorName.selector,
+        collaborator
+      )
       const editSelector = informationSelector + this.elements.editShareButton.selector
       return this
         .useXpath()
@@ -418,8 +404,14 @@ module.exports = {
       }
       if (filterDisplayName !== null) {
         informationSelector = {
-          selector: util.format(this.elements.collaboratorInformationByCollaboratorName.selector, filterDisplayName),
-          locateStrategy: this.elements.collaboratorInformationByCollaboratorName.locateStrategy,
+          selector: util.format(this.api.page.FilesPageElement
+            .SharingDialog
+            .collaboratorsDialog()
+            .elements.collaboratorInformationByCollaboratorName.selector, filterDisplayName),
+          locateStrategy: this.api.page.FilesPageElement
+            .SharingDialog
+            .collaboratorsDialog()
+            .elements.collaboratorInformationByCollaboratorName.locateStrategy,
           abortOnFailure: false
         }
       }
@@ -577,10 +569,6 @@ module.exports = {
       selector: '/a',
       locateStrategy: 'xpath'
     },
-    createShareButton: {
-      selector: '//*[contains(@class, "files-collaborators-open-add-share-dialog-button")]',
-      locateStrategy: 'xpath'
-    },
     editShareButton: {
       // within collaboratorInformationByCollaboratorName
       selector: '//*[contains(@class, "files-collaborators-collaborator-edit")]',
@@ -588,10 +576,6 @@ module.exports = {
     },
     cancelButton: {
       selector: '.files-collaborators-collaborator-cancel'
-    },
-    createShareDialog: {
-      selector: '//*[contains(@class, "files-collaborators-collaborator-add-dialog")]',
-      locateStrategy: 'xpath'
     },
     editShareDialog: {
       selector: '//*[contains(@class, "files-collaborators-collaborator-edit-dialog")]',

--- a/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
@@ -4,6 +4,7 @@ const federationSharePostfix = '\nRemote user'
 const util = require('util')
 const _ = require('lodash')
 const { COLLABORATOR_PERMISSION_ARRAY } = require('../../helpers/sharingHelper')
+const { client } = require('nightwatch-api')
 const collaboratorDialog = client.page.FilesPageElement.SharingDialog.collaboratorsDialog()
 
 module.exports = {
@@ -521,13 +522,13 @@ module.exports = {
       // addresses users and groups
       selector: '.files-collaborators-collaborator'
     },
-    collaboratorInformationByCollaboratorName: {
-      selector: '//*[contains(@class, "files-collaborators-collaborator-name") and .="%s"]/ancestor::*[contains(concat(" ", @class, " "), " files-collaborators-collaborator ")]',
-      locateStrategy: 'xpath'
-    },
     collaboratorInformationSubName: {
       // within collaboratorsInformation
       selector: '.files-collaborators-collaborator-name'
+    },
+    collaboratorInformationByCollaboratorName: {
+      selector: '//*[contains(@class, "files-collaborators-collaborator-name") and .="%s"]/ancestor::*[contains(concat(" ", @class, " "), " files-collaborators-collaborator ")]',
+      locateStrategy: 'xpath'
     },
     collaboratorInformationSubRole: {
       // within collaboratorsInformation
@@ -554,17 +555,8 @@ module.exports = {
       selector: '/a',
       locateStrategy: 'xpath'
     },
-    editShareButton: {
-      // within collaboratorInformationByCollaboratorName
-      selector: '//*[contains(@class, "files-collaborators-collaborator-edit")]',
-      locateStrategy: 'xpath'
-    },
     cancelButton: {
       selector: '.files-collaborators-collaborator-cancel'
-    },
-    editShareDialog: {
-      selector: '//*[contains(@class, "files-collaborators-collaborator-edit-dialog")]',
-      locateStrategy: 'xpath'
     },
     addShareSaveButton: {
       selector: '#files-collaborators-collaborator-save-new-share-button'

--- a/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
@@ -4,6 +4,7 @@ const federationSharePostfix = '\nRemote user'
 const util = require('util')
 const _ = require('lodash')
 const { COLLABORATOR_PERMISSION_ARRAY } = require('../../helpers/sharingHelper')
+const collaboratorDialog = client.page.FilesPageElement.SharingDialog.collaboratorsDialog()
 
 module.exports = {
   commands: {
@@ -146,7 +147,7 @@ module.exports = {
      * @param {string} permissions
      */
     shareWithUserOrGroup: async function (sharee, shareWithGroup = false, role, permissions, remote = false) {
-      await this.api.page.FilesPageElement.SharingDialog.collaboratorsDialog().clickCreateShare()
+      await collaboratorDialog.clickCreateShare()
       await this.selectCollaboratorForShare(sharee, shareWithGroup, remote)
       await this.selectRoleForNewCollaborator(role)
       if (permissions === undefined) {
@@ -182,22 +183,6 @@ module.exports = {
         .click('@saveShareButton')
         .waitForOutstandingAjaxCalls()
         .waitForElementNotPresent('@saveShareButton')
-    },
-    /**
-     *
-     * @param {string} collaborator
-     */
-    clickEditShare: function (collaborator) {
-      const informationSelector = util.format(
-        this.elements.collaboratorInformationByCollaboratorName.selector,
-        collaborator
-      )
-      const editSelector = informationSelector + this.elements.editShareButton.selector
-      return this
-        .useXpath()
-        .waitForElementVisible(editSelector)
-        .click(editSelector)
-        .waitForElementVisible('@editShareDialog')
     },
     clickCancel: function () {
       return this
@@ -254,7 +239,7 @@ module.exports = {
      * @param {string} requiredPermissions
      */
     changeCustomPermissionsTo: async function (collaborator, requiredPermissions) {
-      await this.clickEditShare(collaborator)
+      await collaboratorDialog.clickEditShare(collaborator)
 
       const requiredPermissionArray = this.getArrayFromPermissionString(requiredPermissions)
       const sharePermissions = await this.getSharePermissions()
@@ -281,7 +266,7 @@ module.exports = {
      * @param {string} permissions
      */
     getDisplayedPermission: async function (collaborator) {
-      await this.clickEditShare(collaborator)
+      await collaboratorDialog.clickEditShare(collaborator)
       // read the permissions from the checkboxes
       const currentSharePermissions = await this.getSharePermissions()
       await this.clickCancel()
@@ -292,7 +277,7 @@ module.exports = {
      * @param {string} collaborator
      */
     disableAllCustomPermissions: async function (collaborator) {
-      await this.clickEditShare(collaborator)
+      await collaboratorDialog.clickEditShare(collaborator)
       const sharePermissions = await this.getSharePermissions(collaborator)
       const enabledPermissions = Object.keys(sharePermissions)
         .filter(permission => sharePermissions[permission] === true)
@@ -370,7 +355,7 @@ module.exports = {
      * @returns {Promise}
      */
     changeCollaboratorRole: async function (collaborator, newRole) {
-      await this.clickEditShare(collaborator)
+      await collaboratorDialog.clickEditShare(collaborator)
       await this.changeCollaboratorRoleInDropdown(newRole)
       return this.saveCollaboratorPermission()
     },
@@ -536,13 +521,13 @@ module.exports = {
       // addresses users and groups
       selector: '.files-collaborators-collaborator'
     },
-    collaboratorInformationSubName: {
-      // within collaboratorsInformation
-      selector: '.files-collaborators-collaborator-name'
-    },
     collaboratorInformationByCollaboratorName: {
       selector: '//*[contains(@class, "files-collaborators-collaborator-name") and .="%s"]/ancestor::*[contains(concat(" ", @class, " "), " files-collaborators-collaborator ")]',
       locateStrategy: 'xpath'
+    },
+    collaboratorInformationSubName: {
+      // within collaboratorsInformation
+      selector: '.files-collaborators-collaborator-name'
     },
     collaboratorInformationSubRole: {
       // within collaboratorsInformation

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -457,11 +457,11 @@ Given('the administrator has excluded group {string} from receiving shares', asy
 })
 
 When('the user opens the share creation dialog in the webUI', function () {
-  return client.page.FilesPageElement.sharingDialog().clickCreateShare()
+  return client.page.FilesPageElement.SharingDialog.collaboratorsDialog().clickCreateShare()
 })
 
 When('the user cancels the share creation dialog in the webUI', function () {
-  return client.page.FilesPageElement.sharingDialog().clickCancel()
+  return client.page.FilesPageElement.collaboratorsDialog().clickCancel()
 })
 
 When('the user types {string} in the share-with-field', function (input) {

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -461,7 +461,7 @@ When('the user opens the share creation dialog in the webUI', function () {
 })
 
 When('the user cancels the share creation dialog in the webUI', function () {
-  return client.page.FilesPageElement.collaboratorsDialog().clickCancel()
+  return client.page.FilesPageElement.sharingDialog().clickCancel()
 })
 
 When('the user types {string} in the share-with-field', function (input) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Function `clickEditShare` and related methods are moved from sharingDialog PageObject into collaboratorsDialog.

## Related Issue
#2677 

## Motivation and Context
Appropriate placements for different PO methods and elements.

## How Has This Been Tested?
- locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
