### PR TITLE
[Tests-Only]Moved markAsFavorite command into filesRow

### DIFF
--- a/tests/acceptance/pageObjects/FilesPageElement/fileActionsMenu.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/fileActionsMenu.js
@@ -190,10 +190,6 @@ module.exports = {
     renameFileConfirmationBtn: {
       selector: '#oc-dialog-rename-confirm'
     },
-    fileActionsButtonInFileRow: {
-      selector: '//button[contains(@class, "files-list-row-show-actions")]',
-      locateStrategy: 'xpath'
-    },
     shareButtonInFileRow: {
       selector: '//button[@aria-label="Collaborators"]',
       locateStrategy: 'xpath'

--- a/tests/acceptance/pageObjects/FilesPageElement/filesRow.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesRow.js
@@ -1,0 +1,102 @@
+const { client } = require('nightwatch-api')
+const filesList = client.page.FilesPageElement.filesList()
+
+module.exports = {
+  commands: {
+
+    /**
+     *
+     * @param {string} path
+     */
+    markAsFavorite: async function (path) {
+      await filesList.waitForFileVisible(path)
+
+      const favoriteIconButton = filesList.getFileRowSelectorByFileName(path) +
+        this.elements.notMarkedFavoriteInFileRow.selector
+
+      await this.initAjaxCounters()
+        .useXpath()
+        .click(favoriteIconButton)
+        .waitForOutstandingAjaxCalls()
+        .useCss()
+
+      return this
+    },
+    /**
+     *
+     * @param {string} path
+     *
+     * @return {Promise<boolean>}
+     */
+    isMarkedFavorite: async function (path) {
+      let visible = false
+      const markedFavoriteIcon = filesList.getFileRowSelectorByFileName(path) +
+        this.elements.markedFavoriteInFileRow.selector
+      await filesList.waitForFileVisible(path)
+      await this.api
+        .element('xpath', markedFavoriteIcon, (result) => {
+          visible = !!result.value.ELEMENT
+        })
+      return visible
+    },
+    /**
+     * @param {string} path
+     */
+    unmarkFavorite: async function (path) {
+      const unFavoriteBtn = filesList.getFileRowSelectorByFileName(path) +
+        this.elements.markedFavoriteInFileRow.selector
+
+      await filesList.waitForFileVisible(path)
+
+      await this.initAjaxCounters()
+        .useXpath()
+        .click(unFavoriteBtn)
+        .waitForOutstandingAjaxCalls()
+        .useCss()
+
+      return this
+    },
+    /**
+     * Get Selector for File Actions expander
+     *
+     * @param {string} fileName
+     * @param {string} elementType
+     * @returns {string} file action button selector
+     */
+    getFileActionBtnSelector: function (fileName, elementType = 'file') {
+      return filesList.getFileRowSelectorByFileName(fileName, elementType) +
+        this.elements.fileActionsButtonInFileRow.selector
+    },
+    /**
+     * opens file-actions menu for given resource
+     *
+     * @param {string} resource name
+     * @param {string} resource type (file|folder)
+     *
+     * @returns {*}
+     */
+    openFileActionsMenu: function (resource, elementType = 'file') {
+      const fileActionsBtnSelector = this.getFileActionBtnSelector(resource, elementType)
+      this
+        .useXpath()
+        .waitForElementVisible(fileActionsBtnSelector)
+        .click(fileActionsBtnSelector)
+        .useCss()
+      return this.api.page.FilesPageElement.fileActionsMenu()
+    }
+  },
+  elements: {
+    notMarkedFavoriteInFileRow: {
+      selector: '//span[contains(@class, "oc-star-dimm")]',
+      locateStrategy: 'xpath'
+    },
+    markedFavoriteInFileRow: {
+      selector: '//span[contains(@class, "oc-star-shining")]',
+      locateStrategy: 'xpath'
+    },
+    fileActionsButtonInFileRow: {
+      selector: '//button[contains(@class, "files-list-row-show-actions")]',
+      locateStrategy: 'xpath'
+    }
+  }
+}

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -319,15 +319,15 @@ When('the user renames the following file/folder using the webUI', async functio
 })
 
 Given('the user has marked file/folder {string} as favorite using the webUI', function (path) {
-  return client.page.FilesPageElement.filesList().markAsFavorite(path)
+  return client.page.FilesPageElement.filesRow().markAsFavorite(path)
 })
 
 When('the user marks file/folder {string} as favorite using the webUI', function (path) {
-  return client.page.FilesPageElement.filesList().markAsFavorite(path)
+  return client.page.FilesPageElement.filesRow().markAsFavorite(path)
 })
 
 When('the user unmarks the favorited file/folder {string} using the webUI', function (path) {
-  return client.page.FilesPageElement.filesList().unmarkFavorite(path)
+  return client.page.FilesPageElement.filesRow().unmarkFavorite(path)
 })
 
 Then('there should be no files/folders/resources listed on the webUI', async function () {
@@ -628,14 +628,14 @@ Then('as {string} these files/folders/resources should be listed in the folder {
 })
 
 Then('file/folder {string} should be marked as favorite on the webUI', function (path) {
-  return client.page.FilesPageElement.filesList().isMarkedFavorite(path)
+  return client.page.FilesPageElement.filesRow().isMarkedFavorite(path)
     .then(result => {
       assert.strictEqual(result, true, `${path} expected to be favorite but was not`)
     })
 })
 
 Then('file/folder {string} should not be marked as favorite on the webUI', function (path) {
-  return client.page.FilesPageElement.filesList().isMarkedFavorite(path)
+  return client.page.FilesPageElement.filesRow().isMarkedFavorite(path)
     .then(result => {
       assert.strictEqual(result, false, `not expected ${path} to be favorite but was`)
     })


### PR DESCRIPTION
## Description
Function `markAsFavorite` and related methods/elements are moved into filesRow PageObject

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of #2677

## Motivation and Context
Appropriate placements for different PO methods and elements

## How Has This Been Tested?
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
