### PR TITLE
Fix issue when debugging ODS with yarn link

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -8,7 +8,8 @@ module.exports = merge(common, {
   resolve: {
     alias: {
       vue: 'vue/dist/vue.js'
-    }
+    },
+    symlinks: false
   },
   devServer: {
     contentBase: path.resolve(__dirname),


### PR DESCRIPTION
Disable symlink resolution in webpack to prevent it to try and linkt the
minified files from the linked node modules.
