### PR TITLE
[Tests-Only] Used only virtualScrollWrapper inside findItemInFilesList

### DIFF
--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -599,16 +599,14 @@ module.exports = {
         function (
           {
             itemName,
-            listContainerSelector,
             scrollWrapperSelector,
             listHeaderSelector
           },
           done
         ) {
-          const filesListContainer = document.querySelector(listContainerSelector)
           const virtualScrollWrapper = document.querySelector(scrollWrapperSelector)
           const tableHeaderPosition = document.querySelector(listHeaderSelector).getBoundingClientRect().top
-          let scrollDistance = filesListContainer.scrollTop
+          let scrollDistance = virtualScrollWrapper.scrollTop
 
           function scrollUntilElementVisible () {
             const item = document.querySelector(`[filename="${itemName}"]`)
@@ -616,7 +614,7 @@ module.exports = {
             if (item) {
               const position = item.getBoundingClientRect()
               // Add position from top to list container height to properly decide if the item is visible
-              const visiblePosition = filesListContainer.clientHeight + tableHeaderPosition
+              const visiblePosition = virtualScrollWrapper.clientHeight + tableHeaderPosition
 
               // Check if the item is inside the view after it's renredered
               if (position.top > -1 && position.top <= visiblePosition) {
@@ -630,7 +628,7 @@ module.exports = {
               return
             }
 
-            scrollDistance += filesListContainer.clientHeight
+            scrollDistance += virtualScrollWrapper.clientHeight
             virtualScrollWrapper.scrollTop = scrollDistance
             setTimeout(function () {
               scrollUntilElementVisible()
@@ -640,7 +638,6 @@ module.exports = {
           scrollUntilElementVisible()
         }, [{
           itemName: itemName,
-          listContainerSelector: this.elements.filesTableContainer.selector,
           scrollWrapperSelector: this.elements.virtualScrollWrapper.selector,
           listHeaderSelector: this.elements.filesTableHeader.selector
         }])


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
For testing, `findItemInFilesList` is used to locate those resource in webUI viewport which have to be scrolled.
Inside function `findItemInFilesList` two wrapper elements were used, and different were used to calculate `scrollDistance` and `visiblePosition`
This PR removes un-necessary wrapper defined inside the function and use functional wrapper element.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #3089

## Motivation and Context
To make CI great again

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :robot:
- (Running suite multiple times in CI) https://github.com/owncloud/phoenix/pull/3120

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...