### PR TITLE
[Tests-Only] Change acceptance test steps to consistently say 'in the trashbin'

### DIFF
--- a/tests/acceptance/features/webUIFiles/search.feature
+++ b/tests/acceptance/features/webUIFiles/search.feature
@@ -133,7 +133,7 @@ Feature: Search
     And file "strängéनेपालीloremfile.txt" with path "/strängé नेपाली folder" should be listed in the search results in the other folders section on the webUI
 
   @issue-1726
-  Scenario: Search for deleted folder in trashbin
+  Scenario: Search for deleted folder in the trashbin
     Given user "user1" has created folder "deleted folder"
     And user "user1" has created folder "not deleted folder"
     And the following files have been deleted by user "user1"
@@ -165,4 +165,4 @@ Feature: Search
     Then file "lorem-big.txt" should be listed on the webUI
     #Then file "lorem-big.txt" should not be listed on the webUI
     And as "user1" file "lorem-big.txt" should not exist
-    And as "user1" the file with original path "lorem-big.txt" should exist in trash
+    And as "user1" the file with original path "lorem-big.txt" should exist in the trashbin

--- a/tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature
@@ -18,10 +18,10 @@ Feature: files and folders exist in the trashbin after being deleted
       | strängé नेपाली folder                 |
       | strängé filename (duplicate #2 &).txt |
     And the user browses to the trashbin page
-    Then as "user1" folder "simple-folder" should exist in trash
-    And as "user1" file "lorem.txt" should exist in trash
-    And as "user1" folder "strängé नेपाली folder" should exist in trash
-    And as "user1" file "strängé filename (duplicate #2 &).txt" should exist in trash
+    Then as "user1" folder "simple-folder" should exist in the trashbin
+    And as "user1" file "lorem.txt" should exist in the trashbin
+    And as "user1" folder "strängé नेपाली folder" should exist in the trashbin
+    And as "user1" file "strängé filename (duplicate #2 &).txt" should exist in the trashbin
     And the deleted elements should be listed on the webUI
 
   Scenario: Delete a file with problematic characters and check it is in the trashbin
@@ -53,10 +53,10 @@ Feature: files and folders exist in the trashbin after being deleted
       | lorem.txt     |
       | simple-folder |
     And the user browses to the trashbin page
-    Then as "user1" file "data.zip" should exist in trash
-    And as "user1" file "lorem.txt" should exist in trash
-    And as "user1" folder "simple-folder" should exist in trash
-    And as "user1" the file with original path "simple-folder/lorem.txt" should exist in trash
+    Then as "user1" file "data.zip" should exist in the trashbin
+    And as "user1" file "lorem.txt" should exist in the trashbin
+    And as "user1" folder "simple-folder" should exist in the trashbin
+    And as "user1" the file with original path "simple-folder/lorem.txt" should exist in the trashbin
     And the deleted elements should be listed on the webUI
 
   @issue-1725 @issue-1910
@@ -65,8 +65,8 @@ Feature: files and folders exist in the trashbin after being deleted
     And the user has created folder "my-other-empty-folder"
     When the user reloads the current page of the webUI
     And the user deletes folder "my-empty-folder" using the webUI
-    Then as "user1" folder "my-empty-folder" should exist in trash
-    But as "user1" the folder with original path "my-other-empty-folder" should not exist in trash
+    Then as "user1" folder "my-empty-folder" should exist in the trashbin
+    But as "user1" the folder with original path "my-other-empty-folder" should not exist in the trashbin
     When the user browses to the trashbin page
     Then folder "my-empty-folder" should be listed on the webUI
     But folder "my-other-empty-folder" should not be listed on the webUI
@@ -88,9 +88,9 @@ Feature: files and folders exist in the trashbin after being deleted
       | name      |
       | lorem.txt |
     And the user browses to the trashbin page
-    Then as "user1" the file with original path "lorem.txt" should exist in trash
-    And as "user1" the file with original path "simple-folder/lorem.txt" should exist in trash
-    And as "user1" the file with original path "strängé नेपाली folder/lorem.txt" should exist in trash
+    Then as "user1" the file with original path "lorem.txt" should exist in the trashbin
+    And as "user1" the file with original path "simple-folder/lorem.txt" should exist in the trashbin
+    And as "user1" the file with original path "strängé नेपाली folder/lorem.txt" should exist in the trashbin
     And file "lorem.txt" should be listed on the webUI
 #    And file "lorem.txt" with path "./lorem.txt" should be listed in the trashbin on the webUI
 #    And file "lorem.txt" with path "simple-folder/lorem.txt" should be listed in the trashbin on the webUI

--- a/tests/acceptance/features/webUITrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinRestore.feature
@@ -110,8 +110,8 @@ Feature: Restore deleted files/folders
     And the user restores file "simple-folder/file-to-delete-and-restore" from the trashbin using the webUI
     Then the error message with header "Restoration of file-to-delete-and-restore failed" should be displayed on the webUI
     #And a success message "file-to-delete-and-restore was restored successfully" should be displayed on the webUI
-    #And as "user1" the file with original path "simple-folder/file-to-delete-and-restore" should not exist in trash
-    And as "user1" the file with original path "simple-folder/file-to-delete-and-restore" should exist in trash
+    #And as "user1" the file with original path "simple-folder/file-to-delete-and-restore" should not exist in the trashbin
+    And as "user1" the file with original path "simple-folder/file-to-delete-and-restore" should exist in the trashbin
     And as "user1" file "simple-folder-renamed/file-to-delete-and-restore" should not exist
     #And as "user1" file "simple-folder-renamed/file-to-delete-and-restore" should exist
     And as "user1" file "simple-folder/file-to-delete-and-restore" should not exist

--- a/tests/acceptance/stepDefinitions/webdavContext.js
+++ b/tests/acceptance/stepDefinitions/webdavContext.js
@@ -125,13 +125,13 @@ Given('user {string} has favorited element {string}', function (userId, element)
     })
 })
 
-Then('as {string} file/folder {string} should exist in trash', async function (user, element) {
+Then('as {string} file/folder {string} should exist in the trashbin', async function (user, element) {
   const items = await webdavHelper.getTrashBinElements(user)
   const trashFiles = items.map(item => item.originalFilename)
   assert.strictEqual(trashFiles.includes(element), true)
 })
 
-Then('as {string} the file/folder with original path {string} should not exist in trash', function (user, path) {
+Then('as {string} the file/folder with original path {string} should not exist in the trashbin', function (user, path) {
   return webdavHelper.getTrashBinElements(user)
     .then(items => {
       const trashFiles = items.map(item => item.originalLocation)
@@ -139,7 +139,7 @@ Then('as {string} the file/folder with original path {string} should not exist i
     })
 })
 
-Then('as {string} the file/folder with original path {string} should exist in trash', function (user, path) {
+Then('as {string} the file/folder with original path {string} should exist in the trashbin', function (user, path) {
   return webdavHelper.getTrashBinElements(user)
     .then(items => {
       const trashFiles = items.map(item => item.originalLocation)


### PR DESCRIPTION
## Description
See https://github.com/owncloud/core/pull/37047

Make the trashbin acceptance test steps consistently use "in the trashbin".

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
