### PR TITLE
[Tests-Only] Refactor expiration date picker

### DIFF
--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -369,7 +369,7 @@ Feature: Share by public link
       | name       | Public link      |
       | expireDate | 2038-10-14       |
     And user "user1" has logged in using the webUI
-    When the user tries to edit expiration of the public link named "Public link" of file "lorem.txt" to past date "2019-Oct-10"
+    When the user tries to edit expiration of the public link named "Public link" of file "lorem.txt" to past date "2019 October 10"
     Then the fields of the last public link share response of user "user1" should include
       | expireDate | 2038-10-14 |
 

--- a/tests/acceptance/pageObjects/FilesPageElement/expirationDatePicker.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/expirationDatePicker.js
@@ -3,7 +3,7 @@ const util = require('util')
 module.exports = {
   commands: {
     /**
-     * sets up the xpath for year in expiry date of public link
+     * sets up the xpath for year of expiry date
      *
      * @param year
      * @returns {{locateStrategy: string, selector: *}}
@@ -16,9 +16,9 @@ module.exports = {
       }
     },
     /**
-     * sets up the xpath for month in expiry date of public link
+     * sets up the xpath for month of expiry date
      *
-     * @param month
+     * @param {string} month month name
      * @returns {{locateStrategy: string, selector: *}}
      */
     setExpiryDateMonthSelectorXpath: function (month) {
@@ -29,7 +29,7 @@ module.exports = {
       }
     },
     /**
-     * sets up the xpath for year in expiry date of public link
+     * sets up the xpath for year of expiry date
      *
      * @param day
      * @returns {{locateStrategy: string, selector: *}}
@@ -64,7 +64,7 @@ module.exports = {
     /**
      * sets provided month in expiry date field on webUI
      *
-     * @param {string} month
+     * @param {number} month
      * @returns {Promise<void>}
      */
     setExpiryDateMonth: function (month) {
@@ -94,23 +94,21 @@ module.exports = {
     /**
      * checks if the given expiryDate is disabled or not
      *
-     * @param {string} pastDate provided past date for inspection
-     *  pastDate should be in form 2000-August-7 | 2000-Aug-7
-     *  leading zeros before day are removed
+     * @param {Date} pastDate provided past date for inspection
+     *
      * @returns {Promise<boolean>}
      */
     isExpiryDateDisabled: async function (pastDate) {
-      const [year, month, day] = pastDate.split(/-/)
       let disabled = false
-      const iDay = parseInt(day)
-      const yearSelector = this.setExpiryDateYearSelectorXpath(year)
-      const monthSelector = this.setExpiryDateMonthSelectorXpath(month)
-      const daySelector = this.setExpiryDateDaySelectorXpath(iDay)
-      const linkExpirationDateField = this.api.page.FilesPageElement.publicLinksDialog().elements.linkExpirationDateField.selector
+      const yearSelector = this.setExpiryDateYearSelectorXpath(pastDate.getFullYear())
+      const monthSelector = this.setExpiryDateMonthSelectorXpath(
+        pastDate.toLocaleString('en-GB', { month: 'long' })
+      )
+      const daySelector = this.setExpiryDateDaySelectorXpath(pastDate.getDay())
       await this
         .initAjaxCounters()
-        .waitForElementVisible(linkExpirationDateField)
-        .click(linkExpirationDateField)
+        .waitForElementVisible('@linkExpirationDateField')
+        .click('@linkExpirationDateField')
         .waitForElementVisible('@dateTimePopupYear')
         .waitForAnimationToFinish()
         .waitForElementEnabled(
@@ -170,6 +168,9 @@ module.exports = {
     },
     dateTimePopupDate: {
       selector: '.vdatetime-popup__date'
+    },
+    linkExpirationDateField: {
+      selector: '.vdatetime-input'
     }
   }
 }

--- a/tests/acceptance/pageObjects/FilesPageElement/publicLinksDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/publicLinksDialog.js
@@ -72,7 +72,7 @@ module.exports = {
      * @returns {Promise}
      */
     setPublicLinkExpiryDate: async function (value) {
-      const publicLinkDatePicker = this.api.page.FilesPageElement.publicLinksDatePicker()
+      const expirationDatePicker = this.api.page.FilesPageElement.expirationDatePicker()
       if (value === '') {
         return this.click('@publicLinkDeleteExpirationDateButton')
       }
@@ -81,12 +81,12 @@ module.exports = {
       const year = dateToSet.getFullYear()
       const month = dateToSet.toLocaleString('en-GB', { month: 'long' })
       const day = dateToSet.getDate()
-
+      const linkExpirationDateField = expirationDatePicker.elements.linkExpirationDateField.selector
       await this
         .initAjaxCounters()
-        .waitForElementVisible('@linkExpirationDateField')
-        .click('@linkExpirationDateField')
-      return publicLinkDatePicker
+        .waitForElementVisible(linkExpirationDateField)
+        .click(linkExpirationDateField)
+      return expirationDatePicker
         .setExpiryDateYear(year)
         .setExpiryDateMonth(month)
         .setExpiryDateDay(day)
@@ -425,13 +425,6 @@ module.exports = {
     publicLinkSaveButton: {
       selector: '#oc-files-file-link-save'
     },
-    dateTimePopup: {
-      selector: '.vdatetime-popup'
-    },
-    dateTimeCancelButton: {
-      selector: '//div[@class="vdatetime-popup__actions"]/div[.="Cancel"]',
-      locateStrategy: 'xpath'
-    },
     sidebarPrivateLinkLabel: {
       selector: '#files-sidebar-private-link-label'
     },
@@ -440,9 +433,6 @@ module.exports = {
     },
     publicLinkDeleteExpirationDateButton: {
       selector: '#oc-files-file-link-expire-date-delete'
-    },
-    linkExpirationDateField: {
-      selector: '.vdatetime-input'
     }
   }
 }

--- a/tests/acceptance/stepDefinitions/publicLinkContext.js
+++ b/tests/acceptance/stepDefinitions/publicLinkContext.js
@@ -133,9 +133,11 @@ When('the user tries to edit expiration of the public link named {string} of fil
       .closeSidebar(100)
       .openPublicLinkDialog(resource)
     await client.page.FilesPageElement.publicLinksDialog().clickLinkEditBtn(linkName)
+    const value = sharingHelper.calculateDate(pastDate)
+    const dateToSet = new Date(Date.parse(value))
     const isDisabled = await client.page.FilesPageElement
-      .publicLinksDatePicker()
-      .isExpiryDateDisabled(pastDate)
+      .expirationDatePicker()
+      .isExpiryDateDisabled(dateToSet)
     return assert.ok(
       isDisabled,
       'Expected expiration date to be disabled but found not disabled'


### PR DESCRIPTION
## Description
PageObject for public links date-picker is equally applicable for collaboration sharing too. So, refactors are made so that expiration PO is more general to work with.

Also, function `isExpiryDateDisabled` is adjusted to accept proper `Date` type arg.

## Related Issue
-  fixes #3166 

## Motivation and Context

## How Has This Been Tested?
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...