### PR TITLE
Use end of the day in expiration date

### DIFF
--- a/apps/files/src/components/Collaborators/Collaborator.vue
+++ b/apps/files/src/components/Collaborators/Collaborator.vue
@@ -93,7 +93,7 @@
             class="uk-text-meta files-collaborators-collaborator-additional-info"
             v-text="collaborator.collaborator.additionalInfo"
           />
-          <span class="oc-text"><span class="files-collaborators-collaborator-role">{{ originalRole.label }}</span><template v-if="collaborator.expires"> | <translate class="files-collaborators-collaborator-expires" :translate-params="{expires: formDateFromNow(collaborator.expires)}">Expires %{expires}</translate></template></span>
+          <span class="oc-text"><span class="files-collaborators-collaborator-role">{{ originalRole.label }}</span><template v-if="collaborator.expires"> | <translate class="files-collaborators-collaborator-expires" :translate-params="{expires: formDateFromNow(expirationDate)}">Expires %{expires}</translate></template></span>
         </div>
       </oc-table-cell>
       <oc-table-cell shrink>
@@ -119,6 +119,7 @@
 
 <script>
 import { mapGetters } from 'vuex'
+import moment from 'moment'
 import { shareTypes } from '../../helpers/shareTypes'
 import { basename, dirname } from 'path'
 import CollaboratorsMixins from '../../mixins/collaborators'
@@ -231,6 +232,10 @@ export default {
       return 'files-collaborators-collaborator-info-' + (
         isUser ? (this.isRemoteUser ? 'remote' : 'user') : 'group'
       )
+    },
+
+    expirationDate () {
+      return moment(this.collaborator.expires).endOf('day')
     }
   },
   methods: {

--- a/changelog/unreleased/3158
+++ b/changelog/unreleased/3158
@@ -1,0 +1,5 @@
+Bugfix: Use end of the day in expiration date
+
+We've changed the expiration date field in the collaborators list to the end of the day.
+
+https://github.com/owncloud/phoenix/pull/3158


### PR DESCRIPTION
## Motivation and Context
The expiration date was being set to the beginning of the day but the share expires at the end of the day instead.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 