### PR TITLE
Align columns to right

### DIFF
--- a/apps/files/src/components/AllFilesList.vue
+++ b/apps/files/src/components/AllFilesList.vue
@@ -7,18 +7,38 @@
         <oc-star id="files-table-header-star" aria-hidden="true" class="uk-display-block uk-disabled" />
       </div>
       <div class="uk-text-truncate uk-text-meta uk-width-expand" ref="headerNameColumn" >
-        <sortable-column-header @click="toggleSort('name')" :aria-label="$gettext('Sort files by name')" :is-active="fileSortField == 'name'" :is-desc="fileSortDirectionDesc">
+        <sortable-column-header
+          @click="toggleSort('name')"
+          :aria-label="$gettext('Sort files by name')"
+          :is-active="fileSortField == 'name'"
+          :is-desc="fileSortDirectionDesc"
+        >
           <translate translate-context="Name column in files table">Name</translate>
         </sortable-column-header>
       </div>
       <div v-if="!$_isFavoritesList"><!-- indicators column --></div>
       <div :class="{ 'uk-visible@s' : !_sidebarOpen, 'uk-hidden'  : _sidebarOpen }" class="uk-text-meta uk-width-small">
-        <sortable-column-header @click="toggleSort('size')" :aria-label="$gettext('Sort files by size')" :is-active="fileSortField == 'size'" :is-desc="fileSortDirectionDesc">
+        <sortable-column-header
+          @click="toggleSort('size')"
+          :aria-label="$gettext('Sort files by size')"
+          :is-active="fileSortField == 'size'"
+          :is-desc="fileSortDirectionDesc"
+          class="uk-align-right"
+        >
           <translate translate-context="Size column in files table">Size</translate>
         </sortable-column-header>
       </div>
-      <div :class="{ 'uk-visible@s' : !_sidebarOpen, 'uk-hidden'  : _sidebarOpen }" class="uk-text-nowrap uk-text-meta uk-width-small">
-        <sortable-column-header @click="toggleSort('mdateMoment')" :aria-label="$gettext('Sort files by updated time')" :is-active="fileSortField == 'mdateMoment'" :is-desc="fileSortDirectionDesc">
+      <div
+        :class="{ 'uk-visible@s' : !_sidebarOpen, 'uk-hidden'  : _sidebarOpen }"
+        class="uk-text-nowrap uk-text-meta uk-width-small uk-margin-right"
+      >
+        <sortable-column-header
+          @click="toggleSort('mdateMoment')"
+          :aria-label="$gettext('Sort files by updated time')"
+          :is-active="fileSortField == 'mdateMoment'"
+          :is-desc="fileSortDirectionDesc"
+          class="uk-align-right"
+        >
           <translate translate-context="Short column label in files able for the time at which a file was modified">Updated</translate>
         </sortable-column-header>
       </div>
@@ -38,13 +58,19 @@
           class="uk-margin-small-left"
         />
       </div>
-      <div v-if="!$_isFavoritesList" class="uk-flex uk-flex-middle">
+      <div v-if="!$_isFavoritesList" class="uk-flex uk-flex-middle uk-flex-right">
         <StatusIndicators :item="item" :parentPath="currentFolder.path" @click="$_openSideBar" />
       </div>
-      <div class="uk-text-meta uk-text-nowrap uk-width-small" :class="{ 'uk-visible@s' : !_sidebarOpen, 'uk-hidden'  : _sidebarOpen }">
+      <div
+        class="uk-text-meta uk-text-nowrap uk-width-small uk-text-right"
+        :class="{ 'uk-visible@s' : !_sidebarOpen, 'uk-hidden'  : _sidebarOpen }"
+      >
         {{ item.size | fileSize }}
       </div>
-      <div class="uk-text-meta uk-text-nowrap uk-width-small" :class="{ 'uk-visible@s' : !_sidebarOpen, 'uk-hidden'  : _sidebarOpen }">
+      <div
+        class="uk-text-meta uk-text-nowrap uk-width-small uk-text-right"
+        :class="{ 'uk-visible@s' : !_sidebarOpen, 'uk-hidden'  : _sidebarOpen }"
+      >
         {{ formDateFromNow(item.mdate) }}
       </div>
     </template>

--- a/apps/files/src/components/Collaborators/SharedFilesList.vue
+++ b/apps/files/src/components/Collaborators/SharedFilesList.vue
@@ -8,19 +8,37 @@
         </sortable-column-header>
       </div>
       <div><!-- indicators column --></div>
-      <div key="shared-with-header-cell" v-if="!$_isSharedWithMe" class="uk-visible@s uk-text-nowrap uk-text-meta uk-width-medium" translate-context="Collaborators table column" v-text="$gettext('Collaborators')" />
-      <div key="shared-with-header-cell" v-else class="uk-visible@s uk-text-nowrap uk-text-meta uk-width-small" translate-context="Owner table column" v-text="$gettext('Owner')" />
       <div
-        v-if="$route.name === 'files-shared-with-me'"
+        v-if="!$_isSharedWithMe"
+        key="shared-with-header-cell"
+        class="uk-visible@s uk-text-nowrap uk-text-meta uk-width-medium uk-text-right"
+        translate-context="Collaborators table column"
+        v-text="$gettext('Collaborators')"
+      />
+      <div
+        v-else
         shrink
         type="head"
-        class="uk-text-nowrap uk-text-meta uk-width-small"
+        class="uk-text-nowrap uk-text-meta uk-width-small uk-text-right"
         v-translate
       >
         Status
       </div>
-      <div class="uk-visible@s uk-text-nowrap uk-text-meta uk-width-small">
-        <sortable-column-header @click="toggleSort('shareTimeMoment')" :aria-label="$gettext('Sort files by share time')" :is-active="fileSortField == 'shareTimeMoment'" :is-desc="fileSortDirectionDesc">
+      <div
+        v-if="$route.name === 'files-shared-with-me'"
+        key="shared-with-header-cell"
+        class="uk-visible@s uk-text-nowrap uk-text-meta uk-width-small uk-text-right"
+        translate-context="Owner table column"
+        v-text="$gettext('Owner')"
+      />
+      <div class="uk-visible@s uk-text-nowrap uk-text-meta uk-width-small uk-margin-right">
+        <sortable-column-header
+          @click="toggleSort('shareTimeMoment')"
+          :aria-label="$gettext('Sort files by share time')"
+          :is-active="fileSortField == 'shareTimeMoment'"
+          :is-desc="fileSortDirectionDesc"
+          class="uk-align-right"
+        >
           <translate translate-context="Share time column in files table">Share time</translate>
         </sortable-column-header>
       </div>
@@ -38,8 +56,16 @@
         />
       </div>
       <div><!-- indicators column --></div>
-      <div key="shared-with-cell" v-if="!$_isSharedWithMe" class="uk-visible@s uk-text-meta uk-text-nowrap uk-text-truncate uk-width-medium uk-flex file-row-collaborators">
-        <span v-for="share in item.shares" :key="share.id" class="uk-margin-small-right uk-flex uk-flex-middle">
+      <div
+        v-if="!$_isSharedWithMe"
+        key="shared-with-cell"
+        class="uk-visible@s uk-text-meta uk-text-nowrap uk-text-truncate uk-width-medium uk-flex file-row-collaborators uk-flex-right"
+      >
+        <span
+          v-for="share in item.shares"
+          :key="share.id"
+          class="uk-margin-small-left uk-flex uk-flex-middle"
+        >
           <avatar-image :key="'avatar-' + share.id" v-if="share.shareType === shareTypes.user && share.collaborator" class="uk-margin-xsmall-right" :width="24" :userid="share.collaborator.name" :userName="share.collaborator.displayName" />
           <oc-icon
             v-else
@@ -54,16 +80,23 @@
           <translate :key="'collaborator-name-public-' + share.id" v-if="share.shareType === shareTypes.link" class="file-row-collaborator-name" translate-context="Short public link indicator">Public</translate>
         </span>
       </div>
-      <div v-else key="shared-from-cell" class="uk-visible@s uk-text-meta uk-text-nowrap uk-text-truncate uk-width-small uk-flex uk-flex-middle file-row-collaborators">
-        <avatar-image class="uk-margin-xsmall-right" :width="24" :userid="item.shareOwner.username" :userName="item.shareOwner.displayName" />
-        <span class="file-row-owner-name" v-text="item.shareOwner.displayName"/>
-      </div>
-      <div v-if="$_isSharedWithMe" class="uk-text-nowrap uk-width-small" :key="item.id + item.status">
+      <div v-else class="uk-text-nowrap" :key="item.id + item.status">
         <a v-if="item.status === 1 || item.status === 2" class="file-row-share-status-action uk-text-meta" @click="pendingShareAction(item, 'POST')" v-translate>Accept</a>
         <a v-if="item.status === 1" class="file-row-share-status-action uk-text-meta uk-margin-left" @click="pendingShareAction(item, 'DELETE')" v-translate>Decline</a>
         <span class="uk-text-small uk-margin-left file-row-share-status-text" v-text="shareStatus(item.status)" />
       </div>
-      <div class="uk-visible@s uk-text-meta uk-text-nowrap uk-width-small" v-text="formDateFromNow(item.shareTime)" />
+      <div
+        v-if="$_isSharedWithMe"
+        key="shared-from-cell"
+        class="uk-visible@s uk-text-meta uk-text-nowrap uk-text-truncate uk-width-small uk-flex uk-flex-middle file-row-collaborators uk-flex-right"
+      >
+        <avatar-image class="uk-margin-xsmall-right" :width="24" :userid="item.shareOwner.username" :userName="item.shareOwner.displayName" />
+        <span class="file-row-owner-name" v-text="item.shareOwner.displayName"/>
+      </div>
+      <div
+        class="uk-visible@s uk-text-meta uk-text-nowrap uk-width-small uk-text-right"
+        v-text="formDateFromNow(item.shareTime)"
+      />
     </template>
     <template #noContentMessage>
       <no-content-message icon="group">

--- a/apps/files/src/components/FileList.vue
+++ b/apps/files/src/components/FileList.vue
@@ -42,7 +42,7 @@
                 />
               </div>
               <slot name="rowColumns" :item="item" :index="index" />
-              <div class="uk-text-right uk-margin-small-right">
+              <div class="uk-text-right uk-margin-left uk-margin-small-right">
                 <oc-button
                   :id="actionsDropdownButtonId(item.id, active)"
                   class="files-list-row-show-actions"

--- a/apps/files/src/components/FilesLists/StatusIndicators/DefaultIndicators.vue
+++ b/apps/files/src/components/FilesLists/StatusIndicators/DefaultIndicators.vue
@@ -43,21 +43,33 @@ export default {
     ...mapGetters('Files', ['sharesTree']),
 
     indicators () {
-      return [{
+      const collaborators = {
         id: 'files-sharing',
         label: this.shareUserIconLabel(this.item),
         visible: this.isUserShare(this.item),
         icon: 'group',
         status: this.shareUserIconVariation(this.item),
         handler: this.indicatorHandler
-      }, {
+      }
+      const links = {
         id: 'file-link',
         label: this.shareLinkIconLabel(this.item),
         visible: this.isLinkShare(this.item),
         icon: 'link',
         status: this.shareLinkIconVariation(this.item),
         handler: this.indicatorHandler
-      }]
+      }
+      const indicators = []
+
+      if (collaborators.visible) {
+        indicators.push(collaborators)
+      }
+
+      if (links.visible) {
+        indicators.push(links)
+      }
+
+      return indicators
     },
 
     shareTypesIndirect () {

--- a/apps/files/src/components/Trashbin.vue
+++ b/apps/files/src/components/Trashbin.vue
@@ -19,7 +19,13 @@
             :class="{ 'uk-visible@s' : !_sidebarOpen, 'uk-hidden'  : _sidebarOpen }"
             class="uk-text-nowrap uk-text-meta uk-width-small"
           >
-            <sortable-column-header @click="toggleSort('deleteTimestampMoment')" :aria-label="$gettext('Sort files by deletion time')" :is-active="fileSortField == 'deleteTimestampMoment'" :is-desc="fileSortDirectionDesc">
+            <sortable-column-header
+              class="uk-align-right uk-margin-right"
+              @click="toggleSort('deleteTimestampMoment')"
+              :aria-label="$gettext('Sort files by deletion time')"
+              :is-active="fileSortField == 'deleteTimestampMoment'"
+              :is-desc="fileSortDirectionDesc"
+            >
               <translate translate-context="Deletion time column in trashbin files table">Deletion Time</translate>
             </sortable-column-header>
           </div>
@@ -30,7 +36,7 @@
               :name="$_ocTrashbin_fileName(item)" :extension="item.extension" class="file-row-name" :icon="fileTypeIcon(item)"
               :filename="item.name" :key="item.id"/>
           </div>
-          <div class="uk-text-meta uk-text-nowrap uk-width-small" :class="{ 'uk-visible@s' : !_sidebarOpen, 'uk-hidden'  : _sidebarOpen }">
+          <div class="uk-text-meta uk-text-nowrap uk-width-small uk-text-right" :class="{ 'uk-visible@s' : !_sidebarOpen, 'uk-hidden'  : _sidebarOpen }">
             {{ formDateFromNow(item.deleteTimestamp) }}
           </div>
         </template>

--- a/changelog/unreleased/3163
+++ b/changelog/unreleased/3163
@@ -1,0 +1,6 @@
+Change: Align columns in file lists to the right
+
+We've aligned columns in all file lists to the right so it is easier for the user to compare them.
+
+https://github.com/owncloud/phoenix/issues/3036
+https://github.com/owncloud/phoenix/pull/3163


### PR DESCRIPTION
## Description
Aligned columns to the right and hide indicators which are inactive.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #3036

## Motivation and Context
Easy comparison between rows for the user.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Manually

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/25989331/76221469-6cf63280-6219-11ea-900e-cbedc5eaa82b.png)