### PR TITLE
Change share icons to collaborators

### DIFF
--- a/apps/files/src/components/Collaborators/SharedFilesList.vue
+++ b/apps/files/src/components/Collaborators/SharedFilesList.vue
@@ -66,7 +66,7 @@
       <div class="uk-text-meta uk-text-nowrap uk-width-small" v-text="formDateFromNow(item.shareTime)" />
     </template>
     <template #noContentMessage>
-      <no-content-message icon="share">
+      <no-content-message icon="group">
         <template #message>
           <span v-if="$_isSharedWithMe" v-translate>You are currently not collaborating on other people's resources.</span>
           <span v-else v-translate>You are currently not collaborating on any of your resources with other people.</span>

--- a/apps/files/src/default.js
+++ b/apps/files/src/default.js
@@ -55,7 +55,7 @@ const appInfo = {
         return false
       },
       quickAccess: {
-        icon: 'share',
+        icon: 'group',
         ariaLabel: $gettext('Collaborators')
       }
     }, {
@@ -88,7 +88,7 @@ const navItems = [
   },
   {
     name: $gettext('Shared with me'),
-    iconMaterial: 'share',
+    iconMaterial: 'group',
     route: {
       name: 'files-shared-with-me',
       path: `/${appInfo.id}/shared-with-me`
@@ -96,7 +96,7 @@ const navItems = [
   },
   {
     name: $gettext('Shared with others'),
-    iconMaterial: 'share',
+    iconMaterial: 'group',
     route: {
       name: 'files-shared-with-others',
       path: `/${appInfo.id}/shared-with-others`

--- a/changelog/unreleased/3116
+++ b/changelog/unreleased/3116
@@ -1,0 +1,6 @@
+Bugfix: Changed share icons to collaborators icons
+
+Adjust icon in files app navigation bar and also in the file actions
+dropdown to use the group icon.
+
+https://github.com/owncloud/phoenix/pull/3116


### PR DESCRIPTION
## Description
Adjust icon in files app navigation bar and also in the file actions
dropdown to use the group icon.

## Related Issue
Fixes https://github.com/owncloud/enterprise/issues/3858

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):
<img width="492" alt="image" src="https://user-images.githubusercontent.com/277525/75541881-f25e3380-5a1e-11ea-88b1-8299fa7c597e.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...