### PR TITLE
Moved collaborators additional info into own row

### DIFF
--- a/apps/files/src/components/Collaborators/AutocompleteItem.vue
+++ b/apps/files/src/components/Collaborators/AutocompleteItem.vue
@@ -1,6 +1,9 @@
 <template>
-  <div class="uk-flex uk-flex-middle">
-    <avatar-image v-if="item.value.shareType === shareTypes.user" class="uk-margin-small-right" :width="48" :userid="item.value.shareWith" :userName="item.label" />
+  <div
+    class="uk-flex uk-flex-middle"
+    :class="collaboratorClass"
+  >
+    <avatar-image v-if="isUser" class="uk-margin-small-right" :width="48" :userid="item.value.shareWith" :userName="item.label" />
     <template v-else>
       <oc-icon v-if="item.value.shareType === shareTypes.group" class="uk-margin-small-right" name="group" size="large" key="avatar-group" />
       <oc-icon v-else class="uk-margin-small-right" name="person" size="large" key="avatar-generic-person" />
@@ -11,7 +14,6 @@
         v-text="item.label"
       />
       <div v-if="item.value.shareWithAdditionalInfo" v-text="item.value.shareWithAdditionalInfo" />
-      <div class="uk-text-meta" v-text="$_ocCollaborators_collaboratorType(item.value.shareType)" />
     </div>
   </div>
 </template>
@@ -22,12 +24,33 @@ import { shareTypes } from '../../helpers/shareTypes'
 
 export default {
   name: 'AutocompleteItem',
+
   mixins: [Mixins],
+
   props: ['item'],
+
   data () {
     return {
       shareTypes,
       loading: false
+    }
+  },
+
+  computed: {
+    isUser () {
+      return this.item.value.shareType === shareTypes.user
+    },
+
+    isRemoteUser () {
+      return this.item.value.shareType === shareTypes.remote
+    },
+
+    collaboratorClass () {
+      const isUser = this.isUser || this.isRemoteUser
+
+      return 'files-collaborators-search-' + (
+        isUser ? (this.isRemoteUser ? 'remote' : 'user') : 'group'
+      )
     }
   }
 }

--- a/apps/files/src/components/Collaborators/Collaborator.vue
+++ b/apps/files/src/components/Collaborators/Collaborator.vue
@@ -45,18 +45,41 @@
       </oc-table-cell>
       <oc-table-cell shrink>
         <div key="collaborator-avatar-loaded">
-          <avatar-image v-if="collaborator.shareType === shareTypes.user" class="uk-margin-small-right" :width="48" :userid="collaborator.collaborator.name" :userName="collaborator.collaborator.displayName" />
+          <avatar-image
+            v-if="isUser"
+            class="uk-margin-small-right files-collaborators-collaborator-indicator"
+            :width="48"
+            :userid="collaborator.collaborator.name"
+            :userName="collaborator.collaborator.displayName"
+            :aria-label="$gettext('User')"
+          />
           <div v-else key="collaborator-avatar-placeholder">
-            <oc-icon v-if="collaborator.shareType === shareTypes.group" class="uk-margin-small-right" name="group" size="large" key="avatar-group" />
-            <oc-icon v-else class="uk-margin-small-right" name="person" size="large" key="avatar-generic-person" />
+            <oc-icon
+              v-if="collaborator.shareType === shareTypes.group"
+              class="uk-margin-small-right files-collaborators-collaborator-indicator"
+              name="group"
+              size="large"
+              key="avatar-group"
+              :aria-label="$gettext('Group')"
+            />
+            <oc-icon
+              v-else
+              class="uk-margin-small-right files-collaborators-collaborator-indicator"
+              name="person"
+              size="large"
+              key="avatar-generic-person"
+              :aria-label="$gettext('Remote user')"
+            />
           </div>
         </div>
       </oc-table-cell>
       <oc-table-cell>
-        <div class="uk-flex uk-flex-column uk-flex-center">
+        <div
+          class="uk-flex uk-flex-column uk-flex-center"
+          :class="collaboratorListItemClass"
+        >
           <div class="oc-text">
             <span class="files-collaborators-collaborator-name uk-text-bold">{{ collaborator.collaborator.displayName }}</span>
-            <span v-if="collaborator.shareType === shareTypes.user && collaborator.collaborator.additionalInfo" class="uk-text-meta files-collaborators-collaborator-additional-info">({{ collaborator.collaborator.additionalInfo }})</span>
             <translate
               v-if="collaborator.collaborator.name === user.id"
               translate-comment="Indicator for current user in collaborators list"
@@ -65,7 +88,11 @@
               (me)
             </translate>
           </div>
-          <span class="uk-text-meta files-collaborators-collaborator-share-type" v-text="$_ocCollaborators_collaboratorType(collaborator.shareType)" />
+          <span
+            v-if="collaborator.collaborator.additionalInfo"
+            class="uk-text-meta files-collaborators-collaborator-additional-info"
+            v-text="collaborator.collaborator.additionalInfo"
+          />
           <span class="oc-text"><span class="files-collaborators-collaborator-role">{{ originalRole.label }}</span><template v-if="collaborator.expires"> | <translate class="files-collaborators-collaborator-expires" :translate-params="{expires: formDateFromNow(collaborator.expires)}">Expires %{expires}</translate></template></span>
         </div>
       </oc-table-cell>
@@ -188,6 +215,22 @@ export default {
       return {
         label: this.$gettext('Unknown Role')
       }
+    },
+
+    isUser () {
+      return this.collaborator.shareType === shareTypes.user
+    },
+
+    isRemoteUser () {
+      return this.collaborator.shareType === shareTypes.remote
+    },
+
+    collaboratorListItemClass () {
+      const isUser = this.isUser || this.isRemoteUser
+
+      return 'files-collaborators-collaborator-info-' + (
+        isUser ? (this.isRemoteUser ? 'remote' : 'user') : 'group'
+      )
     }
   },
   methods: {

--- a/apps/files/src/mixins/collaborators.js
+++ b/apps/files/src/mixins/collaborators.js
@@ -69,13 +69,6 @@ export default {
     }
   },
   methods: {
-    $_ocCollaborators_collaboratorType (type) {
-      if (parseInt(type, 10) === 0) return this.$gettext('User')
-
-      if (parseInt(type, 10) === 6) return this.$gettext('Remote user')
-
-      return this.$gettext('Group')
-    },
     collaboratorOptionChanged ({ role, permissions, expirationDate }) {
       this.selectedRole = role
       this.additionalPermissions = permissions

--- a/changelog/unreleased/3130
+++ b/changelog/unreleased/3130
@@ -1,0 +1,5 @@
+Change: Moved collaborators additional info on own row and removed type row
+
+We've moved collaborators additional info on own row under the name of collaborator and removed collaborator type row.
+
+https://github.com/owncloud/phoenix/pull/3130

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -546,8 +546,8 @@ Feature: Sharing files and folders with internal users
     Then user "User Two" should be listed with additional info "<additional-info-result>" in the collaborators list on the webUI
     Examples:
       | additional-info-field | additional-info-result |
-      | id                    | (user2)                |
-      | email                 | (user2@example.org)    |
+      | id                    | user2                  |
+      | email                 | user2@example.org      |
 
   Scenario: collaborators list does not contain additional info when disabled
     Given the setting "user_additional_info_field" of app "core" has been set to ""

--- a/tests/acceptance/pageObjects/FilesPageElement/SharingDialog/collaboratorsDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/SharingDialog/collaboratorsDialog.js
@@ -74,10 +74,11 @@ module.exports = {
         subSelectors = {
           displayName: this.elements.collaboratorInformationSubName,
           role: this.elements.collaboratorInformationSubRole,
-          shareType: this.elements.collaboratorInformationSubShareType,
           additionalInfo: this.elements.collaboratorInformationSubAdditionalInfo,
           viaLabel: this.elements.collaboratorInformationSubVia,
-          resharer: this.elements.collaboratorInformationSubResharer
+          resharer: this.elements.collaboratorInformationSubResharer,
+          // Type of user is stored in aria-label of indicator so we use the selector for the indicator
+          shareType: this.elements.collaboratorIndicator
         }
       }
 
@@ -105,9 +106,16 @@ module.exports = {
           )
 
           if (attrElementId) {
-            await this.api.elementIdText(attrElementId, (text) => {
-              collaboratorResult[attrName] = text.value
-            })
+            // Get collaborator type via aria-label of indicator
+            if (attrName === 'shareType') {
+              await this.api.elementIdAttribute(attrElementId, 'aria-label', (label) => {
+                collaboratorResult[attrName] = label.value
+              })
+            } else {
+              await this.api.elementIdText(attrElementId, (text) => {
+                collaboratorResult[attrName] = text.value
+              })
+            }
           } else {
             collaboratorResult[attrName] = false
           }
@@ -169,10 +177,6 @@ module.exports = {
       // within collaboratorsInformation
       selector: '.files-collaborators-collaborator-role'
     },
-    collaboratorInformationSubShareType: {
-      // within collaboratorsInformation
-      selector: '.files-collaborators-collaborator-share-type'
-    },
     collaboratorInformationSubAdditionalInfo: {
       // within collaboratorsInformation
       selector: '.files-collaborators-collaborator-additional-info'
@@ -184,6 +188,9 @@ module.exports = {
     collaboratorInformationSubResharer: {
       // within collaboratorsInformation
       selector: '.files-collaborators-collaborator-reshare-information'
+    },
+    collaboratorIndicator: {
+      selector: '.files-collaborators-collaborator-indicator'
     }
   }
 }


### PR DESCRIPTION
## Description
Moved additional info of collaborator to own row, removed row with the type of collaborator, included type as an aria-label and refactored related tests.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Acceptance tests

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/25989331/75885405-bc59ee80-5e26-11ea-907f-33eb9e440d8c.png)

![image](https://user-images.githubusercontent.com/25989331/75885409-bf54df00-5e26-11ea-9ef6-3e3d162b2473.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 