### PR TITLE
Update ODS to 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "node-fs-extra": "^0.8.2",
     "npm-run-all": "^4.1.5",
     "oidc-client": "^1.9.1",
-    "owncloud-design-system": "^1.1.0",
+    "owncloud-design-system": "^1.1.1",
     "owncloud-sdk": "^1.0.0-523",
     "p-limit": "^2.2.1",
     "parse-json": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6721,10 +6721,10 @@ os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
-owncloud-design-system@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/owncloud-design-system/-/owncloud-design-system-1.1.0.tgz#65e97203017e725ea1ad9eb3f1f567f15be6cc4d"
-  integrity sha512-IFxteWJIOa92F5126z+GHQ7qA9xtZHlvCVqenpBL2uTymDNLRzxvtNICXyADBDLlKw4/jDVEqiUXO3Q6XGQ/5Q==
+owncloud-design-system@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/owncloud-design-system/-/owncloud-design-system-1.1.1.tgz#4c23e9f4b2555c5e2d1ea8049a8c7c4a80346f2e"
+  integrity sha512-dIuMbhJLqsVfV8eXvBSMizJrrxXUDFA0WLIxS2MZ5qPAa9VjiDiPxzLQZKSYEotSpN+lgermzH/Mr0xU8w6Ksg==
   dependencies:
     lodash "^4.17.11"
     mini-css-extract-plugin "^0.9.0"


### PR DESCRIPTION
Brings in a fix for OcIcon to refresh when updating its url property.
