### PR TITLE
[Tests-Only] Moved getCollaboratorsList and getCollaboratorsListNames command into collabratorsDialog

### DIFF
--- a/tests/acceptance/pageObjects/FilesPageElement/SharingDialog/collaboratorsDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/SharingDialog/collaboratorsDialog.js
@@ -49,6 +49,85 @@ module.exports = {
         .click(editSelector)
         .waitForElementVisible('@editShareDialog')
         .useCss()
+    },
+    /**
+     *
+     * @param {Object.<String,Object>} subSelectors Map of arbitrary attribute name to selector to query
+     * inside the collaborator element, defaults to all when null
+     * @returns {Promise.<string[]>} Array of users/groups in share list
+     */
+    getCollaboratorsList: async function (subSelectors = null, filterDisplayName = null) {
+      let results = []
+      let informationSelector = {
+        selector: '@collaboratorsInformation',
+        abortOnFailure: false
+      }
+      if (filterDisplayName !== null) {
+        informationSelector = {
+          selector: util.format(this.elements.collaboratorInformationByCollaboratorName.selector, filterDisplayName),
+          locateStrategy: this.elements.collaboratorInformationByCollaboratorName.locateStrategy,
+          abortOnFailure: false
+        }
+      }
+
+      if (subSelectors === null) {
+        subSelectors = {
+          displayName: this.elements.collaboratorInformationSubName,
+          role: this.elements.collaboratorInformationSubRole,
+          shareType: this.elements.collaboratorInformationSubShareType,
+          additionalInfo: this.elements.collaboratorInformationSubAdditionalInfo,
+          viaLabel: this.elements.collaboratorInformationSubVia,
+          resharer: this.elements.collaboratorInformationSubResharer
+        }
+      }
+
+      let collaboratorsElementIds = null
+      await this.initAjaxCounters()
+        .waitForElementPresent(informationSelector)
+        .waitForOutstandingAjaxCalls()
+        .api.elements('css selector', this.elements.collaboratorsInformation, result => {
+          collaboratorsElementIds = result.value.map(item => item[Object.keys(item)[0]])
+        })
+
+      results = collaboratorsElementIds.map(async (collaboratorElementId) => {
+        const collaboratorResult = {}
+        for (const attrName in subSelectors) {
+          let attrElementId = null
+          await this.api.elementIdElement(
+            collaboratorElementId,
+            'css selector',
+            subSelectors[attrName],
+            (result) => {
+              if (result.status !== -1) {
+                attrElementId = result.value.ELEMENT
+              }
+            }
+          )
+
+          if (attrElementId) {
+            await this.api.elementIdText(attrElementId, (text) => {
+              collaboratorResult[attrName] = text.value
+            })
+          } else {
+            collaboratorResult[attrName] = false
+          }
+        }
+
+        return collaboratorResult
+      })
+
+      results = await Promise.all(results)
+      return results
+    },
+    /**
+     *
+     * @returns {Promise.<string[]>} Array of user/group display names in share list
+     */
+    getCollaboratorsListNames: async function () {
+      const list = await this.getCollaboratorsList({
+        name: this.elements.collaboratorInformationSubName
+      })
+      return list.map(result => result.name)
     }
   },
   elements: {
@@ -77,6 +156,34 @@ module.exports = {
     editShareDialog: {
       selector: '//*[contains(@class, "files-collaborators-collaborator-edit-dialog")]',
       locateStrategy: 'xpath'
+    },
+    collaboratorsInformation: {
+      // addresses users and groups
+      selector: '.files-collaborators-collaborator'
+    },
+    collaboratorInformationSubName: {
+      // within collaboratorsInformation
+      selector: '.files-collaborators-collaborator-name'
+    },
+    collaboratorInformationSubRole: {
+      // within collaboratorsInformation
+      selector: '.files-collaborators-collaborator-role'
+    },
+    collaboratorInformationSubShareType: {
+      // within collaboratorsInformation
+      selector: '.files-collaborators-collaborator-share-type'
+    },
+    collaboratorInformationSubAdditionalInfo: {
+      // within collaboratorsInformation
+      selector: '.files-collaborators-collaborator-additional-info'
+    },
+    collaboratorInformationSubVia: {
+      // within collaboratorsInformation
+      selector: '.files-collaborators-collaborator-via-label'
+    },
+    collaboratorInformationSubResharer: {
+      // within collaboratorsInformation
+      selector: '.files-collaborators-collaborator-reshare-information'
     }
   }
 }

--- a/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
@@ -378,91 +378,6 @@ module.exports = {
     },
     /**
      *
-     * @param {Object.<String,Object>} subSelectors Map of arbitrary attribute name to selector to query
-     * inside the collaborator element, defaults to all when null
-     * @returns {Promise.<string[]>} Array of users/groups in share list
-     */
-    getCollaboratorsList: async function (subSelectors = null, filterDisplayName = null) {
-      let results = []
-      let informationSelector = {
-        selector: '@collaboratorsInformation',
-        abortOnFailure: false
-      }
-      if (filterDisplayName !== null) {
-        informationSelector = {
-          selector: util.format(this.api.page.FilesPageElement
-            .SharingDialog
-            .collaboratorsDialog()
-            .elements.collaboratorInformationByCollaboratorName.selector, filterDisplayName),
-          locateStrategy: this.api.page.FilesPageElement
-            .SharingDialog
-            .collaboratorsDialog()
-            .elements.collaboratorInformationByCollaboratorName.locateStrategy,
-          abortOnFailure: false
-        }
-      }
-
-      if (subSelectors === null) {
-        subSelectors = {
-          displayName: this.elements.collaboratorInformationSubName,
-          role: this.elements.collaboratorInformationSubRole,
-          shareType: this.elements.collaboratorInformationSubShareType,
-          additionalInfo: this.elements.collaboratorInformationSubAdditionalInfo,
-          viaLabel: this.elements.collaboratorInformationSubVia,
-          resharer: this.elements.collaboratorInformationSubResharer
-        }
-      }
-
-      let collaboratorsElementIds = null
-      await this.initAjaxCounters()
-        .waitForElementPresent(informationSelector)
-        .waitForOutstandingAjaxCalls()
-        .api.elements('css selector', this.elements.collaboratorsInformation, result => {
-          collaboratorsElementIds = result.value.map(item => item[Object.keys(item)[0]])
-        })
-
-      results = collaboratorsElementIds.map(async (collaboratorElementId) => {
-        const collaboratorResult = {}
-        for (const attrName in subSelectors) {
-          let attrElementId = null
-          await this.api.elementIdElement(
-            collaboratorElementId,
-            'css selector',
-            subSelectors[attrName],
-            (result) => {
-              if (result.status !== -1) {
-                attrElementId = result.value.ELEMENT
-              }
-            }
-          )
-
-          if (attrElementId) {
-            await this.api.elementIdText(attrElementId, (text) => {
-              collaboratorResult[attrName] = text.value
-            })
-          } else {
-            collaboratorResult[attrName] = false
-          }
-        }
-
-        return collaboratorResult
-      })
-
-      results = await Promise.all(results)
-      return results
-    },
-    /**
-     *
-     * @returns {Promise.<string[]>} Array of user/group display names in share list
-     */
-    getCollaboratorsListNames: async function () {
-      const list = await this.getCollaboratorsList({
-        name: this.elements.collaboratorInformationSubName
-      })
-      return list.map(result => result.name)
-    },
-    /**
-     *
      * @returns {string}
      */
     getGroupSharePostfix: function () {
@@ -517,38 +432,6 @@ module.exports = {
     sharedWithListItem: {
       selector: '//*[@id="file-share-list"]//*[@class="oc-user"]//div[.="%s"]/../..',
       locateStrategy: 'xpath'
-    },
-    collaboratorsInformation: {
-      // addresses users and groups
-      selector: '.files-collaborators-collaborator'
-    },
-    collaboratorInformationSubName: {
-      // within collaboratorsInformation
-      selector: '.files-collaborators-collaborator-name'
-    },
-    collaboratorInformationByCollaboratorName: {
-      selector: '//*[contains(@class, "files-collaborators-collaborator-name") and .="%s"]/ancestor::*[contains(concat(" ", @class, " "), " files-collaborators-collaborator ")]',
-      locateStrategy: 'xpath'
-    },
-    collaboratorInformationSubRole: {
-      // within collaboratorsInformation
-      selector: '.files-collaborators-collaborator-role'
-    },
-    collaboratorInformationSubShareType: {
-      // within collaboratorsInformation
-      selector: '.files-collaborators-collaborator-share-type'
-    },
-    collaboratorInformationSubAdditionalInfo: {
-      // within collaboratorsInformation
-      selector: '.files-collaborators-collaborator-additional-info'
-    },
-    collaboratorInformationSubVia: {
-      // within collaboratorsInformation
-      selector: '.files-collaborators-collaborator-via-label'
-    },
-    collaboratorInformationSubResharer: {
-      // within collaboratorsInformation
-      selector: '.files-collaborators-collaborator-reshare-information'
     },
     collaboratorMoreInformation: {
       // within collaboratorInformationByCollaboratorName

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -172,7 +172,7 @@ const assertCollaboratorslistContains = function (type, name, role = null, via =
     throw new Error(`illegal type "${type}"`)
   }
 
-  return client.page.FilesPageElement.sharingDialog().getCollaboratorsList(null, name)
+  return client.page.FilesPageElement.SharingDialog.collaboratorsDialog().getCollaboratorsList(null, name)
     .then(shares => {
       const share = shares.find(share => {
         return (name === share.displayName && type === share.shareType.toLowerCase())
@@ -209,10 +209,10 @@ const assertCollaboratorslistDoesNotContain = function (type, name) {
   if (type !== 'user' && type !== 'group') {
     throw new Error('illegal type')
   }
-  const sharingDialog = client.page.FilesPageElement.sharingDialog()
-  return sharingDialog.getCollaboratorsList({
-    displayName: sharingDialog.elements.collaboratorInformationSubName,
-    shareType: sharingDialog.elements.collaboratorInformationSubShareType
+  const collaboratorsDialog = client.page.FilesPageElement.SharingDialog.collaboratorsDialog()
+  return collaboratorsDialog.getCollaboratorsList({
+    displayName: collaboratorsDialog.elements.collaboratorInformationSubName,
+    shareType: collaboratorsDialog.elements.collaboratorInformationSubShareType
   }, name).then(shares => {
     const share = shares.find(share => {
       return (name === share.displayName && type === share.shareType.toLowerCase())
@@ -830,14 +830,14 @@ Then('the collaborators list for file/folder/resource {string} should be empty',
     .openSharingDialog(resource)
 
   const count = (await api
-    .sharingDialog()
+    .SharingDialog.collaboratorsDialog()
     .getCollaboratorsList({})
   ).length
   assert.strictEqual(count, 0, `Expected to have no collaborators for '${resource}', Found: ${count}`)
 })
 
 Then('the current collaborators list should have order {string}', async function (expectedNames) {
-  const actualNames = (await client.page.FilesPageElement.sharingDialog().getCollaboratorsListNames()).join(',')
+  const actualNames = (await client.page.FilesPageElement.SharingDialog.collaboratorsDialog().getCollaboratorsListNames()).join(',')
   assert.strictEqual(actualNames, expectedNames, `Expected to have collaborators in order '${expectedNames}', Found: ${actualNames}`)
 })
 


### PR DESCRIPTION
## Description
Function `getCollaboratorsList` and `getCollaboratorsListNames` along with their related methods are moved from sharingDialog PageObject into collabratorsDialog.

## Related Issue
#2677 

## Motivation and Context
Appropriate placements for different PO methods and elements

## How Has This Been Tested?
- locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
