### PR TITLE
[Tests-Only] Add acceptance tests for enforced expiration on collaborators share

### DIFF
--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -358,7 +358,7 @@ Feature: Sharing files and folders with internal groups
     And user "user3" has logged in using the webUI
     When the user edits the collaborator expiry date of "grp1" of file "lorem.txt" to "+7" days using the webUI
     Then user "user1" should have received a share with target "lorem (2).txt" and expiration date in 7 days
-    Then user "user2" should have received a share with target "lorem (2).txt" and expiration date in 7 days
+    And user "user2" should have received a share with target "lorem (2).txt" and expiration date in 7 days
     And user "user3" should have a share with these details:
       | field      | value      |
       | path       | /lorem.txt |
@@ -367,3 +367,50 @@ Feature: Sharing files and folders with internal groups
       | share_with | grp1       |
       | expiration | +7         |
 
+  Scenario: share a resource with another internal group with default expiration date
+    Given the setting "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
+    And the setting "shareapi_expire_after_n_days_group_share" of app "core" has been set to "42"
+    And user "user3" has logged in using the webUI
+    When the user shares folder "lorem.txt" with group "grp1" as "Viewer" using the webUI
+    Then user "user3" should have a share with these details:
+      | field      | value              |
+      | path       | /lorem.txt         |
+      | share_type | group              |
+      | uid_owner  | user3              |
+      | share_with | grp1               |
+      | expiration | +42                |
+    And user "user1" should have received a share with target "lorem (2).txt" and expiration date in 42 days
+    And user "user2" should have received a share with target "lorem (2).txt" and expiration date in 42 days
+
+  Scenario Outline: share a resource with another internal group with expiration date beyond maximum enforced expiration date
+    Given the setting "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
+    And the setting "shareapi_enforce_expire_date_group_share" of app "core" has been set to "yes"
+    And the setting "shareapi_expire_after_n_days_group_share" of app "core" has been set to "5"
+    And user "user3" has logged in using the webUI
+    When the user tries to share resource "<shared-resource>" with group "grp1" which expires in "+6" days using the webUI
+    Then the expiration date shown on the webUI should be "+5" days
+    And user "user1" should not have created any shares
+    Examples:
+      | shared-resource |
+      | lorem.txt       |
+      | simple-folder   |
+
+  Scenario Outline: share a resource with another internal group with expiration date within maximum enforced expiration date
+    Given the setting "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
+    And the setting "shareapi_enforce_expire_date_group_share" of app "core" has been set to "yes"
+    And the setting "shareapi_expire_after_n_days_group_share" of app "core" has been set to "5"
+    And user "user3" has created a new share with following settings
+      | path            | <shared-resource> |
+      | shareTypeString | group             |
+      | shareWith       | grp1              |
+      | expireDate      | +4                |
+    And user "user3" has logged in using the webUI
+    When the user tries to edit the collaborator expiry date of "grp1" of resource "<shared-resource>" to "+7" days using the webUI
+    Then the expiration date shown on the webUI should be "+4" days
+    And it should not be possible to save the pending share on the webUI
+    And user "user1" should have received a share with target "<target-resource>" and expiration date in 4 days
+    And user "user2" should have received a share with target "<target-resource>" and expiration date in 4 days
+    Examples:
+      | shared-resource | target-resource   |
+      | lorem.txt       | lorem (2).txt     |
+      | simple-folder   | simple-folder (2) |

--- a/tests/acceptance/pageObjects/FilesPageElement/publicLinksDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/publicLinksDialog.js
@@ -1,5 +1,6 @@
 const util = require('util')
 const _ = require('lodash')
+const sharingHelper = require('../../helpers/sharingHelper')
 
 module.exports = {
   commands: {
@@ -79,10 +80,12 @@ module.exports = {
       } else if (key === 'password') {
         return this.setPublicLinkPassword(value)
       } else if (key === 'expireDate') {
+        value = sharingHelper.calculateDate(value)
         return this.api.page
           .FilesPageElement
-          .expirationDatePicker()
-          .setExpirationDate(value)
+          .sharingDialog()
+          .openExpirationDatePicker()
+          .setExpirationDate(value, 'link')
       }
       return this
     },
@@ -97,10 +100,10 @@ module.exports = {
      * @param {string} editData.expireDate - Expire date for a public link share
      * @returns {exports}
      */
-    editPublicLink: function (linkName, editData) {
-      this.clickLinkEditBtn(linkName)
+    editPublicLink: async function (linkName, editData) {
+      await this.clickLinkEditBtn(linkName)
       for (const [key, value] of Object.entries(editData)) {
-        this.setPublicLinkForm(key, value)
+        await this.setPublicLinkForm(key, value)
       }
       return this
     },

--- a/tests/acceptance/stepDefinitions/publicLinkContext.js
+++ b/tests/acceptance/stepDefinitions/publicLinkContext.js
@@ -128,15 +128,17 @@ When('the user edits the public link named {string} of file/folder/resource {str
 
 When('the user tries to edit expiration of the public link named {string} of file {string} to past date {string}',
   async function (linkName, resource, pastDate) {
-    await client.page.FilesPageElement
+    const api = client.page.FilesPageElement
+    await api
       .appSideBar()
       .closeSidebar(100)
       .openPublicLinkDialog(resource)
-    await client.page.FilesPageElement.publicLinksDialog().clickLinkEditBtn(linkName)
+    await api.publicLinksDialog().clickLinkEditBtn(linkName)
     const value = sharingHelper.calculateDate(pastDate)
     const dateToSet = new Date(Date.parse(value))
-    const isDisabled = await client.page.FilesPageElement
-      .expirationDatePicker()
+    const isDisabled = await api
+      .sharingDialog()
+      .openExpirationDatePicker()
       .isExpiryDateDisabled(dateToSet)
     return assert.ok(
       isDisabled,


### PR DESCRIPTION
## Description
Acceptance test added for enforced expiration date on a user/group share

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of #3132

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...