### PR TITLE
Sort collaborators column, deduplicate public

### DIFF
--- a/changelog/unreleased/3137
+++ b/changelog/unreleased/3137
@@ -1,0 +1,10 @@
+Bugfix: Sorted collaborators column, deduplicate public entry
+
+The collaborators column that appears in the "shared with others"
+section are now sorted: first by share type (user, group, link, remote) and then by
+display name using natural sort.
+Additionally, if there is more than one public link for the resource, the text "Public"
+only appears once in the collaborators column.
+
+https://github.com/owncloud/phoenix/issues/3137
+https://github.com/owncloud/phoenix/pull/3171

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -310,9 +310,13 @@ Feature: Share by public link
   Scenario: user shares a file through public link and then it appears in a shared-with-others page
     Given the setting "shareapi_allow_public_notification" of app "core" has been set to "yes"
     And user "user1" has shared folder "simple-folder" with link with "read, update, create, delete" permissions
+    And user "user1" has shared folder "simple-folder" with link with "read" permissions
     And user "user1" has logged in using the webUI
     When the user browses to the shared-with-others page
     Then folder "simple-folder" should be listed on the webUI
+    And the following resources should have the following collaborators
+      | fileName            | expectedCollaborators |
+      | simple-folder       | Public |
 
   Scenario: user edits the password of an already existing public link
     Given user "user1" has shared folder "simple-folder" with link with "read, update, create, delete" permissions and password "pass123"


### PR DESCRIPTION
## Description
The collaborators appears a the column in the "shared with others" section are now sorted: first by share type (user, group, remote, link) and then by display name using natural sort.
Additionally, if there is more than one public link for the resource, the text "Public" only appears once in the collaborators column.

## Related Issue
Fixes https://github.com/owncloud/phoenix/issues/3137

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- manual test in UI
- acceptance test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
None