### PR TITLE
Indirect share info now visible in favorite and other file lists

### DIFF
--- a/apps/files/src/components/AllFilesList.vue
+++ b/apps/files/src/components/AllFilesList.vue
@@ -11,7 +11,7 @@
           <translate translate-context="Name column in files table">Name</translate>
         </sortable-column-header>
       </div>
-      <div><!-- indicators column --></div>
+      <div v-if="!$_isFavoritesList"><!-- indicators column --></div>
       <div :class="{ 'uk-visible@s' : !_sidebarOpen, 'uk-hidden'  : _sidebarOpen }" class="uk-text-meta uk-width-small">
         <sortable-column-header @click="toggleSort('size')" :aria-label="$gettext('Sort files by size')" :is-active="fileSortField == 'size'" :is-desc="fileSortDirectionDesc">
           <translate translate-context="Size column in files table">Size</translate>
@@ -38,7 +38,7 @@
           class="uk-margin-small-left"
         />
       </div>
-      <div class="uk-flex uk-flex-middle">
+      <div v-if="!$_isFavoritesList" class="uk-flex uk-flex-middle">
         <StatusIndicators :item="item" :parentPath="currentFolder.path" @click="$_openSideBar" />
       </div>
       <div class="uk-text-meta uk-text-nowrap uk-width-small" :class="{ 'uk-visible@s' : !_sidebarOpen, 'uk-hidden'  : _sidebarOpen }">

--- a/apps/files/src/store/actions.js
+++ b/apps/files/src/store/actions.js
@@ -755,7 +755,7 @@ export default {
     parentPaths.forEach((queryPath) => {
       // skip already cached paths
       if (context.getters.sharesTree[queryPath]) {
-        return
+        return Promise.resolve()
       }
       sharesTree[queryPath] = []
       // query the outgoing share information for each of the parent paths

--- a/apps/files/src/store/getters.js
+++ b/apps/files/src/store/getters.js
@@ -75,7 +75,11 @@ export default {
   sharesTree: state => state.sharesTree,
   sharesTreeLoading: state => state.sharesTreeLoading,
   loadingFolder: state => {
-    return state.loadingFolder || state.sharesTreeLoading
+    // when loading the shares tree, it is only related to the full folder
+    // whenever no file is selected / no sidebar is open.
+    // else it means we're loading the shares only for the sidebar contents and shouldn't
+    // be showing a progress bar for the whole folder
+    return state.loadingFolder || (state.highlightedFile === null && state.sharesTreeLoading)
   },
   quota: state => {
     return state.quota

--- a/changelog/unreleased/3040
+++ b/changelog/unreleased/3040
@@ -1,0 +1,9 @@
+Bugfix: Indirect share info now visible in favorite and other file lists
+
+When open the share panel of other flat file lists like the favorites,
+the collaborators list and link list are now showing the same entries like
+in the "All files" list, which includes indirect shares (via) that were
+previously missing.
+
+https://github.com/owncloud/phoenix/issues/3040
+https://github.com/owncloud/phoenix/pull/3135

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -531,6 +531,20 @@ Feature: Sharing files and folders with internal users
     Then user "User One" should be listed as "Owner" reshared through "User Two" via "simple-folder (2)" in the collaborators list on the webUI
     And the current collaborators list should have order "User One,User Three"
 
+  @issue-3040
+  Scenario: see resource owner of parent shares in "shared with others" and "favorites" list
+    Given user "user3" has been created with default attributes
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user2" has shared folder "simple-folder (2)/simple-empty-folder" with user "user3"
+    And user "user2" has favorited element "simple-folder (2)/simple-empty-folder"
+    And user "user2" has logged in using the webUI
+    When the user browses to the shared-with-others page
+    And the user opens the share dialog for folder "simple-empty-folder" using the webUI
+    Then user "User One" should be listed as "Owner" via "simple-folder (2)" in the collaborators list on the webUI
+    When the user browses to the favorites page using the webUI
+    And the user opens the share dialog for folder "simple-folder (2)/simple-empty-folder" using the webUI
+    Then user "User One" should be listed as "Owner" via "simple-folder (2)" in the collaborators list on the webUI
+
   @issue-2898
   Scenario: see resource owner for direct shares in "shared with me"
     Given user "user1" has shared folder "simple-folder" with user "user2"

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -761,3 +761,19 @@ Feature: Share by public link
     Then a link named "Public Link" should be listed with role "Viewer" in the public link list of resource "textfile.txt" via "simple-folder" on the webUI
     And a link named "strängé लिंक नाम (#2 &).नेपाली" should be listed with role "Viewer" in the public link list of resource "textfile.txt" via "sub-folder" on the webUI
 
+  @issue-3040
+  Scenario: sharing details of indirect link share in "favorites" file lists
+    Given user "user1" has created a public link with following settings
+      | path | /simple-folder |
+      | name | Public Link    |
+    And user "user1" has created a public link with following settings
+      | path | /simple-folder/simple-empty-folder |
+      | name | Public Link Sub                    |
+    And user "user1" has favorited element "simple-folder/simple-empty-folder"
+    And user "user1" has logged in using the webUI
+    When the user browses to the shared-with-others page
+    And the user opens the share dialog for folder "simple-empty-folder" using the webUI
+    Then a link named "Public Link" should be listed with role "Viewer" in the public link list of resource "simple-empty-folder" via "simple-folder" on the webUI
+    And a link named "Public Link Sub" should be listed with role "Viewer" in the public link list of resource "simple-empty-folder" on the webUI
+    When the user browses to the favorites page using the webUI
+    Then a link named "Public Link" should be listed with role "Viewer" in the public link list of resource "simple-folder/simple-empty-folder" via "simple-folder" on the webUI

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -361,7 +361,9 @@ module.exports = {
           if (result.value.error) {
             this.assert.fail(result.value.error)
           }
-          this.assert.strictEqual(result.value, fileName, 'displayed file name not as expected')
+          // using basename because some file lists display the full path while the
+          // file name attribute only contains the basename
+          this.assert.strictEqual(result.value, path.basename(fileName), 'displayed file name not as expected')
         })
         .useCss()
       return this


### PR DESCRIPTION
## Description
When open the share panel of other flat file lists like the favorites,
the collaborators list and link list are now showing the same entries like
in the "All files" list, which includes indirect shares (via) that were
previously missing.

## Related Issue
Fixes https://github.com/owncloud/phoenix/issues/3040

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- [x] TEST: favorite list: indirect collaborators appearing
- [x] TEST: favorite list: indirect links appearing
- [x] TEST: shared with other list: indirect collaborators appearing
- [x] TEST: shared with other list: indirect links appearing
- [x] TEST: shared with me list: indirect collaborators appearing => no via possible here
- [x] TEST: shared with me list: indirect links appearing => no via possible here
- [x] acceptance tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] TODO: fix remaining issues (see tests section)
- [ ] TODO: add acceptance tests