### PR TITLE
Setup prettier in eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,23 +1,25 @@
 {
-    "env": {
-        "browser": true,
-        "es6": true,
-        "amd": true
-    },
-    "extends": [
-        "standard",
-        "plugin:vue/essential"
-        ],
-    "parserOptions": {
-        "parser": "babel-eslint",
-        "sourceType": "module"
-    },
-    "rules": {
-      "require-await": "warn",
-      "vue/order-in-components": "error"
-    },
-    "globals": {
-      "require": false,
-      "requirejs": false
-    }
+  "env": {
+    "browser": true,
+    "es6": true,
+    "amd": true
+  },
+  "extends": [
+    "standard",
+    "plugin:vue/recommended",
+    "plugin:prettier/recommended",
+    "prettier/standard",
+    "prettier/vue"
+  ],
+  "parserOptions": {
+    "parser": "babel-eslint",
+    "sourceType": "module"
+  },
+  "rules": {
+    "require-await": "warn"
+  },
+  "globals": {
+    "require": false,
+    "requirejs": false
+  }
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "printWidth": 100,
+  "semi": false,
+  "singleQuote": true
+}

--- a/apps/draw-io/src/DrawIoEditor.vue
+++ b/apps/draw-io/src/DrawIoEditor.vue
@@ -13,10 +13,10 @@ export default {
   }),
   computed: {
     ...mapGetters(['getToken']),
-    loading () {
+    loading() {
       return this.content === ''
     },
-    iframeSource () {
+    iframeSource() {
       const query = queryString.stringify({
         embed: 1,
         picker: 0,
@@ -29,7 +29,7 @@ export default {
       return 'https://www.draw.io?' + query
     }
   },
-  created () {
+  created() {
     this.filePath = this.$route.params.filePath
 
     window.addEventListener('message', event => {
@@ -48,7 +48,7 @@ export default {
   },
   methods: {
     ...mapActions(['showMessage']),
-    error (error) {
+    error(error) {
       this.showMessage({
         title: this.$gettext('PDF could not be loaded…'),
         desc: error,
@@ -56,29 +56,36 @@ export default {
       })
     },
 
-    load () {
-      this.$client.files.getFileContents(this.filePath, { resolveWithResponseObject: true })
+    load() {
+      this.$client.files
+        .getFileContents(this.filePath, { resolveWithResponseObject: true })
         .then(resp => {
           this.currentETag = resp.headers.ETag
-          this.$refs.drawIoEditor.contentWindow.postMessage(JSON.stringify({
-            action: 'load',
-            xml: resp.body
-          }), '*')
+          this.$refs.drawIoEditor.contentWindow.postMessage(
+            JSON.stringify({
+              action: 'load',
+              xml: resp.body
+            }),
+            '*'
+          )
         })
         .catch(error => {
           this.error(error)
         })
     },
-    save (payload) {
-      this.$client.files.putFileContents(this.filePath, payload.xml, {
-        previousEntityTag: this.currentETag
-      }).then((resp) => {
-        this.currentETag = resp.ETag
-      }).catch(error => {
-        this.error(error)
-      })
+    save(payload) {
+      this.$client.files
+        .putFileContents(this.filePath, payload.xml, {
+          previousEntityTag: this.currentETag
+        })
+        .then(resp => {
+          this.currentETag = resp.ETag
+        })
+        .catch(error => {
+          this.error(error)
+        })
     },
-    exit () {
+    exit() {
       window.close()
     }
   }
@@ -99,5 +106,4 @@ export default {
   overflow: hidden;
   z-index: 999999;
 }
-
 </style>

--- a/apps/draw-io/src/app.js
+++ b/apps/draw-io/src/app.js
@@ -4,29 +4,32 @@ import 'regenerator-runtime/runtime'
 import translationsJson from '../l10n/translations'
 import DrawIoEditor from './DrawIoEditor.vue'
 
-const routes = [{
-  name: 'draw-io-edit',
-  path: '/edit/:filePath',
-  components: {
-    fullscreen: DrawIoEditor
-  },
-  meta: { hideHeadbar: true }
-}]
+const routes = [
+  {
+    name: 'draw-io-edit',
+    path: '/edit/:filePath',
+    components: {
+      fullscreen: DrawIoEditor
+    },
+    meta: { hideHeadbar: true }
+  }
+]
 
 const appInfo = {
   name: 'Draw.io',
   id: 'draw-io',
   icon: 'grid_on',
-  extensions: [{
-    extension: 'drawio',
-    newTab: true,
-    routeName: 'draw-io-edit',
-    newFileMenu: {
-      menuTitle ($gettext) {
-        return $gettext('New draw.io document…')
+  extensions: [
+    {
+      extension: 'drawio',
+      newTab: true,
+      routeName: 'draw-io-edit',
+      newFileMenu: {
+        menuTitle($gettext) {
+          return $gettext('New draw.io document…')
+        }
       }
     }
-  }
   ]
 }
 

--- a/apps/files/src/components/AllFilesList.vue
+++ b/apps/files/src/components/AllFilesList.vue
@@ -1,112 +1,168 @@
 <template>
-  <file-list :fileData="fileData" id="files-list" :loading="loadingFolder" :actions="actions" :compactMode="_sidebarOpen"
-      :isActionEnabled="isActionEnabled">
+  <file-list
+    id="files-list"
+    :file-data="fileData"
+    :loading="loadingFolder"
+    :actions="actions"
+    :compact-mode="_sidebarOpen"
+    :is-action-enabled="isActionEnabled"
+  >
     <template #headerColumns>
       <div v-if="!publicPage()">
         <span class="oc-visually-hidden" v-text="favoritesHeaderText" />
-        <oc-star id="files-table-header-star" aria-hidden="true" class="uk-display-block uk-disabled" />
+        <oc-star
+          id="files-table-header-star"
+          aria-hidden="true"
+          class="uk-display-block uk-disabled"
+        />
       </div>
-      <div class="uk-text-truncate uk-text-meta uk-width-expand" ref="headerNameColumn" >
+      <div ref="headerNameColumn" class="uk-text-truncate uk-text-meta uk-width-expand">
         <sortable-column-header
-          @click="toggleSort('name')"
           :aria-label="$gettext('Sort files by name')"
-          :is-active="fileSortField == 'name'"
+          :is-active="fileSortField === 'name'"
           :is-desc="fileSortDirectionDesc"
+          @click="toggleSort('name')"
         >
           <translate translate-context="Name column in files table">Name</translate>
         </sortable-column-header>
       </div>
       <div v-if="!$_isFavoritesList"><!-- indicators column --></div>
-      <div :class="{ 'uk-visible@s' : !_sidebarOpen, 'uk-hidden'  : _sidebarOpen }" class="uk-text-meta uk-width-small">
+      <div
+        :class="{ 'uk-visible@s': !_sidebarOpen, 'uk-hidden': _sidebarOpen }"
+        class="uk-text-meta uk-width-small"
+      >
         <sortable-column-header
-          @click="toggleSort('size')"
           :aria-label="$gettext('Sort files by size')"
-          :is-active="fileSortField == 'size'"
+          :is-active="fileSortField === 'size'"
           :is-desc="fileSortDirectionDesc"
           class="uk-align-right"
+          @click="toggleSort('size')"
         >
           <translate translate-context="Size column in files table">Size</translate>
         </sortable-column-header>
       </div>
       <div
-        :class="{ 'uk-visible@s' : !_sidebarOpen, 'uk-hidden'  : _sidebarOpen }"
+        :class="{ 'uk-visible@s': !_sidebarOpen, 'uk-hidden': _sidebarOpen }"
         class="uk-text-nowrap uk-text-meta uk-width-small uk-margin-right"
       >
         <sortable-column-header
-          @click="toggleSort('mdateMoment')"
           :aria-label="$gettext('Sort files by updated time')"
-          :is-active="fileSortField == 'mdateMoment'"
+          :is-active="fileSortField === 'mdateMoment'"
           :is-desc="fileSortDirectionDesc"
           class="uk-align-right"
+          @click="toggleSort('mdateMoment')"
         >
-          <translate translate-context="Short column label in files able for the time at which a file was modified">Updated</translate>
+          <translate
+            translate-context="Short column label in files able for the time at which a file was modified"
+            >Updated</translate
+          >
         </sortable-column-header>
       </div>
     </template>
-    <template #rowColumns="{ item, index }">
+    <template #rowColumns="{ item: rowItem, index }">
       <div v-if="!publicPage()">
-        <oc-star class="uk-display-block" @click.native.stop="toggleFileFavorite(item)" :shining="item.starred" />
+        <oc-star
+          class="uk-display-block"
+          :shining="rowItem.starred"
+          @click.native.stop="toggleFileFavorite(rowItem)"
+        />
       </div>
-      <div class="uk-text-truncate uk-width-expand" :ref="index === 0 ? 'firstRowNameColumn' : null">
+      <div
+        :ref="index === 0 ? 'firstRowNameColumn' : null"
+        class="uk-text-truncate uk-width-expand"
+      >
         <file-item
-          @click.native.stop="item.type === 'folder' ? navigateTo(item.path.substr(1)) : openFileActionBar(item)"
-          :item="item"
+          :key="rowItem.viewId"
+          :item="rowItem"
           :dav-url="davUrl"
           :show-path="$_isFavoritesList"
           class="file-row-name"
-          :key="item.viewId"/>
+          @click.native.stop="
+            rowItem.type === 'folder'
+              ? navigateTo(rowItem.path.substr(1))
+              : openFileActionBar(rowItem)
+          "
+        />
         <oc-spinner
-          v-if="actionInProgress(item)"
+          v-if="actionInProgress(rowItem)"
           size="small"
-          :uk-tooltip="disabledActionTooltip(item)"
+          :uk-tooltip="disabledActionTooltip(rowItem)"
           class="uk-margin-small-left"
         />
       </div>
       <div v-if="!$_isFavoritesList" class="uk-flex uk-flex-middle uk-flex-right">
-        <Indicators :defaultIndicators="indicatorArray(item)" :item="item" @click="$_openSideBar" />
+        <Indicators
+          :default-indicators="indicatorArray(rowItem)"
+          :item="rowItem"
+          @click="$_openSideBar"
+        />
       </div>
       <div
         class="uk-text-meta uk-text-nowrap uk-width-small uk-text-right"
-        :class="{ 'uk-visible@s' : !_sidebarOpen, 'uk-hidden'  : _sidebarOpen }"
+        :class="{ 'uk-visible@s': !_sidebarOpen, 'uk-hidden': _sidebarOpen }"
       >
-        {{ item.size | fileSize }}
+        {{ rowItem.size | fileSize }}
       </div>
       <div
         class="uk-text-meta uk-text-nowrap uk-width-small uk-text-right"
-        :class="{ 'uk-visible@s' : !_sidebarOpen, 'uk-hidden'  : _sidebarOpen }"
+        :class="{ 'uk-visible@s': !_sidebarOpen, 'uk-hidden': _sidebarOpen }"
       >
-        {{ formDateFromNow(item.mdate) }}
+        {{ formDateFromNow(rowItem.mdate) }}
       </div>
     </template>
     <template #noContentMessage>
       <no-content-message v-if="!$_isFavoritesList" icon="folder">
-        <template #message><span v-translate>There are no resources in this folder.</span></template>
-        <template #callToAction><span v-translate>Drag files and folders here or use the "+ New" button to upload.</span></template>
+        <template #message
+          ><span v-translate>There are no resources in this folder.</span></template
+        >
+        <template #callToAction
+          ><span v-translate
+            >Drag files and folders here or use the "+ New" button to upload.</span
+          ></template
+        >
       </no-content-message>
       <no-content-message v-else icon="star">
-        <template #message><span v-translate>There are no resources marked as favorite.</span></template>
-        <template #callToAction><span v-translate>You can mark some by clicking on the star icon in the file list.</span></template>
+        <template #message
+          ><span v-translate>There are no resources marked as favorite.</span></template
+        >
+        <template #callToAction
+          ><span v-translate
+            >You can mark some by clicking on the star icon in the file list.</span
+          ></template
+        >
       </no-content-message>
     </template>
     <template #footer>
-      <div v-if="activeFilesCount.folders > 0 || activeFilesCount.files > 0" class="uk-text-nowrap uk-text-meta">
+      <div
+        v-if="activeFilesCount.folders > 0 || activeFilesCount.files > 0"
+        class="uk-text-nowrap uk-text-meta"
+      >
         <span id="files-list-count-folders" v-text="activeFilesCount.folders" />
-        <translate :translate-n="activeFilesCount.folders" translate-plural="folders">folder</translate>
+        <translate :translate-n="activeFilesCount.folders" translate-plural="folders"
+          >folder</translate
+        >
         <translate>and</translate>
         <span id="files-list-count-files" v-text="activeFilesCount.files" />
         <translate :translate-n="activeFilesCount.files" translate-plural="files">file</translate>
         <template v-if="activeFiles.length > 0">
-          &dash; {{ filesTotalSize | fileSize }}
+          &ndash; {{ filesTotalSize | fileSize }}
         </template>
       </div>
-      <div v-if="quotaVisible" class="uk-visible@s uk-width-2-3 uk-width-1-2@xl uk-text-meta uk-flex" :class="{ 'uk-visible@xl' : _sidebarOpen  }">
+      <div
+        v-if="quotaVisible"
+        class="uk-visible@s uk-width-2-3 uk-width-1-2@xl uk-text-meta uk-flex"
+        :class="{ 'uk-visible@xl': _sidebarOpen }"
+      >
         <span class="uk-margin-small-right">
           <translate>Used space:</translate> {{ quota.used | fileSize }}
           <template v-if="quota.definition !== 'default' && quota.definition !== 'none'">
             <translate>of</translate> {{ quota.definition }}
           </template>
         </span>
-        <div class="uk-width-expand oc-align-self-center" v-if="quota.definition !== 'default' && quota.definition !== 'none'">
+        <div
+          v-if="quota.definition !== 'default' && quota.definition !== 'none'"
+          class="uk-width-expand oc-align-self-center"
+        >
           <oc-progress :value="parseInt(quota.relative)" :max="100" class="uk-margin-remove" />
         </div>
       </div>
@@ -136,12 +192,27 @@ export default {
     NoContentMessage,
     SortableColumnHeader
   },
-  mixins: [
-    Mixins,
-    FileActions
-  ],
-  props: ['fileData', 'starsEnabled', 'checkboxEnabled', 'dateEnabled', 'parentFolder'],
-  data () {
+  mixins: [Mixins, FileActions],
+  props: {
+    fileData: {
+      type: Array,
+      required: true
+    },
+    starsEnabled: {
+      type: Boolean
+    },
+    checkboxEnabled: {
+      type: Boolean
+    },
+    dateEnabled: {
+      type: Boolean
+    },
+    parentFolder: {
+      type: Object,
+      default: null
+    }
+  },
+  data() {
     return {
       favoritesHeaderText: this.$gettext('Favorites')
     }
@@ -161,11 +232,11 @@ export default {
     ]),
     ...mapGetters(['configuration']),
 
-    item () {
+    item() {
       return this.$route.params.item
     },
 
-    shareTypesIndirect () {
+    shareTypesIndirect() {
       const parentPath = this.currentFolder.path
       if (!parentPath) {
         return []
@@ -179,11 +250,11 @@ export default {
       parentPaths.pop()
 
       const shareTypes = {}
-      parentPaths.forEach((parentPath) => {
+      parentPaths.forEach(parentPath => {
         // TODO: optimize for performance by skipping once we got all known types
         const shares = this.sharesTree[parentPath]
         if (shares) {
-          shares.forEach((share) => {
+          shares.forEach(share => {
             // note: no distinction between incoming and outgoing shares as we display the same
             // indirect indicator for them
             shareTypes[share.shareType] = true
@@ -194,58 +265,41 @@ export default {
       return Object.keys(shareTypes).map(shareType => parseInt(shareType, 10))
     },
 
-    davUrl () {
+    davUrl() {
       let davUrl
       // FIXME: use SDK once it switches to DAV v2
       if (this.publicPage()) {
-        davUrl = [
-          '..',
-          'dav',
-          'public-files'
-        ].join('/')
+        davUrl = ['..', 'dav', 'public-files'].join('/')
       } else {
-        davUrl = [
-          '..',
-          'dav',
-          'files',
-          this.$store.getters.user.id
-        ].join('/')
+        davUrl = ['..', 'dav', 'files', this.$store.getters.user.id].join('/')
       }
       return this.$client.files.getFileUrl(davUrl)
     },
 
-    $_isFavoritesList () {
-      return (this.$route.name === 'files-favorites')
+    $_isFavoritesList() {
+      return this.$route.name === 'files-favorites'
     },
 
-    quotaVisible () {
-      return (
-        !this.publicPage() &&
-          this.currentFolder &&
-          !this.currentFolder.isMounted()
-      )
+    quotaVisible() {
+      return !this.publicPage() && this.currentFolder && !this.currentFolder.isMounted()
     }
   },
   watch: {
-    $route () {
+    $route() {
       this.$_ocFilesFolder_getFolder()
     }
   },
-  beforeMount () {
+  beforeMount() {
     this.$_ocFilesFolder_getFolder()
   },
   methods: {
-    ...mapActions('Files', [
-      'loadFolder',
-      'markFavorite',
-      'setHighlightedFile'
-    ]),
+    ...mapActions('Files', ['loadFolder', 'markFavorite', 'setHighlightedFile']),
 
-    $_openSideBar (item, sideBarName) {
+    $_openSideBar(item, sideBarName) {
       this.$emit('sideBarOpen', item, sideBarName)
     },
 
-    $_ocFilesFolder_getFolder () {
+    $_ocFilesFolder_getFolder() {
       let absolutePath
 
       if (this.configuration.rootFolder) {
@@ -260,47 +314,49 @@ export default {
         $gettext: this.$gettext,
         routeName: this.$route.name,
         loadSharesTree: !this.publicPage()
-      }).then(() => {
-        const scrollTo = this.$route.query.scrollTo
-        if (scrollTo && this.activeFiles.length > 0) {
-          this.$nextTick(() => {
-            const file = this.activeFiles.find(item => item.name === scrollTo)
-            this.setHighlightedFile(file)
-            this.$scrollTo(`#file-row-${file.viewId}`, 500, {
-              container: '#files-list-container'
-            })
-          })
-        }
-      }).catch((error) => {
-        // password for public link shares is missing -> this is handled on the caller side
-        if (this.publicPage() && error.statusCode === 401) {
-          this.$router.push({
-            name: 'public-link',
-            params: {
-              token: this.$route.params.item
-            }
-          })
-          return
-        }
-        this.showMessage({
-          title: this.$gettext('Loading folder failed…'),
-          desc: error.message,
-          status: 'danger'
-        })
       })
+        .then(() => {
+          const scrollTo = this.$route.query.scrollTo
+          if (scrollTo && this.activeFiles.length > 0) {
+            this.$nextTick(() => {
+              const file = this.activeFiles.find(item => item.name === scrollTo)
+              this.setHighlightedFile(file)
+              this.$scrollTo(`#file-row-${file.viewId}`, 500, {
+                container: '#files-list-container'
+              })
+            })
+          }
+        })
+        .catch(error => {
+          // password for public link shares is missing -> this is handled on the caller side
+          if (this.publicPage() && error.statusCode === 401) {
+            this.$router.push({
+              name: 'public-link',
+              params: {
+                token: this.$route.params.item
+              }
+            })
+            return
+          }
+          this.showMessage({
+            title: this.$gettext('Loading folder failed…'),
+            desc: error.message,
+            status: 'danger'
+          })
+        })
     },
-    toggleFileFavorite (item) {
+    toggleFileFavorite(item) {
       this.markFavorite({
         client: this.$client,
         file: item
       })
     },
 
-    isActionEnabled (item, action) {
+    isActionEnabled(item, action) {
       return action.isEnabled(item, this.parentFolder)
     },
 
-    indicatorArray (item) {
+    indicatorArray(item) {
       const collaborators = {
         id: 'files-sharing',
         label: this.shareUserIconLabel(item),
@@ -330,7 +386,7 @@ export default {
       return indicators
     },
 
-    $_shareTypes (item) {
+    $_shareTypes(item) {
       if (typeof item.shareTypes !== 'undefined') {
         return item.shareTypes
       }
@@ -341,47 +397,53 @@ export default {
       return []
     },
 
-    isDirectUserShare (item) {
-      return (intersection(userShareTypes, this.$_shareTypes(item)).length > 0)
+    isDirectUserShare(item) {
+      return intersection(userShareTypes, this.$_shareTypes(item)).length > 0
     },
 
-    isIndirectUserShare (item) {
-      return (item.isReceivedShare() || intersection(userShareTypes, this.shareTypesIndirect).length > 0)
+    isIndirectUserShare(item) {
+      return (
+        item.isReceivedShare() || intersection(userShareTypes, this.shareTypesIndirect).length > 0
+      )
     },
 
-    isDirectLinkShare (item) {
-      return (this.$_shareTypes(item).indexOf(shareTypes.link) >= 0)
+    isDirectLinkShare(item) {
+      return this.$_shareTypes(item).indexOf(shareTypes.link) >= 0
     },
 
-    isIndirectLinkShare () {
-      return (this.shareTypesIndirect.indexOf(shareTypes.link) >= 0)
+    isIndirectLinkShare() {
+      return this.shareTypesIndirect.indexOf(shareTypes.link) >= 0
     },
 
-    isUserShare (item) {
+    isUserShare(item) {
       return this.isDirectUserShare(item) || this.isIndirectUserShare(item)
     },
 
-    isLinkShare (item) {
+    isLinkShare(item) {
       return this.isDirectLinkShare(item) || this.isIndirectLinkShare(item)
     },
 
-    shareUserIconVariation (item) {
+    shareUserIconVariation(item) {
       return this.isDirectUserShare(item) ? 'active' : 'passive'
     },
 
-    shareLinkIconVariation (item) {
+    shareLinkIconVariation(item) {
       return this.isDirectLinkShare(item) ? 'active' : 'passive'
     },
 
-    shareUserIconLabel (item) {
-      return this.isDirectUserShare(item) ? this.$gettext('Directly shared with collaborators') : this.$gettext('Shared with collaborators through one of the parent folders')
+    shareUserIconLabel(item) {
+      return this.isDirectUserShare(item)
+        ? this.$gettext('Directly shared with collaborators')
+        : this.$gettext('Shared with collaborators through one of the parent folders')
     },
 
-    shareLinkIconLabel (item) {
-      return this.isDirectLinkShare(item) ? this.$gettext('Directly shared with links') : this.$gettext('Shared with links through one of the parent folders')
+    shareLinkIconLabel(item) {
+      return this.isDirectLinkShare(item)
+        ? this.$gettext('Directly shared with links')
+        : this.$gettext('Shared with links through one of the parent folders')
     },
 
-    indicatorHandler (item, sideBarName) {
+    indicatorHandler(item, sideBarName) {
       this.$emit('click', item, sideBarName)
     }
   }
@@ -389,8 +451,8 @@ export default {
 </script>
 
 <style scoped>
-  /* FIXME */
-  #files-table-header-star {
-    opacity: 0;
-  }
+/* FIXME */
+#files-table-header-star {
+  opacity: 0;
+}
 </style>

--- a/apps/files/src/components/Collaborators/AdditionalPermissions.vue
+++ b/apps/files/src/components/Collaborators/AdditionalPermissions.vue
@@ -2,11 +2,11 @@
   <oc-grid gutter="small">
     <oc-checkbox
       v-for="permission in permissions"
-      :key="permission.name"
       :id="`files-collaborators-permission-${permission.name}`"
+      :key="permission.name"
+      v-model="permission.value"
       :label="permission.description"
       class="uk-margin-xsmall-right files-collaborators-permission-checkbox"
-      v-model="permission.value"
       @change="permissionChecked"
     />
   </oc-grid>
@@ -30,11 +30,12 @@ export default {
      */
     collaboratorsPermissions: {
       type: Object,
-      required: false
+      required: false,
+      default: () => {}
     }
   },
   computed: {
-    permissions () {
+    permissions() {
       const permissions = this.availablePermissions
 
       for (const permission in permissions) {
@@ -50,7 +51,7 @@ export default {
     }
   },
   methods: {
-    permissionChecked () {
+    permissionChecked() {
       const selectedPermissions = []
       const permissions = filterObject(this.permissions, (key, value) => {
         return value.value === true

--- a/apps/files/src/components/Collaborators/AutocompleteItem.vue
+++ b/apps/files/src/components/Collaborators/AutocompleteItem.vue
@@ -1,18 +1,30 @@
 <template>
-  <div
-    class="uk-flex uk-flex-middle"
-    :class="collaboratorClass"
-  >
-    <avatar-image v-if="isUser" class="uk-margin-small-right" :width="48" :userid="item.value.shareWith" :userName="item.label" />
+  <div class="uk-flex uk-flex-middle" :class="collaboratorClass">
+    <avatar-image
+      v-if="isUser"
+      class="uk-margin-small-right"
+      :width="48"
+      :userid="item.value.shareWith"
+      :user-name="item.label"
+    />
     <template v-else>
-      <oc-icon v-if="item.value.shareType === shareTypes.group" class="uk-margin-small-right" name="group" size="large" key="avatar-group" />
-      <oc-icon v-else class="uk-margin-small-right" name="person" size="large" key="avatar-generic-person" />
+      <oc-icon
+        v-if="item.value.shareType === shareTypes.group"
+        key="avatar-group"
+        class="uk-margin-small-right"
+        name="group"
+        size="large"
+      />
+      <oc-icon
+        v-else
+        key="avatar-generic-person"
+        class="uk-margin-small-right"
+        name="person"
+        size="large"
+      />
     </template>
     <div class="files-collaborators-autocomplete-user-text">
-      <div
-        class="uk-text-bold files-collaborators-autocomplete-username"
-        v-text="item.label"
-      />
+      <div class="uk-text-bold files-collaborators-autocomplete-username" v-text="item.label" />
       <div v-if="item.value.shareWithAdditionalInfo" v-text="item.value.shareWithAdditionalInfo" />
     </div>
   </div>
@@ -27,9 +39,14 @@ export default {
 
   mixins: [Mixins],
 
-  props: ['item'],
+  props: {
+    item: {
+      type: Object,
+      required: true
+    }
+  },
 
-  data () {
+  data() {
     return {
       shareTypes,
       loading: false
@@ -37,19 +54,19 @@ export default {
   },
 
   computed: {
-    isUser () {
+    isUser() {
       return this.item.value.shareType === shareTypes.user
     },
 
-    isRemoteUser () {
+    isRemoteUser() {
       return this.item.value.shareType === shareTypes.remote
     },
 
-    collaboratorClass () {
+    collaboratorClass() {
       const isUser = this.isUser || this.isRemoteUser
 
-      return 'files-collaborators-search-' + (
-        isUser ? (this.isRemoteUser ? 'remote' : 'user') : 'group'
+      return (
+        'files-collaborators-search-' + (isUser ? (this.isRemoteUser ? 'remote' : 'user') : 'group')
       )
     }
   }

--- a/apps/files/src/components/Collaborators/Collaborator.vue
+++ b/apps/files/src/components/Collaborators/Collaborator.vue
@@ -1,32 +1,53 @@
 <template>
   <oc-table middle class="files-collaborators-collaborator">
-    <oc-table-row v-if="$_reshareInformation" class="files-collaborators-collaborator-table-row-top">
+    <oc-table-row
+      v-if="$_reshareInformation"
+      class="files-collaborators-collaborator-table-row-top"
+    >
       <oc-table-cell shrink :colspan="firstColumn ? 2 : 1"></oc-table-cell>
       <oc-table-cell colspan="2">
         <div class="uk-text-meta">
-          <oc-button variation="raw" :id="$_resharerToggleId" :aria-label="$gettext('Show resharer details')">
+          <oc-button
+            :id="$_resharerToggleId"
+            variation="raw"
+            :aria-label="$gettext('Show resharer details')"
+          >
             <span class="uk-flex uk-flex-middle">
               <oc-icon name="repeat" class="uk-preserve-width oc-icon-xsmall" />
-              <span class="uk-padding-remove uk-margin-xsmall-left uk-text-truncate files-collaborators-collaborator-reshare-information">{{ $_reshareInformation }}</span>
+              <span
+                class="uk-padding-remove uk-margin-xsmall-left uk-text-truncate files-collaborators-collaborator-reshare-information"
+                >{{ $_reshareInformation }}</span
+              >
             </span>
           </oc-button>
           <oc-drop
-            :dropId="$_resharerToggleId + '-drop'"
+            ref="menu"
+            :drop-id="$_resharerToggleId + '-drop'"
             :toggle="'#' + $_resharerToggleId"
             mode="click"
-            :options="{pos:'bottom-left', delayHide: 0}"
+            :options="{ pos: 'bottom-left', delayHide: 0 }"
             class="uk-width-large uk-margin-small-top"
-            ref="menu"
-            closeOnClick
+            close-on-click
           >
             <translate tag="h4">Shared by:</translate>
             <ul class="uk-list uk-list-divider uk-overflow-hidden uk-margin-remove">
               <li v-for="resharer in collaborator.resharers" :key="resharer.name">
                 <div class="uk-flex uk-flex-middle uk-flex-left">
-                  <avatar-image class="uk-margin-small-right" :width="48" :userid="resharer.name" :userName="resharer.displayName" />
+                  <avatar-image
+                    class="uk-margin-small-right"
+                    :width="48"
+                    :userid="resharer.name"
+                    :user-name="resharer.displayName"
+                  />
                   <div>
-                    <span class="files-collaborators-resharer-name uk-text-bold">{{ resharer.displayName }}</span>
-                    <span v-if="resharer.additionalInfo" class="uk-text-meta files-collaborators-resharer-additional-info">({{ resharer.additionalInfo }})</span>
+                    <span class="files-collaborators-resharer-name uk-text-bold">{{
+                      resharer.displayName
+                    }}</span>
+                    <span
+                      v-if="resharer.additionalInfo"
+                      class="uk-text-meta files-collaborators-resharer-additional-info"
+                      >({{ resharer.additionalInfo }})</span
+                    >
                   </div>
                 </div>
               </li>
@@ -36,11 +57,21 @@
       </oc-table-cell>
     </oc-table-row>
     <oc-table-row class="files-collaborators-collaborator-table-row-info">
-      <oc-table-cell shrink v-if="firstColumn">
-        <oc-button v-if="$_deleteButtonVisible" :ariaLabel="$gettext('Delete share')" @click="$_removeShare" variation="raw" class="files-collaborators-collaborator-delete">
+      <oc-table-cell v-if="firstColumn" shrink>
+        <oc-button
+          v-if="$_deleteButtonVisible"
+          :aria-label="$gettext('Delete share')"
+          variation="raw"
+          class="files-collaborators-collaborator-delete"
+          @click="$_removeShare"
+        >
           <oc-icon name="close" />
         </oc-button>
-        <oc-spinner v-else-if="$_loadingSpinnerVisible" :aria-label="$gettext('Removing collaborator…')" size="small" />
+        <oc-spinner
+          v-else-if="$_loadingSpinnerVisible"
+          :aria-label="$gettext('Removing collaborator…')"
+          size="small"
+        />
         <oc-icon v-else name="lock" class="uk-invisible"></oc-icon>
       </oc-table-cell>
       <oc-table-cell shrink>
@@ -50,36 +81,35 @@
             class="uk-margin-small-right files-collaborators-collaborator-indicator"
             :width="48"
             :userid="collaborator.collaborator.name"
-            :userName="collaborator.collaborator.displayName"
+            :user-name="collaborator.collaborator.displayName"
             :aria-label="$gettext('User')"
           />
           <div v-else key="collaborator-avatar-placeholder">
             <oc-icon
               v-if="collaborator.shareType === shareTypes.group"
+              key="avatar-group"
               class="uk-margin-small-right files-collaborators-collaborator-indicator"
               name="group"
               size="large"
-              key="avatar-group"
               :aria-label="$gettext('Group')"
             />
             <oc-icon
               v-else
+              key="avatar-generic-person"
               class="uk-margin-small-right files-collaborators-collaborator-indicator"
               name="person"
               size="large"
-              key="avatar-generic-person"
               :aria-label="$gettext('Remote user')"
             />
           </div>
         </div>
       </oc-table-cell>
       <oc-table-cell>
-        <div
-          class="uk-flex uk-flex-column uk-flex-center"
-          :class="collaboratorListItemClass"
-        >
+        <div class="uk-flex uk-flex-column uk-flex-center" :class="collaboratorListItemClass">
           <div class="oc-text">
-            <span class="files-collaborators-collaborator-name uk-text-bold">{{ collaborator.collaborator.displayName }}</span>
+            <span class="files-collaborators-collaborator-name uk-text-bold">{{
+              collaborator.collaborator.displayName
+            }}</span>
             <translate
               v-if="collaborator.collaborator.name === user.id"
               translate-comment="Indicator for current user in collaborators list"
@@ -93,11 +123,27 @@
             class="uk-text-meta files-collaborators-collaborator-additional-info"
             v-text="collaborator.collaborator.additionalInfo"
           />
-          <span class="oc-text"><span class="files-collaborators-collaborator-role">{{ originalRole.label }}</span><template v-if="collaborator.expires"> | <translate class="files-collaborators-collaborator-expires" :translate-params="{expires: formDateFromNow(expirationDate)}">Expires %{expires}</translate></template></span>
+          <span class="oc-text"
+            ><span class="files-collaborators-collaborator-role">{{ originalRole.label }}</span
+            ><template v-if="collaborator.expires">
+              |
+              <translate
+                class="files-collaborators-collaborator-expires"
+                :translate-params="{ expires: formDateFromNow(expirationDate) }"
+                >Expires %{expires}</translate
+              ></template
+            ></span
+          >
         </div>
       </oc-table-cell>
       <oc-table-cell shrink>
-        <oc-button v-if="$_editButtonVisible" :aria-label="$gettext('Edit share')" @click="$emit('onEdit', collaborator)" variation="raw" class="files-collaborators-collaborator-edit">
+        <oc-button
+          v-if="$_editButtonVisible"
+          :aria-label="$gettext('Edit share')"
+          variation="raw"
+          class="files-collaborators-collaborator-edit"
+          @click="$emit('onEdit', collaborator)"
+        >
           <oc-icon name="edit" />
         </oc-button>
       </oc-table-cell>
@@ -106,10 +152,16 @@
       <oc-table-cell shrink :colspan="firstColumn ? 2 : 1"></oc-table-cell>
       <oc-table-cell colspan="2">
         <div class="uk-text-meta">
-          <router-link :to="$_viaRouterParams" :aria-label="$gettext('Navigate to parent')"
-                       class="files-collaborators-collaborator-follow-via uk-flex uk-flex-middle">
+          <router-link
+            :to="$_viaRouterParams"
+            :aria-label="$gettext('Navigate to parent')"
+            class="files-collaborators-collaborator-follow-via uk-flex uk-flex-middle"
+          >
             <oc-icon name="exit_to_app" size="small" class="uk-preserve-width" />
-            <span class="oc-file-name uk-padding-remove uk-margin-xsmall-left uk-text-truncate files-collaborators-collaborator-via-label">{{ $_viaLabel }}</span>
+            <span
+              class="oc-file-name uk-padding-remove uk-margin-xsmall-left uk-text-truncate files-collaborators-collaborator-via-label"
+              >{{ $_viaLabel }}</span
+            >
           </router-link>
         </div>
       </oc-table-cell>
@@ -127,10 +179,7 @@ import Mixins from '../../mixins'
 
 export default {
   name: 'Collaborator',
-  mixins: [
-    Mixins,
-    CollaboratorsMixins
-  ],
+  mixins: [Mixins, CollaboratorsMixins],
   props: {
     collaborator: {
       type: Object,
@@ -145,7 +194,7 @@ export default {
       default: true
     }
   },
-  data: function () {
+  data: function() {
     return {
       shareTypes,
       removalInProgress: false
@@ -154,43 +203,47 @@ export default {
   computed: {
     ...mapGetters(['user']),
 
-    $_resharerToggleId () {
+    $_resharerToggleId() {
       return 'collaborator-' + this.collaborator.collaborator.name + '-resharer-details-toggle'
     },
 
-    $_loadingSpinnerVisible () {
+    $_loadingSpinnerVisible() {
       return this.modifiable && this.removalInProgress
     },
-    $_deleteButtonVisible () {
+    $_deleteButtonVisible() {
       return this.modifiable && !this.removalInProgress
     },
-    $_editButtonVisible () {
+    $_editButtonVisible() {
       return this.modifiable && !this.removalInProgress
     },
 
-    $_isIndirectShare () {
+    $_isIndirectShare() {
       // it is assumed that the "incoming" attribute only exists
       // on shares coming from this.collaborator.sTree which are all indirect
       // and not related to the current folder
       return this.collaborator.incoming || this.collaborator.outgoing
     },
 
-    $_reshareInformation () {
+    $_reshareInformation() {
       if (!this.collaborator.resharers) {
         return null
       }
       return this.collaborator.resharers.map(share => share.displayName).join(', ')
     },
 
-    $_viaLabel () {
+    $_viaLabel() {
       if (!this.$_isIndirectShare) {
         return null
       }
       const translated = this.$gettext('Via %{folderName}')
-      return this.$gettextInterpolate(translated, { folderName: basename(this.collaborator.path) }, true)
+      return this.$gettextInterpolate(
+        translated,
+        { folderName: basename(this.collaborator.path) },
+        true
+      )
     },
 
-    $_viaRouterParams () {
+    $_viaRouterParams() {
       const viaPath = this.collaborator.path
       return {
         name: 'files-list',
@@ -203,7 +256,7 @@ export default {
       }
     },
 
-    originalRole () {
+    originalRole() {
       if (this.collaborator.role.name === 'advancedRole') {
         return this.advancedRole
       }
@@ -218,28 +271,29 @@ export default {
       }
     },
 
-    isUser () {
+    isUser() {
       return this.collaborator.shareType === shareTypes.user
     },
 
-    isRemoteUser () {
+    isRemoteUser() {
       return this.collaborator.shareType === shareTypes.remote
     },
 
-    collaboratorListItemClass () {
+    collaboratorListItemClass() {
       const isUser = this.isUser || this.isRemoteUser
 
-      return 'files-collaborators-collaborator-info-' + (
-        isUser ? (this.isRemoteUser ? 'remote' : 'user') : 'group'
+      return (
+        'files-collaborators-collaborator-info-' +
+        (isUser ? (this.isRemoteUser ? 'remote' : 'user') : 'group')
       )
     },
 
-    expirationDate () {
+    expirationDate() {
       return moment(this.collaborator.expires).endOf('day')
     }
   },
   methods: {
-    $_removeShare () {
+    $_removeShare() {
       this.removalInProgress = true
       this.$emit('onDelete', this.collaborator)
     }
@@ -248,23 +302,23 @@ export default {
 </script>
 
 <style scoped="scoped">
-  /* FIXME: Move to ODS somehow */
-  .files-collaborators-collaborator-table-row-top > td {
-    padding: 0 10px 3px 0;
-  }
-  .files-collaborators-collaborator-table-row-info > td {
-    padding: 0 10px 0 0;
-  }
-  .files-collaborators-collaborator-table-row-bottom > td {
-    padding: 3px 10px 0 0;
-  }
-  .files-collaborators-collaborator-via-label {
-    max-width: 75%;
-  }
+/* FIXME: Move to ODS somehow */
+.files-collaborators-collaborator-table-row-top > td {
+  padding: 0 10px 3px 0;
+}
+.files-collaborators-collaborator-table-row-info > td {
+  padding: 0 10px 0 0;
+}
+.files-collaborators-collaborator-table-row-bottom > td {
+  padding: 3px 10px 0 0;
+}
+.files-collaborators-collaborator-via-label {
+  max-width: 75%;
+}
 </style>
 <style>
-  /* TODO: Move to ODS  */
-  .oc-text {
-    font-size: 1rem;
-  }
+/* TODO: Move to ODS  */
+.oc-text {
+  font-size: 1rem;
+}
 </style>

--- a/apps/files/src/components/Collaborators/CollaboratorsEditOptions.vue
+++ b/apps/files/src/components/Collaborators/CollaboratorsEditOptions.vue
@@ -1,17 +1,17 @@
 <template>
-  <oc-grid gutter="small" childWidth="1-1">
+  <oc-grid gutter="small" child-width="1-1">
     <roles-select
       mode="collaborators"
       :roles="roles"
-      :selectedRole="role"
+      :selected-role="role"
       @roleSelected="selectRole"
     />
-    <label class="oc-label" v-if="$_ocCollaborators_hasAdditionalPermissions">
+    <label v-if="$_ocCollaborators_hasAdditionalPermissions" class="oc-label">
       <translate>Additional permissions:</translate>
     </label>
     <additional-permissions
-      :availablePermissions="role.additionalPermissions"
-      :collaboratorsPermissions="collaboratorsPermissions"
+      :available-permissions="role.additionalPermissions"
+      :collaborators-permissions="collaboratorsPermissions"
       @permissionChecked="checkAdditionalPermissions"
     />
     <div v-if="expirationSupported">
@@ -24,8 +24,8 @@
           id="files-collaborators-collaborator-expiration-input"
           :key="`collaborator-datepicker-${enteredExpirationDate}`"
           :date="enteredExpirationDate"
-          :maxDatetime="maxExpirationDate"
-          :minDatetime="minExpirationDate"
+          :max-datetime="maxExpirationDate"
+          :min-datetime="minExpirationDate"
           :placeholder="expirationDatePlaceholder"
           @input="setExpirationDate"
         />
@@ -34,8 +34,8 @@
           id="files-collaborators-collaborator-expiration-delete"
           class="uk-position-small uk-position-center-right oc-cursor-pointer"
           :uk-tooltip="expirationDateRemoveTooltip"
-          @click="resetExpirationDate"
           uk-close
+          @click="resetExpirationDate"
         />
       </div>
     </div>
@@ -58,33 +58,35 @@ export default {
     AdditionalPermissions
   },
 
-  mixins: [
-    collaboratorsMixins
-  ],
+  mixins: [collaboratorsMixins],
 
   props: {
     existingRole: {
       type: Object,
-      required: false
+      required: false,
+      default: undefined
     },
     collaboratorsPermissions: {
       type: Object,
-      required: false
+      required: false,
+      default: undefined
     },
     expirationDate: {
       type: Date,
-      required: false
+      required: false,
+      default: undefined
     },
     existingCollaboratorType: {
       type: [Object, String],
       required: false,
-      validator: function (value) {
+      default: null,
+      validator: function(value) {
         return ['user', 'group'].indexOf(value) > -1 || value === null
       }
     }
   },
 
-  data () {
+  data() {
     return {
       selectedRole: null,
       additionalPermissions: null,
@@ -95,22 +97,22 @@ export default {
   computed: {
     ...mapGetters(['capabilities']),
 
-    editingUser () {
+    editingUser() {
       return this.existingCollaboratorType === 'user'
     },
 
-    editingGroup () {
+    editingGroup() {
       return this.existingCollaboratorType === 'group'
     },
 
-    $_ocCollaborators_hasAdditionalPermissions () {
+    $_ocCollaborators_hasAdditionalPermissions() {
       if (this.selectedRole && this.selectedRole.name !== 'advancedRole') {
         return Object.keys(this.selectedRole.additionalPermissions).length > 0
       }
       return false
     },
 
-    role () {
+    role() {
       // Returns default role
       if (!this.existingRole && !this.selectedRole) {
         const defaultRole = this.roles[Object.keys(this.roles)[0]]
@@ -119,11 +121,8 @@ export default {
       }
 
       if (
-        (
-          this.existingRole && this.existingRole.name === 'advancedRole' && !this.selectedRole
-        ) || (
-          this.selectedRole && this.selectedRole.name === 'advancedRole'
-        )
+        (this.existingRole && this.existingRole.name === 'advancedRole' && !this.selectedRole) ||
+        (this.selectedRole && this.selectedRole.name === 'advancedRole')
       ) {
         this.selectRole(this.advancedRole, false)
         return this.advancedRole
@@ -137,11 +136,11 @@ export default {
       return this.selectedRole
     },
 
-    expirationSupported () {
+    expirationSupported() {
       return this.userExpirationDate && this.groupExpirationDate
     },
 
-    defaultExpirationDateSet () {
+    defaultExpirationDateSet() {
       if (this.editingUser) {
         return this.userExpirationDate.enabled
       }
@@ -153,15 +152,15 @@ export default {
       return this.userExpirationDate.enabled || this.groupExpirationDate.enabled
     },
 
-    userExpirationDate () {
+    userExpirationDate() {
       return this.capabilities.files_sharing.user.expire_date
     },
 
-    groupExpirationDate () {
+    groupExpirationDate() {
       return this.capabilities.files_sharing.group.expire_date
     },
 
-    defaultExpirationDate () {
+    defaultExpirationDate() {
       if (!this.defaultExpirationDateSet) {
         return null
       }
@@ -170,11 +169,17 @@ export default {
       const groupMaxExpirationDays = parseInt(this.groupExpirationDate.days, 10)
 
       if (this.editingUser) {
-        return moment().add(userMaxExpirationDays, 'days').endOf('day').toISOString()
+        return moment()
+          .add(userMaxExpirationDays, 'days')
+          .endOf('day')
+          .toISOString()
       }
 
       if (this.editingGroup) {
-        return moment().add(groupMaxExpirationDays, 'days').endOf('day').toISOString()
+        return moment()
+          .add(groupMaxExpirationDays, 'days')
+          .endOf('day')
+          .toISOString()
       }
 
       // Since we are not separating process for adding users and groups as collaborators
@@ -187,10 +192,13 @@ export default {
         days = userMaxExpirationDays || groupMaxExpirationDays
       }
 
-      return moment().add(days, 'days').endOf('day').toISOString()
+      return moment()
+        .add(days, 'days')
+        .endOf('day')
+        .toISOString()
     },
 
-    expirationDateEnforced () {
+    expirationDateEnforced() {
       if (this.editingUser) {
         return this.userExpirationDate.enforced
       }
@@ -202,7 +210,7 @@ export default {
       return this.userExpirationDate.enforced || this.groupExpirationDate.enforced
     },
 
-    maxExpirationDate () {
+    maxExpirationDate() {
       if (!this.expirationDateEnforced) {
         return null
       }
@@ -210,57 +218,64 @@ export default {
       return this.defaultExpirationDate
     },
 
-    minExpirationDate () {
-      return moment().add(1, 'days').endOf('day').toISOString()
+    minExpirationDate() {
+      return moment()
+        .add(1, 'days')
+        .endOf('day')
+        .toISOString()
     },
 
-    expirationDatePlaceholder () {
+    expirationDatePlaceholder() {
       return this.$gettext('Expiration date')
     },
 
-    expirationDateRemoveTooltip () {
+    expirationDateRemoveTooltip() {
       return this.$gettext('Remove expiration date')
     },
 
-    canResetExpirationDate () {
+    canResetExpirationDate() {
       return !this.expirationDateEnforced && this.enteredExpirationDate
     }
   },
 
-  mounted () {
+  mounted() {
     if (this.editingUser || this.editingGroup) {
       // FIXME: Datepicker is not displaying correct timezone so for now we add it manually
       // this.enteredExpirationDate = this.expirationDate ? moment(this.expirationDate).toISOString(true) : null
-      this.enteredExpirationDate = this.expirationDate ? moment(this.expirationDate).add(moment().utcOffset(), 'm').toISOString() : null
+      this.enteredExpirationDate = this.expirationDate
+        ? moment(this.expirationDate)
+            .add(moment().utcOffset(), 'm')
+            .toISOString()
+        : null
     } else {
       this.enteredExpirationDate = this.defaultExpirationDate
     }
   },
 
   methods: {
-    selectRole (role) {
+    selectRole(role) {
       this.selectedRole = role
       this.publishChange()
     },
 
-    checkAdditionalPermissions (permissions) {
+    checkAdditionalPermissions(permissions) {
       this.additionalPermissions = permissions
       this.publishChange()
     },
 
-    setExpirationDate (date) {
+    setExpirationDate(date) {
       // Expiration date picker is emitting empty string when the component is initialised
       // This ensures it will be null as we treat it everywhere in that way
       this.enteredExpirationDate = date === '' ? null : date
       this.publishChange()
     },
 
-    resetExpirationDate () {
+    resetExpirationDate() {
       this.enteredExpirationDate = null
       this.publishChange()
     },
 
-    publishChange () {
+    publishChange() {
       this.$emit('optionChange', {
         role: this.selectedRole,
         permissions: this.additionalPermissions,

--- a/apps/files/src/components/Collaborators/EditCollaborator.vue
+++ b/apps/files/src/components/Collaborators/EditCollaborator.vue
@@ -1,36 +1,61 @@
 <template>
   <div class="files-collaborators-collaborator-edit-dialog">
-    <transition enter-active-class="uk-animation-slide-top-small" leave-active-class="uk-animation-slide-top-small uk-animation-reverse"
-                name="custom-classes-transition">
-      <oc-alert v-if="errors" class="oc-files-collaborators-collaborator-error-alert" variation="danger">
+    <transition
+      enter-active-class="uk-animation-slide-top-small"
+      leave-active-class="uk-animation-slide-top-small uk-animation-reverse"
+      name="custom-classes-transition"
+    >
+      <oc-alert
+        v-if="errors"
+        class="oc-files-collaborators-collaborator-error-alert"
+        variation="danger"
+      >
         {{ errors }}
       </oc-alert>
     </transition>
-    <div v-if="user.id !== collaborator.owner.name" class="uk-text-meta uk-flex uk-flex-middle uk-margin-small-bottom">
+    <div
+      v-if="user.id !== collaborator.owner.name"
+      class="uk-text-meta uk-flex uk-flex-middle uk-margin-small-bottom"
+    >
       <oc-icon name="repeat" class="uk-margin-small-right" /> {{ collaborator.owner.displayName }}
     </div>
     <collaborator class="uk-width-expand" :collaborator="collaborator" :first-column="false" />
     <collaborators-edit-options
-      :existingRole="$_originalRole"
-      :collaboratorsPermissions="$_originalPermissions"
-      :expirationDate="originalExpirationDate"
-      :existingCollaboratorType="collaboratorType"
-      @optionChange="collaboratorOptionChanged"
+      :existing-role="$_originalRole"
+      :collaborators-permissions="$_originalPermissions"
+      :expiration-date="originalExpirationDate"
+      :existing-collaborator-type="collaboratorType"
       class="uk-margin-bottom"
+      @optionChange="collaboratorOptionChanged"
     />
     <hr class="divider" />
     <oc-grid gutter="small" class="uk-margin-bottom">
       <div>
-        <oc-button :disabled="saving" @click="$_ocCollaborators_cancelChanges" class="files-collaborators-collaborator-cancel" key="edit-collaborator-cancel-button">
+        <oc-button
+          key="edit-collaborator-cancel-button"
+          :disabled="saving"
+          class="files-collaborators-collaborator-cancel"
+          @click="$_ocCollaborators_cancelChanges"
+        >
           <translate>Cancel</translate>
         </oc-button>
-        <oc-button :disabled="true" key="edit-collaborator-saving-button" v-if="saving">
-          <oc-spinner :aria-label="$gettext('Saving Share')" class="uk-position-small uk-position-center-left" size="xsmall"/>
-          <span :aria-hidden="true" class="uk-margin-small-left" v-translate>Saving Share</span>
+        <oc-button v-if="saving" key="edit-collaborator-saving-button" :disabled="true">
+          <oc-spinner
+            :aria-label="$gettext('Saving Share')"
+            class="uk-position-small uk-position-center-left"
+            size="xsmall"
+          />
+          <span v-translate :aria-hidden="true" class="uk-margin-small-left">Saving Share</span>
         </oc-button>
-        <oc-button :aria-label="$gettext('Save Share')" :disabled="!$_hasChanges" @click="$_ocCollaborators_saveChanges" id="files-collaborators-collaborator-save-share-button"
-                   key="edit-collaborator-saving-button" v-else
-                   variation="primary">
+        <oc-button
+          v-else
+          id="files-collaborators-collaborator-save-share-button"
+          key="edit-collaborator-saving-button"
+          :aria-label="$gettext('Save Share')"
+          :disabled="!$_hasChanges"
+          variation="primary"
+          @click="$_ocCollaborators_saveChanges"
+        >
           <translate>Save Share</translate>
         </oc-button>
       </div>
@@ -54,16 +79,14 @@ export default {
     Collaborator,
     CollaboratorsEditOptions
   },
-  mixins: [
-    Mixins
-  ],
+  mixins: [Mixins],
   props: {
     collaborator: {
       type: Object,
       required: true
     }
   },
-  data () {
+  data() {
     return {
       selectedRole: null,
       additionalPermissions: null,
@@ -76,7 +99,7 @@ export default {
     ...mapGetters('Files', ['highlightedFile']),
     ...mapGetters(['user']),
 
-    collaboratorType () {
+    collaboratorType() {
       const collaboratorShareType = this.collaborator.shareType
 
       if (
@@ -94,22 +117,22 @@ export default {
       return null
     },
 
-    $_originalPermissions () {
+    $_originalPermissions() {
       const permissions = this.collaborator.customPermissions
       return filterObject(permissions, (key, value) => value)
     },
 
-    $_originalRole () {
+    $_originalRole() {
       return this.roles[this.collaborator.role.name]
     },
 
-    $_permissionsBitmask () {
+    $_permissionsBitmask() {
       const role = this.selectedRole || this.$_originalRole
       const permissions = this.additionalPermissions || Object.keys(this.$_originalPermissions)
       return roleToBitmask(role, permissions)
     },
 
-    $_hasChanges () {
+    $_hasChanges() {
       if (this.selectedRole !== null && this.selectedRole.name !== this.$_originalRole.name) {
         // if the role has changed, always return true. The user doesn't need to understand if two bitmasks of different roles are the same!
         return true
@@ -117,18 +140,23 @@ export default {
 
       // FIXME: Datepicker is not displaying correct timezone so for now we add it manually
       const originalExpirationDate = this.originalExpirationDate
-        ? moment(this.originalExpirationDate).add(moment().utcOffset(), 'm').toISOString()
+        ? moment(this.originalExpirationDate)
+            .add(moment().utcOffset(), 'm')
+            .toISOString()
         : null
 
       if (this.expirationDate !== originalExpirationDate) {
         return true
       }
 
-      const originalBitmask = roleToBitmask(this.$_originalRole, Object.keys(this.$_originalPermissions))
+      const originalBitmask = roleToBitmask(
+        this.$_originalRole,
+        Object.keys(this.$_originalPermissions)
+      )
       return originalBitmask !== this.$_permissionsBitmask
     },
 
-    originalExpirationDate () {
+    originalExpirationDate() {
       const expirationDate = this.collaborator.expires
 
       if (expirationDate) {
@@ -141,7 +169,7 @@ export default {
   methods: {
     ...mapActions('Files', ['changeShare']),
 
-    $_ocCollaborators_saveChanges () {
+    $_ocCollaborators_saveChanges() {
       this.saving = true
 
       if (!this.selectedRole) this.selectedRole = this.$_originalRole
@@ -162,7 +190,7 @@ export default {
         })
     },
 
-    $_ocCollaborators_cancelChanges () {
+    $_ocCollaborators_cancelChanges() {
       this.selectedRole = null
       this.additionalPermissions = null
       this.expirationDate = this.originalExpirationDate
@@ -171,7 +199,7 @@ export default {
       this.close()
     },
 
-    close () {
+    close() {
       this.$emit('close')
     }
   }
@@ -179,11 +207,11 @@ export default {
 </script>
 
 <style>
-  .oc-text {
-    font-size: 1rem;
-  }
+.oc-text {
+  font-size: 1rem;
+}
 
-  .oc-disabled {
-    opacity: .4;
-  }
+.oc-disabled {
+  opacity: 0.4;
+}
 </style>

--- a/apps/files/src/components/Collaborators/NewCollaborator.vue
+++ b/apps/files/src/components/Collaborators/NewCollaborator.vue
@@ -3,62 +3,84 @@
     <label for="oc-sharing-autocomplete"><translate>New Collaborators:</translate></label>
     <oc-grid gutter="small">
       <oc-autocomplete
-        @input="$_ocCollaborators_selectAutocompleteResult"
-        :ariaLabel="$gettext('Select a collaborator to add')"
-        :items="autocompleteResults"
-        :itemsLoading="autocompleteInProgress"
-        :placeholder="$_ocCollaborationStatus_autocompletePlaceholder"
-        @update:input="$_onAutocompleteInput"
-        :filter="filterRecipients"
-        :fillOnSelection="false"
         id="oc-sharing-autocomplete"
         ref="ocSharingAutocomplete"
+        :aria-label="$gettext('Select a collaborator to add')"
+        :items="autocompleteResults"
+        :items-loading="autocompleteInProgress"
+        :placeholder="$_ocCollaborationStatus_autocompletePlaceholder"
+        :filter="filterRecipients"
+        :fill-on-selection="false"
         class="uk-width-1-1"
-        dropdownClass="uk-width-1-1"
+        dropdown-class="uk-width-1-1"
+        @input="$_ocCollaborators_selectAutocompleteResult"
+        @update:input="$_onAutocompleteInput"
       >
         <template v-slot:item="{ item }">
           <autocomplete-item :item="item" />
         </template>
       </oc-autocomplete>
     </oc-grid>
-    <oc-grid gutter="small" v-if="selectedCollaborators.length > 0">
+    <oc-grid v-if="selectedCollaborators.length > 0" gutter="small">
       <div>
         <div>
           <translate>Selected collaborators:</translate>
         </div>
-          <oc-table middle class="uk-width-expand files-collaborators-collaborator-autocomplete-item">
-            <oc-table-row v-for="collaborator in selectedCollaborators" :key="collaborator.value.shareWith + '-' + collaborator.value.shareType">
-              <oc-table-cell shrink>
-                <oc-button :ariaLabel="$gettext('Delete share')" variation="raw" size="small"
-                           @click="$_ocCollaborators_removeFromSelection(collaborator)"
-                           class="files-collaborators-collaborator-autocomplete-item-remove">
-                  <oc-icon name="close" />
-                </oc-button>
-              </oc-table-cell>
-              <oc-table-cell>
-                <autocomplete-item :item="collaborator" />
-              </oc-table-cell>
-            </oc-table-row>
-          </oc-table>
+        <oc-table middle class="uk-width-expand files-collaborators-collaborator-autocomplete-item">
+          <oc-table-row
+            v-for="collaborator in selectedCollaborators"
+            :key="collaborator.value.shareWith + '-' + collaborator.value.shareType"
+          >
+            <oc-table-cell shrink>
+              <oc-button
+                :aria-label="$gettext('Delete share')"
+                variation="raw"
+                size="small"
+                class="files-collaborators-collaborator-autocomplete-item-remove"
+                @click="$_ocCollaborators_removeFromSelection(collaborator)"
+              >
+                <oc-icon name="close" />
+              </oc-button>
+            </oc-table-cell>
+            <oc-table-cell>
+              <autocomplete-item :item="collaborator" />
+            </oc-table-cell>
+          </oc-table-row>
+        </oc-table>
       </div>
     </oc-grid>
-    <collaborators-edit-options class="uk-margin-bottom" @optionChange="collaboratorOptionChanged" />
+    <collaborators-edit-options
+      class="uk-margin-bottom"
+      @optionChange="collaboratorOptionChanged"
+    />
     <hr class="divider" />
     <oc-grid gutter="small" class="uk-margin-bottom">
       <div>
-        <oc-button :disabled="saving" @click="$_ocCollaborators_newCollaboratorsCancel" class="files-collaborators-collaborator-cancel" key="new-collaborator-cancel-button">
+        <oc-button
+          key="new-collaborator-cancel-button"
+          :disabled="saving"
+          class="files-collaborators-collaborator-cancel"
+          @click="$_ocCollaborators_newCollaboratorsCancel"
+        >
           <translate>Cancel</translate>
         </oc-button>
-        <oc-button :disabled="true" key="new-collaborator-saving-button" v-if="saving">
-          <oc-spinner :aria-label="$gettext('Adding Collaborators')" class="uk-position-small uk-position-center-left" size="xsmall"/>
-          <span :aria-hidden="true" class="uk-margin-small-left" v-translate>Adding Collaborators</span>
+        <oc-button v-if="saving" key="new-collaborator-saving-button" :disabled="true">
+          <oc-spinner
+            :aria-label="$gettext('Adding Collaborators')"
+            class="uk-position-small uk-position-center-left"
+            size="xsmall"
+          />
+          <span v-translate :aria-hidden="true" class="uk-margin-small-left"
+            >Adding Collaborators</span
+          >
         </oc-button>
-        <oc-button :disabled="!$_isValid"
-                   @click="$_ocCollaborators_newCollaboratorsAdd(selectedCollaborators)"
-                   id="files-collaborators-collaborator-save-new-share-button"
-                   key="new-collaborator-save-button"
-                   v-else
-                   variation="primary"
+        <oc-button
+          v-else
+          id="files-collaborators-collaborator-save-new-share-button"
+          key="new-collaborator-save-button"
+          :disabled="!$_isValid"
+          variation="primary"
+          @click="$_ocCollaborators_newCollaboratorsAdd(selectedCollaborators)"
         >
           <translate>Add Collaborators</translate>
         </oc-button>
@@ -87,7 +109,7 @@ export default {
     CollaboratorsEditOptions
   },
   mixins: [Mixins],
-  data () {
+  data() {
     return {
       autocompleteResults: [],
       announcement: '',
@@ -100,25 +122,22 @@ export default {
     }
   },
   computed: {
-    ...mapGetters('Files', [
-      'currentFileOutgoingCollaborators',
-      'highlightedFile'
-    ]),
+    ...mapGetters('Files', ['currentFileOutgoingCollaborators', 'highlightedFile']),
     ...mapGetters(['user']),
 
-    $_ocCollaborationStatus_autocompletePlaceholder () {
+    $_ocCollaborationStatus_autocompletePlaceholder() {
       return this.$gettext("Add new collaborator by name, email or federation ID's")
     },
 
-    $_announcementWhenCollaboratorAdded () {
+    $_announcementWhenCollaboratorAdded() {
       return this.$gettext('Collaborator was added')
     },
 
-    $_isValid () {
+    $_isValid() {
       return this.selectedCollaborators.length > 0
     }
   },
-  mounted () {
+  mounted() {
     // Ensure default role is not undefined
     this.$nextTick(() => {
       this.$refs.ocSharingAutocomplete.focus()
@@ -130,11 +149,11 @@ export default {
   methods: {
     ...mapActions('Files', ['addShare']),
 
-    close () {
+    close() {
       this.$emit('close')
     },
 
-    $_onAutocompleteInput (value) {
+    $_onAutocompleteInput(value) {
       const minSearchLength = parseInt(this.user.capabilities.files_sharing.search_min_length, 10)
       if (value.length < minSearchLength) {
         this.autocompleteInProgress = false
@@ -157,8 +176,11 @@ export default {
 
           this.autocompleteResults = users.concat(groups, remotes).filter(collaborator => {
             const selected = this.selectedCollaborators.find(selectedCollaborator => {
-              return collaborator.value.shareWith === selectedCollaborator.value.shareWith &&
-                parseInt(collaborator.value.shareType, 10) === parseInt(selectedCollaborator.value.shareType, 10)
+              return (
+                collaborator.value.shareWith === selectedCollaborator.value.shareWith &&
+                parseInt(collaborator.value.shareType, 10) ===
+                  parseInt(selectedCollaborator.value.shareType, 10)
+              )
             })
 
             const exists = this.currentFileOutgoingCollaborators.find(existingCollaborator => {
@@ -181,48 +203,50 @@ export default {
           this.autocompleteInProgress = false
         })
     },
-    filterRecipients (item, queryText) {
+    filterRecipients(item, queryText) {
       if (item.value.shareType === shareTypes.remote) {
         // done on server side
         return true
       }
       return (
         item.label.toLocaleLowerCase().indexOf(queryText.toLocaleLowerCase()) > -1 ||
-        item.value.shareWith
-          .toLocaleLowerCase()
-          .indexOf(queryText.toLocaleLowerCase()) > -1
+        item.value.shareWith.toLocaleLowerCase().indexOf(queryText.toLocaleLowerCase()) > -1
       )
     },
-    $_ocCollaborators_newCollaboratorsCancel () {
+    $_ocCollaborators_newCollaboratorsCancel() {
       this.selectedCollaborators = []
       this.saving = false
       this.close()
     },
-    $_ocCollaborators_newCollaboratorsAdd (collaborators) {
+    $_ocCollaborators_newCollaboratorsAdd(collaborators) {
       this.saving = true
 
       const saveQueue = new PQueue({ concurrency: 4 })
       const savePromises = []
       collaborators.forEach(collaborator => {
-        savePromises.push(saveQueue.add(() => this.addShare({
-          client: this.$client,
-          path: this.highlightedFile.path,
-          $gettext: this.$gettext,
-          shareWith: collaborator.value.shareWith,
-          shareType: collaborator.value.shareType,
-          permissions: roleToBitmask(this.selectedRole, this.additionalPermissions),
-          expirationDate: this.expirationDate
-        })))
+        savePromises.push(
+          saveQueue.add(() =>
+            this.addShare({
+              client: this.$client,
+              path: this.highlightedFile.path,
+              $gettext: this.$gettext,
+              shareWith: collaborator.value.shareWith,
+              shareType: collaborator.value.shareType,
+              permissions: roleToBitmask(this.selectedRole, this.additionalPermissions),
+              expirationDate: this.expirationDate
+            })
+          )
+        )
       })
 
       return Promise.all(savePromises).then(() => {
         this.$_ocCollaborators_newCollaboratorsCancel()
       })
     },
-    $_ocCollaborators_selectAutocompleteResult (collaborator) {
+    $_ocCollaborators_selectAutocompleteResult(collaborator) {
       this.selectedCollaborators.push(collaborator)
     },
-    $_ocCollaborators_removeFromSelection (collaborator) {
+    $_ocCollaborators_removeFromSelection(collaborator) {
       this.selectedCollaborators = this.selectedCollaborators.filter(selectedCollaborator => {
         return collaborator !== selectedCollaborator
       })
@@ -232,8 +256,8 @@ export default {
 </script>
 
 <style scoped="scoped">
-  /* FIXME: Move to ODS somehow */
-  .files-collaborators-collaborator-autocomplete-item td {
-    padding: 0 10px 10px 0;
-  }
+/* FIXME: Move to ODS somehow */
+.files-collaborators-collaborator-autocomplete-item td {
+  padding: 0 10px 10px 0;
+}
 </style>

--- a/apps/files/src/components/FileDetails.vue
+++ b/apps/files/src/components/FileDetails.vue
@@ -1,15 +1,25 @@
 <template>
-  <oc-app-side-bar id="files-sidebar" :key="highlightedFile.id" class="uk-padding-small uk-overflow-auto uk-height-1-1" :disableAction="false" @close="close()">
-    <template slot="title" v-if="highlightedFile">
+  <oc-app-side-bar
+    id="files-sidebar"
+    :key="highlightedFile.id"
+    class="uk-padding-small uk-overflow-auto uk-height-1-1"
+    :disable-action="false"
+    @close="close()"
+  >
+    <template v-if="highlightedFile" slot="title">
       <div class="uk-inline">
         <oc-icon :name="fileTypeIcon(highlightedFile)" size="large" />
       </div>
       <div class="uk-inline">
         <div class="uk-flex uk-flex-middle">
-          <span id="files-sidebar-item-name" class="uk-margin-small-right uk-text-bold" v-text="highlightedFile.name" />
+          <span
+            id="files-sidebar-item-name"
+            class="uk-margin-small-right uk-text-bold"
+            v-text="highlightedFile.name"
+          />
         </div>
         <div v-if="$route.name !== 'files-shared-with-others'">
-          <oc-star v-if="!publicPage()" class="uk-inline" :shining="highlightedFile.starred"/>
+          <oc-star v-if="!publicPage()" class="uk-inline" :shining="highlightedFile.starred" />
           <template v-if="highlightedFile.size > -1">
             {{ highlightedFile.size | fileSize }},
           </template>
@@ -20,15 +30,26 @@
     <template slot="content">
       <div>
         <oc-tabs>
-            <oc-tab-item :active="tab.app == activeTab" @click="activeTab = tab.app" v-for="tab of fileSideBarsEnabled" :key="tab.name">
-              {{ tab.title || tab.component.title($gettext) }} {{ tab.name }}
-            </oc-tab-item>
+          <oc-tab-item
+            v-for="tab of fileSideBarsEnabled"
+            :key="tab.name"
+            :active="tab.app == activeTab"
+            @click="activeTab = tab.app"
+          >
+            {{ tab.title || tab.component.title($gettext) }} {{ tab.name }}
+          </oc-tab-item>
         </oc-tabs>
-        <component v-if="fileSideBars.length > 0 && activeTabComponent"
-          v-bind:is="activeTabComponent.component"
-           @reload="$emit('reload')"
-          :componentName="activeTabComponent.propsData ? activeTabComponent.propsData.componentName : ''"
-          :componentUrl="activeTabComponent.propsData ? activeTabComponent.propsData.componentUrl: ''"></component>
+        <component
+          :is="activeTabComponent.component"
+          v-if="fileSideBars.length > 0 && activeTabComponent"
+          :component-name="
+            activeTabComponent.propsData ? activeTabComponent.propsData.componentName : ''
+          "
+          :component-url="
+            activeTabComponent.propsData ? activeTabComponent.propsData.componentUrl : ''
+          "
+          @reload="$emit('reload')"
+        ></component>
       </div>
     </template>
   </oc-app-side-bar>
@@ -41,7 +62,7 @@ import { mapActions, mapGetters } from 'vuex'
 export default {
   name: 'FileDetails',
   mixins: [Mixins],
-  data () {
+  data() {
     return {
       /** String name of the tab that is activated */
       activeTab: null
@@ -50,35 +71,37 @@ export default {
   computed: {
     ...mapGetters(['getToken', 'fileSideBars', 'capabilities']),
     ...mapGetters('Files', ['highlightedFile']),
-    fileSideBarsEnabled () {
-      return this.fileSideBars.filter(b => b.enabled === undefined || b.enabled(this.capabilities, this.highlightedFile))
+    fileSideBarsEnabled() {
+      return this.fileSideBars.filter(
+        b => b.enabled === undefined || b.enabled(this.capabilities, this.highlightedFile)
+      )
     },
-    defaultTab () {
+    defaultTab() {
       if (this.fileSideBarsEnabled.length < 1) return null
 
       return this.fileSideBarsEnabled[0].app
     },
-    activeTabComponent () {
+    activeTabComponent() {
       return this.fileSideBarsEnabled.find(sidebar => sidebar.app === this.activeTab)
     }
   },
   watch: {
     // Switch back to default tab after selecting different file
-    highlightedFile () {
+    highlightedFile() {
       this.activeTab = this.defaultTab
     }
   },
-  mounted () {
+  mounted() {
     // Ensure default tab is not undefined
     this.activeTab = this.defaultTab
   },
   methods: {
     ...mapActions('Files', ['deleteFiles']),
     ...mapActions(['showMessage']),
-    close () {
+    close() {
       this.$emit('reset')
     },
-    showSidebar (app) {
+    showSidebar(app) {
       this.activeTab = app
     }
   }

--- a/apps/files/src/components/FileDrop.vue
+++ b/apps/files/src/components/FileDrop.vue
@@ -1,16 +1,16 @@
 <template>
   <vue-dropzone
     v-if="dropzone"
-    ref="ocDropzone"
     id="oc-dropzone"
+    ref="ocDropzone"
     :options="ocDropzone_options"
+    :use-custom-slot="true"
+    :include-styling="false"
     @vdropzone-drop="$_ocUpload_addDropToQue"
     @vdropzone-files-added="$_ocDropzone_dragEnd"
     @vdropzone-file-added="$_ocDropzone_removeFiles"
     @vdropzone-drag-leave="$_ocDropzone_dragEnd"
-    :useCustomSlot=true
-    :includeStyling=false
-    >
+  >
     <oc-dropzone>
       <translate>
         Drag and drop to upload content into current folder
@@ -28,9 +28,7 @@ export default {
   components: {
     vueDropzone: vue2DropZone
   },
-  mixins: [
-    Mixins
-  ],
+  mixins: [Mixins],
   props: {
     rootPath: { type: String, required: true },
     path: { type: String, required: true },
@@ -42,7 +40,7 @@ export default {
     },
     requestType: { type: String, default: 'PUT' }
   },
-  data () {
+  data() {
     return {
       ocDropzone_options: {
         url: '#', // FIXME: unused
@@ -57,10 +55,10 @@ export default {
   methods: {
     ...mapActions('Files', ['dragOver']),
 
-    $_ocDropzone_dragEnd () {
+    $_ocDropzone_dragEnd() {
       this.dragOver(false)
     },
-    $_ocDropzone_removeFiles (file) {
+    $_ocDropzone_removeFiles(file) {
       this.$refs.ocDropzone.removeFile(file)
     }
   }

--- a/apps/files/src/components/FileInfoVersions.vue
+++ b/apps/files/src/components/FileInfoVersions.vue
@@ -1,48 +1,57 @@
 <template>
-    <div id="oc-file-versions-sidebar">
-      <oc-loader v-if="loading" />
-        <oc-table middle divider v-if="!loading && hasVersion">
-            <oc-table-group>
-                <oc-table-row v-for="(item, index) in versions" :key="index" class="file-row">
-                    <oc-table-cell shrink>
-                      <oc-icon :name="fileTypeIcon(highlightedFile)" />
-                    </oc-table-cell>
-                    <oc-table-cell>
-                        <oc-table-cell class="uk-text-meta uk-text-nowrap">
-                            {{ formDateFromNow(item.fileInfo['{DAV:}getlastmodified']) }}
-                        </oc-table-cell>
-                        <oc-table-cell class="uk-text-meta uk-text-nowrap">
-                            {{  item.fileInfo['{DAV:}getcontentlength'] | fileSize }}
-                        </oc-table-cell>
-                    </oc-table-cell>
-                    <oc-table-cell shrink>
-                      <div class="uk-button-group uk-margin-small-right">
-                        <oc-button variation="raw" @click="revertVersion(item)" :aria-label="$gettext('Restore older version')">
-                          <oc-icon name="restore" />
-                        </oc-button>
-                      </div>
-                    </oc-table-cell>
-                    <oc-table-cell shrink>
-                      <div class="uk-button-group uk-margin-small-right">
-                        <oc-button variation="raw" @click="downloadVersion(item)" :aria-label="$gettext('Download older version')">
-                          <oc-icon name="cloud_download" />
-                        </oc-button>
-                      </div>
-                    </oc-table-cell>
-                </oc-table-row>
-            </oc-table-group>
-        </oc-table>
-        <div v-else>
-          <span v-translate>No Versions available for this file</span>
-        </div>
-    </div></template>
+  <div id="oc-file-versions-sidebar">
+    <oc-loader v-if="loading" />
+    <oc-table v-if="!loading && hasVersion" middle divider>
+      <oc-table-group>
+        <oc-table-row v-for="(item, index) in versions" :key="index" class="file-row">
+          <oc-table-cell shrink>
+            <oc-icon :name="fileTypeIcon(highlightedFile)" />
+          </oc-table-cell>
+          <oc-table-cell>
+            <oc-table-cell class="uk-text-meta uk-text-nowrap">
+              {{ formDateFromNow(item.fileInfo['{DAV:}getlastmodified']) }}
+            </oc-table-cell>
+            <oc-table-cell class="uk-text-meta uk-text-nowrap">
+              {{ item.fileInfo['{DAV:}getcontentlength'] | fileSize }}
+            </oc-table-cell>
+          </oc-table-cell>
+          <oc-table-cell shrink>
+            <div class="uk-button-group uk-margin-small-right">
+              <oc-button
+                variation="raw"
+                :aria-label="$gettext('Restore older version')"
+                @click="revertVersion(item)"
+              >
+                <oc-icon name="restore" />
+              </oc-button>
+            </div>
+          </oc-table-cell>
+          <oc-table-cell shrink>
+            <div class="uk-button-group uk-margin-small-right">
+              <oc-button
+                variation="raw"
+                :aria-label="$gettext('Download older version')"
+                @click="downloadVersion(item)"
+              >
+                <oc-icon name="cloud_download" />
+              </oc-button>
+            </div>
+          </oc-table-cell>
+        </oc-table-row>
+      </oc-table-group>
+    </oc-table>
+    <div v-else>
+      <span v-translate>No Versions available for this file</span>
+    </div>
+  </div></template
+>
 <script>
 import Mixins from '../mixins.js'
 import { mapGetters } from 'vuex'
 
 export default {
   mixins: [Mixins],
-  title: ($gettext) => {
+  title: $gettext => {
     return $gettext('Versions')
   },
   data: () => ({
@@ -52,40 +61,45 @@ export default {
   computed: {
     ...mapGetters('Files', ['highlightedFile']),
     ...mapGetters(['getToken']),
-    hasVersion () {
+    hasVersion() {
       return this.versions.length > 0
     },
-    currentFile () {
+    currentFile() {
       return this.highlightedFile
     }
   },
   watch: {
-    currentFile () {
+    currentFile() {
       this.getFileVersions()
     }
   },
-  mounted () {
+  mounted() {
     this.getFileVersions()
   },
   methods: {
-    currentVersionId (file) {
+    currentVersionId(file) {
       const etag = file.name.split('/')
       return etag[etag.length - 1]
     },
-    getFileVersions () {
+    getFileVersions() {
       this.loading = true
-      this.$client.fileVersions.listVersions(this.currentFile.id).then((res) => {
-        if (res) this.versions = res
-      }).finally(_ => {
-        this.loading = false
-      })
+      this.$client.fileVersions
+        .listVersions(this.currentFile.id)
+        .then(res => {
+          if (res) this.versions = res
+        })
+        .finally(_ => {
+          this.loading = false
+        })
     },
-    revertVersion (file) {
-      this.$client.fileVersions.restoreFileVersion(this.currentFile.id, this.currentVersionId(file), this.currentFile.path).then(() => {
-        this.getFileVersions()
-      })
+    revertVersion(file) {
+      this.$client.fileVersions
+        .restoreFileVersion(this.currentFile.id, this.currentVersionId(file), this.currentFile.path)
+        .then(() => {
+          this.getFileVersions()
+        })
     },
-    downloadVersion (file) {
+    downloadVersion(file) {
       const version = this.currentVersionId(file)
       const url = this.$client.fileVersions.getFileVersionUrl(this.currentFile.id, version)
 

--- a/apps/files/src/components/FileItem.vue
+++ b/apps/files/src/components/FileItem.vue
@@ -3,10 +3,10 @@
     :name="fileName"
     :extension="item.extension"
     :icon="previewIcon"
-    :iconUrl="previewUrl"
+    :icon-url="previewUrl"
     :filename="item.name"
     :data-preview-loaded="previewLoaded"
-    />
+  />
 </template>
 <script>
 import queryString from 'query-string'
@@ -14,26 +14,29 @@ import Mixins from '../mixins'
 
 export default {
   name: 'FileItem',
-  mixins: [
-    Mixins
-  ],
+  mixins: [Mixins],
   props: {
     item: {
-      type: Object
+      type: Object,
+      required: true
     },
     // override for file name
     name: {
-      type: String
+      type: String,
+      required: false,
+      default: undefined
     },
     davUrl: {
-      type: String
+      type: String,
+      required: false,
+      default: undefined
     },
     showPath: {
       type: Boolean,
       default: false
     }
   },
-  data: function () {
+  data: function() {
     return {
       previewUrl: this.item.previewUrl,
       // 'false' while the preview is loading (needs string for Vue.js to render the attribute)
@@ -43,26 +46,28 @@ export default {
     }
   },
   computed: {
-    fileName () {
+    fileName() {
       if (this.name) {
         return this.name
       }
       if (this.showPath) {
         const pathSplit = this.item.path.substr(1).split('/')
-        if (pathSplit.length === 2) return `${pathSplit[pathSplit.length - 2]}/${this.item.basename}`
-        if (pathSplit.length > 2) return `…/${pathSplit[pathSplit.length - 2]}/${this.item.basename}`
+        if (pathSplit.length === 2)
+          return `${pathSplit[pathSplit.length - 2]}/${this.item.basename}`
+        if (pathSplit.length > 2)
+          return `…/${pathSplit[pathSplit.length - 2]}/${this.item.basename}`
       }
       return this.item.basename
     },
-    previewIcon () {
+    previewIcon() {
       return this.fileTypeIcon(this.item)
     }
   },
-  mounted () {
+  mounted() {
     this.loadPreview()
   },
   methods: {
-    loadPreview () {
+    loadPreview() {
       if (this.item.previewUrl) {
         this.previewUrl = this.item.previewUrl
         this.previewLoaded = true
@@ -71,7 +76,11 @@ export default {
 
       // TODO: check if previews are globally enabled (requires capability entry)
       // don't load previews for pending or rejected shares (status)
-      if (!this.davUrl || this.item.type === 'folder' || (typeof this.item.status !== 'undefined' && this.item.status !== 0)) {
+      if (
+        !this.davUrl ||
+        this.item.type === 'folder' ||
+        (typeof this.item.status !== 'undefined' && this.item.status !== 0)
+      ) {
         this.previewLoaded = true
         return
       }
@@ -95,16 +104,19 @@ export default {
         itemPath = itemPath.substr(1)
       }
 
-      const previewUrl = this.davUrl + '/' + this.encodePath(itemPath) + '?' + queryString.stringify(query)
+      const previewUrl =
+        this.davUrl + '/' + this.encodePath(itemPath) + '?' + queryString.stringify(query)
 
-      this.mediaSource(previewUrl, 'url', this.requestHeaders).then(dataUrl => {
-        // cache inside item
-        this.previewUrl = this.item.previewUrl = dataUrl
-        this.previewLoaded = true
-      }).catch((e) => {
-        this.previewUrl = null
-        this.previewLoaded = true
-      })
+      this.mediaSource(previewUrl, 'url', this.requestHeaders)
+        .then(dataUrl => {
+          // cache inside item
+          this.previewUrl = this.item.previewUrl = dataUrl
+          this.previewLoaded = true
+        })
+        .catch(e => {
+          this.previewUrl = null
+          this.previewLoaded = true
+        })
     }
   }
 }

--- a/apps/files/src/components/FileLinkSidebar.vue
+++ b/apps/files/src/components/FileLinkSidebar.vue
@@ -1,45 +1,81 @@
 <template>
-  <div class="uk-position-relative" id="oc-files-file-link">
-    <div v-show="visiblePanel === PANEL_SHOW" :aria-hidden="visiblePanel !== PANEL_SHOW" :key="PANEL_SHOW">
-      <oc-loader v-if="linksLoading" :aria-label="$gettext('Loading list of file links')"/>
+  <div id="oc-files-file-link" class="uk-position-relative">
+    <div
+      v-show="visiblePanel === PANEL_SHOW"
+      :key="PANEL_SHOW"
+      :aria-hidden="visiblePanel !== PANEL_SHOW"
+    >
+      <oc-loader v-if="linksLoading" :aria-label="$gettext('Loading list of file links')" />
       <template v-else>
         <section v-if="$_privateLinkOfHighlightedFile">
           <div class="uk-text-bold">
             <span v-translate>Private Link</span>
-            <oc-button :aria-label="$_privateLinkCopyLabel" variation="raw" class="uk-margin-small-left">
-              <oc-icon v-if="!linksCopied[$_privateLinkOfHighlightedFile]" name="copy_to_clipboard" size="small" id="files-sidebar-private-link-label"
-                       v-clipboard:copy="$_privateLinkOfHighlightedFile" v-clipboard:success="$_clipboardSuccessHandler"/>
-              <oc-icon v-else name="ready" size="small" id="files-sidebar-private-link-icon-copied" class="_clipboard-success-animation"/>
+            <oc-button
+              :aria-label="$_privateLinkCopyLabel"
+              variation="raw"
+              class="uk-margin-small-left"
+            >
+              <oc-icon
+                v-if="!linksCopied[$_privateLinkOfHighlightedFile]"
+                id="files-sidebar-private-link-label"
+                v-clipboard:copy="$_privateLinkOfHighlightedFile"
+                v-clipboard:success="$_clipboardSuccessHandler"
+                name="copy_to_clipboard"
+                size="small"
+              />
+              <oc-icon
+                v-else
+                id="files-sidebar-private-link-icon-copied"
+                name="ready"
+                size="small"
+                class="_clipboard-success-animation"
+              />
             </oc-button>
           </div>
           <div class="uk-text-meta">
             <i><translate>Only invited collaborators can use this link.</translate></i>
           </div>
-          <hr/>
+          <hr />
         </section>
         <section>
           <div class="uk-text-bold">
             <translate>Public Links</translate>
           </div>
           <div class="uk-text-meta">
-            <i><translate>Any external collaborator with the respective link can access this resource. No sign-in required. Assign a password to avoid unintended document exposure.</translate></i>
+            <i
+              ><translate
+                >Any external collaborator with the respective link can access this resource. No
+                sign-in required. Assign a password to avoid unintended document
+                exposure.</translate
+              ></i
+            >
           </div>
           <div class="uk-margin-small-top uk-margin-small-bottom">
-            <oc-button @click="$_addPublicLink" icon="add" variation="primary" id="files-file-link-add">{{ $_addButtonLabel }}</oc-button>
+            <oc-button
+              id="files-file-link-add"
+              icon="add"
+              variation="primary"
+              @click="$_addPublicLink"
+              >{{ $_addButtonLabel }}</oc-button
+            >
           </div>
-          <transition-group class="uk-list uk-list-divider uk-overflow-hidden uk-margin-remove"
-                            :enter-active-class="$_transitionGroupEnter"
-                            :leave-active-class="$_transitionGroupLeave"
-                            name="custom-classes-transition"
-                            tag="ul">
+          <transition-group
+            class="uk-list uk-list-divider uk-overflow-hidden uk-margin-remove"
+            :enter-active-class="$_transitionGroupEnter"
+            :leave-active-class="$_transitionGroupLeave"
+            name="custom-classes-transition"
+            tag="ul"
+          >
             <li v-for="link in links" :key="link.key">
-              <public-link-list-item :link="link"
-                                     :modifiable="!link.indirect"
-                                     :indirect="link.indirect"
-                                     :linksCopied="linksCopied"
-                                     @onCopy="$_clipboardSuccessHandler"
-                                     @onDelete="$_removePublicLink"
-                                     @onEdit="$_editPublicLink" />
+              <public-link-list-item
+                :link="link"
+                :modifiable="!link.indirect"
+                :indirect="link.indirect"
+                :links-copied="linksCopied"
+                @onCopy="$_clipboardSuccessHandler"
+                @onDelete="$_removePublicLink"
+                @onEdit="$_editPublicLink"
+              />
             </li>
           </transition-group>
         </section>
@@ -49,11 +85,13 @@
       </template>
     </div>
     <div v-if="visiblePanel === PANEL_EDIT" :key="PANEL_EDIT">
-      <transition enter-active-class="uk-animation-slide-right uk-animation-fast"
-                  leave-active-class="uk-animation-slide-right uk-animation-reverse uk-animation-fast"
-                  name="custom-classes-transition">
+      <transition
+        enter-active-class="uk-animation-slide-right uk-animation-fast"
+        leave-active-class="uk-animation-slide-right uk-animation-reverse uk-animation-fast"
+        name="custom-classes-transition"
+      >
         <div class="uk-position-cover oc-default-background">
-          <edit-public-link :params="params" @close="$_showList()"/>
+          <edit-public-link :params="params" @close="$_showList()" />
         </div>
       </transition>
     </div>
@@ -80,10 +118,10 @@ export default {
     PublicLinkListItem
   },
   mixins: [mixins],
-  title: ($gettext) => {
+  title: $gettext => {
     return $gettext('Links')
   },
-  data () {
+  data() {
     return {
       visiblePanel: 'showLinks',
       linksCopied: {},
@@ -111,22 +149,22 @@ export default {
       'sharesTreeLoading'
     ]),
     ...mapGetters(['getToken', 'capabilities']),
-    ...mapState('Files', [
-      'sharesTree'
-    ]),
+    ...mapState('Files', ['sharesTree']),
 
-    $_transitionGroupEnter () {
+    $_transitionGroupEnter() {
       return this.transitionGroupActive ? 'uk-animation-slide-left-medium' : ''
     },
-    $_transitionGroupLeave () {
-      return this.transitionGroupActive ? 'uk-animation-slide-right-medium uk-animation-reverse' : ''
+    $_transitionGroupLeave() {
+      return this.transitionGroupActive
+        ? 'uk-animation-slide-right-medium uk-animation-reverse'
+        : ''
     },
 
-    linksLoading () {
+    linksLoading() {
       return this.currentFileOutgoingSharesLoading || this.sharesTreeLoading
     },
 
-    links () {
+    links() {
       return [...this.currentFileOutgoingLinks, ...this.indirectLinks]
         .sort(this.linksComparator)
         .map(share => {
@@ -135,7 +173,7 @@ export default {
         })
     },
 
-    indirectLinks () {
+    indirectLinks() {
       const allShares = []
       const parentPaths = getParentPaths(this.highlightedFile.path, false)
       if (parentPaths.length === 0) {
@@ -145,10 +183,10 @@ export default {
       // remove root entry
       parentPaths.pop()
 
-      parentPaths.forEach((parentPath) => {
+      parentPaths.forEach(parentPath => {
         const shares = this.sharesTree[parentPath]
         if (shares) {
-          shares.forEach((share) => {
+          shares.forEach(share => {
             if (share.outgoing && share.shareType === shareTypes.link) {
               share.key = 'indirect-link-' + share.id
               allShares.push(share)
@@ -160,26 +198,26 @@ export default {
       return allShares.sort(this.linksComparator)
     },
 
-    $_noPublicLinks () {
+    $_noPublicLinks() {
       return this.links.length === 0
     },
 
-    $_expirationDate () {
+    $_expirationDate() {
       const expireDate = this.capabilities.files_sharing.public.expire_date
 
       return {
         enabled: !!expireDate.enabled,
-        days: (expireDate.days) ? expireDate.days : false,
+        days: expireDate.days ? expireDate.days : false,
         enforced: expireDate.enforced === '1'
       }
     },
-    $_addButtonLabel () {
+    $_addButtonLabel() {
       return this.$gettext('Add public link')
     },
-    $_privateLinkCopyLabel () {
+    $_privateLinkCopyLabel() {
       return this.$gettext('Copy private link url')
     },
-    $_privateLinkOfHighlightedFile () {
+    $_privateLinkOfHighlightedFile() {
       if (!this.highlightedFile) {
         return false
       }
@@ -191,64 +229,70 @@ export default {
     }
   },
   watch: {
-    highlightedFile (newItem, oldItem) {
+    highlightedFile(newItem, oldItem) {
       if (oldItem !== newItem) {
         this.transitionGroupActive = false
         this.$_reloadLinks()
       }
     }
   },
-  mounted () {
+  mounted() {
     this.transitionGroupActive = false
     this.$_reloadLinks()
   },
   methods: {
-    ...mapActions('Files', [
-      'loadSharesTree',
-      'loadCurrentFileOutgoingShares',
-      'removeLink'
-    ]),
-    $_resetData () {
+    ...mapActions('Files', ['loadSharesTree', 'loadCurrentFileOutgoingShares', 'removeLink']),
+    $_resetData() {
       this.params = {
         id: null,
         name: this.capabilities.files_sharing.public.defaultPublicLinkShareName,
         permissions: 1,
         hasPassword: false,
-        expireDate: (this.$_expirationDate.days) ? moment().add(this.$_expirationDate.days, 'days').endOf('day').toISOString() : null
+        expireDate: this.$_expirationDate.days
+          ? moment()
+              .add(this.$_expirationDate.days, 'days')
+              .endOf('day')
+              .toISOString()
+          : null
       }
     },
-    $_removePublicLink (link) {
+    $_removePublicLink(link) {
       this.transitionGroupActive = true
       this.removeLink({
         client: this.$client,
         share: link
       })
     },
-    $_editPublicLink (link) {
+    $_editPublicLink(link) {
       this.params = {
         id: link.id,
         name: link.name,
         permissions: parseInt(link.permissions),
         hasPassword: link.password,
-        expireDate: (link.expiration !== null) ? moment(link.expiration).endOf('day').toISOString() : null
+        expireDate:
+          link.expiration !== null
+            ? moment(link.expiration)
+                .endOf('day')
+                .toISOString()
+            : null
       }
       this.visiblePanel = PANEL_EDIT
     },
-    $_addPublicLink () {
+    $_addPublicLink() {
       this.transitionGroupActive = true
       this.$_resetData()
       this.visiblePanel = PANEL_EDIT
     },
-    $_clipboardSuccessHandler (event) {
+    $_clipboardSuccessHandler(event) {
       this.$set(this.linksCopied, event.text, true)
       setTimeout(() => {
         this.linksCopied[event.text] = false
       }, 550)
     },
-    $_showList () {
+    $_showList() {
       this.visiblePanel = PANEL_SHOW
     },
-    $_reloadLinks () {
+    $_reloadLinks() {
       this.$_showList()
       this.loadCurrentFileOutgoingShares({
         client: this.$client,
@@ -261,7 +305,7 @@ export default {
         $gettext: this.$gettext
       })
     },
-    linksComparator (l1, l2) {
+    linksComparator(l1, l2) {
       // sorting priority 1: display name (lower case, ascending), 2: creation time (descending)
       const name1 = l1.name.toLowerCase().trim()
       const name2 = l2.name.toLowerCase().trim()
@@ -282,40 +326,40 @@ export default {
 }
 </script>
 <style scoped>
-  /* FIXME: Move to design system */
-  ._clipboard-success-animation {
-    animation-name: _clipboard-success-animation;
-    animation-duration: .5s;
-    animation-timing-function: ease-out;
-    animation-fill-mode: both;
-  }
+/* FIXME: Move to design system */
+._clipboard-success-animation {
+  animation-name: _clipboard-success-animation;
+  animation-duration: 0.5s;
+  animation-timing-function: ease-out;
+  animation-fill-mode: both;
+}
 
-  @keyframes _clipboard-success-animation {
-    0% {
-      opacity: 1;
-    }
-    50% {
-      opacity: 0.9;
-    }
-    100% {
-      opacity: 0;
-    }
+@keyframes _clipboard-success-animation {
+  0% {
+    opacity: 1;
   }
+  50% {
+    opacity: 0.9;
+  }
+  100% {
+    opacity: 0;
+  }
+}
 </style>
 <style>
-  /* FIXME: Move to design system (copied from FileSharingSidebar.vue) */
-  .oc-app-side-bar .oc-label {
-    display: block;
-    margin-bottom: 5px;
-  }
+/* FIXME: Move to design system (copied from FileSharingSidebar.vue) */
+.oc-app-side-bar .oc-label {
+  display: block;
+  margin-bottom: 5px;
+}
 
-  .oc-app-side-bar .files-file-link-role-button {
-    padding: 0 10px;
-    text-align: left;
-  }
+.oc-app-side-bar .files-file-link-role-button {
+  padding: 0 10px;
+  text-align: left;
+}
 
-  /** needed to cover the container below when transitioning */
-  .oc-app-side-bar .oc-default-background {
-    background-color: white;
-  }
+/** needed to cover the container below when transitioning */
+.oc-app-side-bar .oc-default-background {
+  background-color: white;
+}
 </style>

--- a/apps/files/src/components/FileOpenActions.vue
+++ b/apps/files/src/components/FileOpenActions.vue
@@ -1,17 +1,27 @@
 <template>
-  <div v-if="isOpen" :id="id" uk-offcanvas="mode: slide" class="oc-file-actions uk-offcanvas-bottom uk-open" style="display: block !important;">
+  <div
+    v-if="isOpen"
+    :id="id"
+    uk-offcanvas="mode: slide"
+    class="oc-file-actions uk-offcanvas-bottom uk-open"
+    style="display: block !important;"
+  >
     <div class="uk-offcanvas-bar">
       <oc-button
         icon="close"
         class="uk-position-top-right uk-position-absolute uk-margin-top uk-margin-right"
-        @click="closeActions"
         :aria-label="$gettext('Close file actions menu')"
+        @click="closeActions"
       />
-      <div v-text="$_label" class="uk-margin-small-bottom" />
+      <div class="uk-margin-small-bottom" v-text="$_label" />
       <ul class="uk-nav">
         <li v-for="(action, i) in actions" :key="i">
           <a class="uk-inline" @click="selectAction(action)">
-            <oc-icon v-if="action.icon || action.iconUrl" :name="action.icon" :url="action.iconUrl"/>
+            <oc-icon
+              v-if="action.icon || action.iconUrl"
+              :name="action.icon"
+              :url="action.iconUrl"
+            />
             <span class="uk-text-top" v-text="action.label" />
           </a>
         </li>
@@ -29,7 +39,7 @@ export default {
       default: 'oc-file-actions'
     }
   },
-  data () {
+  data() {
     return {
       filename: '',
       actions: [],
@@ -37,33 +47,33 @@ export default {
     }
   },
   computed: {
-    $_label () {
+    $_label() {
       const translated = this.$gettext('Open %{fileName} in')
       return this.$gettextInterpolate(translated, { fileName: this.filename }, true)
     }
   },
   watch: {
-    $route () {
+    $route() {
       this.closeActions()
     }
   },
-  mounted () {
+  mounted() {
     this.$root.$on('oc-file-actions:open', file => {
       this.showActions(file)
     })
   },
   methods: {
-    showActions (file) {
+    showActions(file) {
       this.filename = file.filename
       this.actions = file.actions
       this.isOpen = true
     },
-    closeActions () {
+    closeActions() {
       this.isOpen = false
       this.actions = []
       this.filename = ''
     },
-    selectAction (action) {
+    selectAction(action) {
       this.closeActions()
       action.onClick()
     }

--- a/apps/files/src/components/FileSharingSidebar.vue
+++ b/apps/files/src/components/FileSharingSidebar.vue
@@ -1,58 +1,88 @@
 <template>
   <div id="oc-files-sharing-sidebar" class="uk-position-relative">
-    <div v-show="visiblePanel === PANEL_SHOW" :aria-hidden="visiblePanel !== PANEL_SHOW" :key="PANEL_SHOW">
+    <div
+      v-show="visiblePanel === PANEL_SHOW"
+      :key="PANEL_SHOW"
+      :aria-hidden="visiblePanel !== PANEL_SHOW"
+    >
       <oc-loader v-if="sharesLoading" :aria-label="$gettext('Loading collaborator list')" />
       <template v-else>
         <div v-if="$_ocCollaborators_canShare" class="uk-margin-small-top uk-margin-small-bottom">
-          <oc-button variation="primary" icon="add" @click="$_ocCollaborators_addShare" class="files-collaborators-open-add-share-dialog-button">
+          <oc-button
+            variation="primary"
+            icon="add"
+            class="files-collaborators-open-add-share-dialog-button"
+            @click="$_ocCollaborators_addShare"
+          >
             <translate>Add Collaborators</translate>
           </oc-button>
         </div>
-        <p class="files-collaborators-no-reshare-permissions-message"
-           key="no-reshare-permissions-message"
-           v-else
-           v-text="noResharePermsMessage"
+        <p
+          v-else
+          key="no-reshare-permissions-message"
+          class="files-collaborators-no-reshare-permissions-message"
+          v-text="noResharePermsMessage"
         />
         <section>
           <ul class="uk-list uk-list-divider uk-overflow-hidden uk-margin-remove">
-            <li  v-if="$_ownerAsCollaborator" :key="$_ownerAsCollaborator.key">
-              <collaborator :collaborator="$_ownerAsCollaborator"/>
+            <li v-if="$_ownerAsCollaborator" :key="$_ownerAsCollaborator.key">
+              <collaborator :collaborator="$_ownerAsCollaborator" />
             </li>
             <li>
-              <collaborator :collaborator="$_currentUserAsCollaborator"/>
+              <collaborator :collaborator="$_currentUserAsCollaborator" />
             </li>
           </ul>
-          <hr class="uk-margin-small-top uk-margin-small-bottom" v-if="collaborators.length > 0" />
+          <hr v-if="collaborators.length > 0" class="uk-margin-small-top uk-margin-small-bottom" />
         </section>
         <section>
-          <transition-group id="files-collaborators-list"
-                            class="uk-list uk-list-divider uk-overflow-hidden uk-margin-remove"
-                            :enter-active-class="$_transitionGroupEnter"
-                            :leave-active-class="$_transitionGroupLeave"
-                            name="custom-classes-transition"
-                            tag="ul">
+          <transition-group
+            id="files-collaborators-list"
+            class="uk-list uk-list-divider uk-overflow-hidden uk-margin-remove"
+            :enter-active-class="$_transitionGroupEnter"
+            :leave-active-class="$_transitionGroupLeave"
+            name="custom-classes-transition"
+            tag="ul"
+          >
             <li v-for="collaborator in collaborators" :key="collaborator.key">
-              <collaborator :collaborator="collaborator" :modifiable="!collaborator.indirect" @onDelete="$_ocCollaborators_deleteShare" @onEdit="$_ocCollaborators_editShare"/>
+              <collaborator
+                :collaborator="collaborator"
+                :modifiable="!collaborator.indirect"
+                @onDelete="$_ocCollaborators_deleteShare"
+                @onEdit="$_ocCollaborators_editShare"
+              />
             </li>
           </transition-group>
         </section>
       </template>
     </div>
     <div v-if="visiblePanel === PANEL_NEW" :key="PANEL_NEW">
-      <transition enter-active-class="uk-animation-slide-right uk-animation-fast"
-                  leave-active-class="uk-animation-slide-right uk-animation-reverse uk-animation-fast"
-                  name="custom-classes-transition">
-        <div class="uk-position-cover oc-default-background" >
-          <new-collaborator v-if="$_ocCollaborators_canShare" key="new-collaborator" @close="$_ocCollaborators_showList" />
+      <transition
+        enter-active-class="uk-animation-slide-right uk-animation-fast"
+        leave-active-class="uk-animation-slide-right uk-animation-reverse uk-animation-fast"
+        name="custom-classes-transition"
+      >
+        <div class="uk-position-cover oc-default-background">
+          <new-collaborator
+            v-if="$_ocCollaborators_canShare"
+            key="new-collaborator"
+            @close="$_ocCollaborators_showList"
+          />
         </div>
       </transition>
     </div>
     <div v-if="visiblePanel === PANEL_EDIT" :key="PANEL_EDIT">
-      <transition enter-active-class="uk-animation-slide-right uk-animation-fast"
-                  leave-active-class="uk-animation-slide-right uk-animation-reverse uk-animation-fast"
-                  name="custom-classes-transition">
+      <transition
+        enter-active-class="uk-animation-slide-right uk-animation-fast"
+        leave-active-class="uk-animation-slide-right uk-animation-reverse uk-animation-fast"
+        name="custom-classes-transition"
+      >
         <div class="uk-position-cover oc-default-background">
-          <edit-collaborator v-if="$_ocCollaborators_canShare" key="edit-collaborator" @close="$_ocCollaborators_showList" :collaborator="currentShare" />
+          <edit-collaborator
+            v-if="$_ocCollaborators_canShare"
+            key="edit-collaborator"
+            :collaborator="currentShare"
+            @close="$_ocCollaborators_showList"
+          />
         </div>
       </transition>
     </div>
@@ -86,7 +116,7 @@ export default {
     Collaborator
   },
   mixins: [Mixins],
-  data () {
+  data() {
     return {
       visiblePanel: PANEL_SHOW,
       currentShare: null,
@@ -105,25 +135,27 @@ export default {
       'currentFileOutgoingSharesLoading',
       'sharesTreeLoading'
     ]),
-    ...mapState('Files', [
-      'incomingShares',
-      'incomingSharesLoading',
-      'sharesTree'
-    ]),
+    ...mapState('Files', ['incomingShares', 'incomingSharesLoading', 'sharesTree']),
     ...mapState(['user']),
 
-    $_transitionGroupEnter () {
+    $_transitionGroupEnter() {
       return this.transitionGroupActive ? 'uk-animation-slide-left-medium' : ''
     },
-    $_transitionGroupLeave () {
-      return this.transitionGroupActive ? 'uk-animation-slide-right-medium uk-animation-reverse' : ''
+    $_transitionGroupLeave() {
+      return this.transitionGroupActive
+        ? 'uk-animation-slide-right-medium uk-animation-reverse'
+        : ''
     },
 
-    sharesLoading () {
-      return this.currentFileOutgoingSharesLoading || this.incomingSharesLoading || this.sharesTreeLoading
+    sharesLoading() {
+      return (
+        this.currentFileOutgoingSharesLoading ||
+        this.incomingSharesLoading ||
+        this.sharesTreeLoading
+      )
     },
 
-    $_currentUserAsCollaborator () {
+    $_currentUserAsCollaborator() {
       const permissions = this.currentUsersPermissions
       const isFolder = this.highlightedFile.type === 'folder'
       let role = { name: '' }
@@ -147,7 +179,7 @@ export default {
       }
     },
 
-    $_ownerAsCollaborator () {
+    $_ownerAsCollaborator() {
       if (!this.$_allIncomingShares.length) {
         return null
       }
@@ -169,7 +201,9 @@ export default {
       })
 
       // make them unique then sort
-      ownerAsCollaborator.resharers = Array.from(resharers.values()).sort(this.collaboratorsComparator.bind(this))
+      ownerAsCollaborator.resharers = Array.from(resharers.values()).sort(
+        this.collaboratorsComparator.bind(this)
+      )
       return ownerAsCollaborator
     },
 
@@ -178,7 +212,7 @@ export default {
      *
      * @return {Array.<Object>} list of incoming shares
      */
-    $_allIncomingShares () {
+    $_allIncomingShares() {
       // direct incoming shares
       const allShares = [...this.incomingShares]
 
@@ -191,10 +225,10 @@ export default {
       // remove root entry
       parentPaths.pop()
 
-      parentPaths.forEach((parentPath) => {
+      parentPaths.forEach(parentPath => {
         const shares = this.sharesTree[parentPath]
         if (shares) {
-          shares.forEach((share) => {
+          shares.forEach(share => {
             if (share.incoming) {
               allShares.push(share)
             }
@@ -205,19 +239,22 @@ export default {
       return allShares
     },
 
-    collaborators () {
+    collaborators() {
       return [...this.currentFileOutgoingCollaborators, ...this.indirectOutgoingShares]
         .sort(this.collaboratorsComparator)
         .map(collaborator => {
           collaborator.key = 'collaborator-' + collaborator.id
-          if (collaborator.owner.name !== collaborator.fileOwner.name && collaborator.owner.name !== this.user.id) {
+          if (
+            collaborator.owner.name !== collaborator.fileOwner.name &&
+            collaborator.owner.name !== this.user.id
+          ) {
             collaborator.resharers = [collaborator.owner]
           }
           return collaborator
         })
     },
 
-    indirectOutgoingShares () {
+    indirectOutgoingShares() {
       const allShares = []
       const parentPaths = getParentPaths(this.highlightedFile.path, false)
       if (parentPaths.length === 0) {
@@ -227,10 +264,10 @@ export default {
       // remove root entry
       parentPaths.pop()
 
-      parentPaths.forEach((parentPath) => {
+      parentPaths.forEach(parentPath => {
         const shares = this.sharesTree[parentPath]
         if (shares) {
-          shares.forEach((share) => {
+          shares.forEach(share => {
             if (share.outgoing && this.$_isCollaboratorShare(share)) {
               share.key = 'indirect-collaborator-' + share.id
               allShares.push(share)
@@ -242,15 +279,15 @@ export default {
       return allShares
     },
 
-    $_ocCollaborators_canShare () {
+    $_ocCollaborators_canShare() {
       return this.highlightedFile.canShare()
     },
-    noResharePermsMessage () {
-      const translated = this.$gettext('You don\'t have permission to share this %{type}.')
+    noResharePermsMessage() {
+      const translated = this.$gettext("You don't have permission to share this %{type}.")
       return this.$gettextInterpolate(translated, { type: this.highlightedFile.type }, false)
     },
 
-    currentUsersPermissions () {
+    currentUsersPermissions() {
       if (this.incomingShares.length > 0) {
         let permissions = permissionsBitmask.read
 
@@ -265,14 +302,14 @@ export default {
     }
   },
   watch: {
-    highlightedFile (newItem, oldItem) {
+    highlightedFile(newItem, oldItem) {
       if (oldItem !== newItem) {
         this.transitionGroupActive = false
         this.$_reloadShares()
       }
     }
   },
-  mounted () {
+  mounted() {
     this.transitionGroupActive = false
     this.$_reloadShares()
   },
@@ -285,10 +322,10 @@ export default {
       'loadIncomingShares',
       'incomingSharesClearState'
     ]),
-    $_isCollaboratorShare (collaborator) {
+    $_isCollaboratorShare(collaborator) {
       return userShareTypes.includes(collaborator.shareType)
     },
-    collaboratorsComparator (c1, c2) {
+    collaboratorsComparator(c1, c2) {
       // Sorted by: type, direct, display name, creation date
       const c1DisplayName = c1.collaborator ? c1.collaborator.displayName : c1.displayName
       const c2DisplayName = c2.collaborator ? c2.collaborator.displayName : c2.displayName
@@ -313,32 +350,34 @@ export default {
 
       return c1UserShare ? -1 : 1
     },
-    $_ocCollaborators_addShare () {
+    $_ocCollaborators_addShare() {
       this.transitionGroupActive = true
       this.visiblePanel = PANEL_NEW
     },
-    $_ocCollaborators_editShare (share) {
+    $_ocCollaborators_editShare(share) {
       this.currentShare = share
       this.visiblePanel = PANEL_EDIT
     },
-    $_ocCollaborators_deleteShare (share) {
+    $_ocCollaborators_deleteShare(share) {
       this.transitionGroupActive = true
       this.deleteShare({
         client: this.$client,
         share: share
       })
     },
-    $_ocCollaborators_showList () {
+    $_ocCollaborators_showList() {
       this.visiblePanel = PANEL_SHOW
       this.currentShare = null
     },
-    $_ocCollaborators_isUser (collaborator) {
-      return collaborator.shareType === shareTypes.user || collaborator.shareType === shareTypes.remote
+    $_ocCollaborators_isUser(collaborator) {
+      return (
+        collaborator.shareType === shareTypes.user || collaborator.shareType === shareTypes.remote
+      )
     },
-    $_ocCollaborators_isGroup (collaborator) {
+    $_ocCollaborators_isGroup(collaborator) {
       return collaborator.shareType === shareTypes.group
     },
-    $_reloadShares () {
+    $_reloadShares() {
       this.$_ocCollaborators_showList()
       this.loadCurrentFileOutgoingShares({
         client: this.$client,

--- a/apps/files/src/components/FileSidebarWebComponent.vue
+++ b/apps/files/src/components/FileSidebarWebComponent.vue
@@ -1,11 +1,11 @@
 <template>
-    <div id="oc-file-sidebar-web-component">
-      <oc-loader v-if="loading" />
-      <div v-if="!loading">
-        <!-- TODO: define all props which need to be passed into a web component -->
-        <component :is="componentName" :selected-file="highlightedFileAsJson"></component>
-      </div>
+  <div id="oc-file-sidebar-web-component">
+    <oc-loader v-if="loading" />
+    <div v-if="!loading">
+      <!-- TODO: define all props which need to be passed into a web component -->
+      <component :is="componentName" :selected-file="highlightedFileAsJson"></component>
     </div>
+  </div>
 </template>
 <script>
 import Mixins from '../mixins.js'
@@ -13,7 +13,7 @@ import { mapGetters } from 'vuex'
 
 export default {
   mixins: [Mixins],
-  title: ($gettext) => {
+  title: $gettext => {
     return null
   },
   props: {
@@ -32,24 +32,25 @@ export default {
   computed: {
     ...mapGetters('Files', ['highlightedFile']),
     ...mapGetters(['getToken']),
-    highlightedFileAsJson () {
+    highlightedFileAsJson() {
       return JSON.stringify(this.highlightedFile)
     }
   },
-  mounted () {
+  mounted() {
     // tell Vue to not take care of the web component
-    window.Vue.config.ignoredElements = [
-      this.componentName
-    ]
+    window.Vue.config.ignoredElements = [this.componentName]
 
     // load component async
-    requirejs([this.componentUrl], app => {
-      this.loading = false
-    }, error => {
-      console.log(error)
-    })
+    requirejs(
+      [this.componentUrl],
+      app => {
+        this.loading = false
+      },
+      error => {
+        console.log(error)
+      }
+    )
   },
-  methods: {
-  }
+  methods: {}
 }
 </script>

--- a/apps/files/src/components/FileUpload.vue
+++ b/apps/files/src/components/FileUpload.vue
@@ -2,7 +2,15 @@
   <oc-nav-item icon="file_upload" @click="triggerUpload">
     <span id="files-file-upload-button" v-translate>Upload File</span>
     <div slot="outer-content">
-      <input id="fileUploadInput" type="file" aria-labelledby="files-file-upload-button" name="file" @change="$_ocUpload_addFileToQue" multiple ref="input" />
+      <input
+        id="fileUploadInput"
+        ref="input"
+        type="file"
+        aria-labelledby="files-file-upload-button"
+        name="file"
+        multiple
+        @change="$_ocUpload_addFileToQue"
+      />
     </div>
   </oc-nav-item>
 </template>
@@ -11,9 +19,7 @@
 import Mixins from '../mixins'
 
 export default {
-  mixins: [
-    Mixins
-  ],
+  mixins: [Mixins],
   props: {
     path: { type: String, required: true },
     headers: {
@@ -31,7 +37,7 @@ export default {
     requestType: { type: String, default: 'PUT' }
   },
   methods: {
-    triggerUpload () {
+    triggerUpload() {
       this.$refs.input.click()
     }
   }
@@ -39,8 +45,8 @@ export default {
 </script>
 
 <style scoped="true">
-  #fileUploadInput {
-    position: absolute;
-    left: -99999px;
-  }
+#fileUploadInput {
+  position: absolute;
+  left: -99999px;
+}
 </style>

--- a/apps/files/src/components/FilesApp.vue
+++ b/apps/files/src/components/FilesApp.vue
@@ -1,35 +1,55 @@
-  <template>
-    <div id="files" class="uk-flex uk-flex-column">
-      <files-app-bar />
-      <upload-progress v-show="$_uploadProgressVisible" class="uk-padding-small uk-background-muted" />
-      <oc-grid class="uk-height-1-1 uk-flex-1 uk-overflow-auto">
-        <div ref="filesListWrapper" tabindex="-1" class="uk-width-expand uk-overflow-auto uk-height-1-1" @dragover="$_ocApp_dragOver" :class="{ 'uk-visible@m' : _sidebarOpen }">
-          <oc-loader id="files-list-progress" v-if="loadingFolder"></oc-loader>
-          <trash-bin v-if="$route.name === 'files-trashbin'" :fileData="activeFiles" />
-          <shared-files-list v-else-if="sharedList" :fileData="activeFiles" @sideBarOpen="openSideBar" />
-          <all-files-list v-else @FileAction="openFileActionBar" :fileData="activeFiles" :parentFolder="currentFolder" @sideBarOpen="openSideBar" />
-        </div>
-        <file-details
-          v-if="_sidebarOpen && $route.name !== 'files-trashbin'"
-          ref="fileDetails" class="uk-width-1-1 uk-width-1-2@m uk-width-1-3@xl uk-height-1-1"
-          @reset="setHighlightedFile(null)"
+<template>
+  <div id="files" class="uk-flex uk-flex-column">
+    <files-app-bar />
+    <upload-progress
+      v-show="$_uploadProgressVisible"
+      class="uk-padding-small uk-background-muted"
+    />
+    <oc-grid class="uk-height-1-1 uk-flex-1 uk-overflow-auto">
+      <div
+        ref="filesListWrapper"
+        tabindex="-1"
+        class="uk-width-expand uk-overflow-auto uk-height-1-1"
+        :class="{ 'uk-visible@m': _sidebarOpen }"
+        @dragover="$_ocApp_dragOver"
+      >
+        <oc-loader v-if="loadingFolder" id="files-list-progress"></oc-loader>
+        <trash-bin v-if="$route.name === 'files-trashbin'" :file-data="activeFiles" />
+        <shared-files-list
+          v-else-if="sharedList"
+          :file-data="activeFiles"
+          @sideBarOpen="openSideBar"
         />
+        <all-files-list
+          v-else
+          :file-data="activeFiles"
+          :parent-folder="currentFolder"
+          @FileAction="openFileActionBar"
+          @sideBarOpen="openSideBar"
+        />
+      </div>
+      <file-details
+        v-if="_sidebarOpen && $route.name !== 'files-trashbin'"
+        ref="fileDetails"
+        class="uk-width-1-1 uk-width-1-2@m uk-width-1-3@xl uk-height-1-1"
+        @reset="setHighlightedFile(null)"
+      />
     </oc-grid>
-    <file-open-actions/>
+    <file-open-actions />
     {{ /* FIXME: hack to prevent conflict of dialog id with the trashbin deletion dialog */ }}
     <template v-if="$route.name !== 'files-trashbin'">
       <oc-dialog-prompt
         name="change-file-dialog"
         :oc-active="renameDialogOpen"
         :value="renameDialogNewName"
-        :ocError="renameDialogErrorMessage"
-        :ocTitle="$_renameDialogTitle"
-        ocConfirmId="oc-dialog-rename-confirm"
+        :oc-error="renameDialogErrorMessage"
+        :oc-title="$_renameDialogTitle"
+        oc-confirm-id="oc-dialog-rename-confirm"
+        :oc-input-placeholder="$_renameDialogPlaceholder"
+        :oc-input-label="$_renameDialogLabel"
         @oc-confirm="doRenameFile"
         @oc-cancel="cancelRenameFile"
         @input="$_validateFileName"
-        :oc-input-placeholder="$_renameDialogPlaceholder"
-        :oc-input-label="$_renameDialogLabel"
       />
       <oc-dialog-prompt
         name="delete-file-confirmation-dialog"
@@ -37,8 +57,8 @@
         :oc-active="deleteDialogOpen"
         :oc-content="deleteDialogMessage"
         :oc-has-input="false"
-        :ocTitle="$_deleteDialogTitle"
-        ocConfirmId="oc-dialog-delete-confirm"
+        :oc-title="$_deleteDialogTitle"
+        oc-confirm-id="oc-dialog-delete-confirm"
         @oc-confirm="reallyDeleteFiles"
         @oc-cancel="cancelDeleteFile"
       />
@@ -69,11 +89,8 @@ export default {
     UploadProgress,
     OcDialogPrompt
   },
-  mixins: [
-    Mixins,
-    FileActions
-  ],
-  data () {
+  mixins: [Mixins, FileActions],
+  data() {
     return {
       createFolder: false,
       fileUploadName: '',
@@ -88,25 +105,35 @@ export default {
   },
   computed: {
     ...mapGetters('Files', [
-      'selectedFiles', 'activeFiles', 'dropzone', 'loadingFolder', 'highlightedFile', 'currentFolder', 'inProgress',
+      'selectedFiles',
+      'activeFiles',
+      'dropzone',
+      'loadingFolder',
+      'highlightedFile',
+      'currentFolder',
+      'inProgress',
       'renameDialogSelectedFile',
-      'deleteDialogSelectedFiles', 'deleteDialogMessage'
+      'deleteDialogSelectedFiles',
+      'deleteDialogMessage'
     ]),
     ...mapGetters(['extensions']),
 
-    _sidebarOpen () {
+    _sidebarOpen() {
       return this.highlightedFile !== null
     },
 
-    sharedList () {
-      return this.$route.name === 'files-shared-with-me' || this.$route.name === 'files-shared-with-others'
+    sharedList() {
+      return (
+        this.$route.name === 'files-shared-with-me' ||
+        this.$route.name === 'files-shared-with-others'
+      )
     },
 
-    $_uploadProgressVisible () {
+    $_uploadProgressVisible() {
       return this.inProgress.length > 0
     },
 
-    $_renameDialogPlaceholder () {
+    $_renameDialogPlaceholder() {
       let translated
       if (!this.renameDialogSelectedFile || !this.renameDialogSelectedFile.name) return null
 
@@ -118,7 +145,7 @@ export default {
       return translated
     },
 
-    $_renameDialogLabel () {
+    $_renameDialogLabel() {
       let translated
       if (!this.renameDialogSelectedFile || !this.renameDialogSelectedFile.name) return ''
 
@@ -130,7 +157,7 @@ export default {
       return translated
     },
 
-    $_renameDialogTitle () {
+    $_renameDialogTitle() {
       let translated
 
       if (!this.renameDialogSelectedFile || !this.renameDialogSelectedFile.name) return null
@@ -140,20 +167,24 @@ export default {
       } else {
         translated = this.$gettext('Rename file %{name}')
       }
-      return this.$gettextInterpolate(translated, { name: this.renameDialogSelectedFile.name }, true)
+      return this.$gettextInterpolate(
+        translated,
+        { name: this.renameDialogSelectedFile.name },
+        true
+      )
     },
 
-    $_deleteDialogTitle () {
+    $_deleteDialogTitle() {
       // FIXME: differentiate between file, folder and multiple
       return this.$gettext('Delete File/Folder')
     }
   },
   watch: {
-    $route () {
+    $route() {
       this.setHighlightedFile(null)
     }
   },
-  created () {
+  created() {
     this.$root.$on('upload-end', () => {
       this.delayForScreenreader(() => this.$refs.filesListWrapper.focus())
     })
@@ -162,11 +193,11 @@ export default {
     ...mapActions('Files', ['dragOver', 'setHighlightedFile']),
     ...mapActions(['openFile', 'showMessage']),
 
-    trace () {
+    trace() {
       console.info('trace', arguments)
     },
 
-    openFileActionBar (file) {
+    openFileActionBar(file) {
       this.openFile({
         filePath: file.path
       })
@@ -203,7 +234,7 @@ export default {
       })
     },
 
-    openSideBar (file, sideBarName) {
+    openSideBar(file, sideBarName) {
       this.setHighlightedFile(file)
       const self = this
       this.$nextTick().then(() => {
@@ -211,15 +242,15 @@ export default {
       })
     },
 
-    $_ocApp_dragOver () {
+    $_ocApp_dragOver() {
       this.dragOver(true)
     },
 
-    $_ocAppSideBar_onReload () {
+    $_ocAppSideBar_onReload() {
       this.$refs.filesList.$_ocFilesFolder_getFolder()
     },
 
-    $_validateFileName (value) {
+    $_validateFileName(value) {
       this.renameDialogErrorMessage = this.validateFileName(value)
     }
   }

--- a/apps/files/src/components/FilesAppBar.vue
+++ b/apps/files/src/components/FilesAppBar.vue
@@ -1,12 +1,25 @@
 <template>
   <div id="files-app-bar" class="oc-app-bar">
-    <file-drop v-if="!isIE11()" :rootPath='item' :path='currentPath' :headers="headers" @success="onFileSuccess" @error="onFileError" @progress="onFileProgress" />
+    <file-drop
+      v-if="!isIE11()"
+      :root-path="item"
+      :path="currentPath"
+      :headers="headers"
+      @success="onFileSuccess"
+      @error="onFileError"
+      @progress="onFileProgress"
+    />
     <oc-grid flex gutter="small">
       <div class="uk-flex-1">
         <div class="uk-flex">
-          <oc-breadcrumb id="files-breadcrumb" :items="breadcrumbs" v-if="showBreadcrumb" home></oc-breadcrumb>
+          <oc-breadcrumb
+            v-if="showBreadcrumb"
+            id="files-breadcrumb"
+            :items="breadcrumbs"
+            home
+          ></oc-breadcrumb>
         </div>
-        <span class="uk-flex uk-flex-middle" v-if="!showBreadcrumb">
+        <span v-if="!showBreadcrumb" class="uk-flex uk-flex-middle">
           <oc-icon v-if="pageIcon" :name="pageIcon" class="uk-margin-small-right" />
           <h1 class="oc-page-title" v-text="pageTitle" />
         </span>
@@ -16,54 +29,115 @@
       </div>
       <div v-if="!publicPage()" class="uk-width-auto uk-visible@m">
         <oc-search-bar
-          @search="onFileSearch"
-          :label="$_searchLabel"
-          :loading="isLoadingSearch"
-          :buttonHidden="true"
-          :button="false"
-          @clear="onSearchClear"
           :key="searchBarKey"
           ref="globalSearchBar"
+          :label="$_searchLabel"
+          :loading="isLoadingSearch"
+          :button-hidden="true"
+          :button="false"
+          @search="onFileSearch"
+          @clear="onSearchClear"
         />
       </div>
       <div>
         <template v-if="$_ocFilesAppBar_showActions">
           <template v-if="canUpload && hasFreeSpace">
-            <oc-button variation="primary" id="new-file-menu-btn" key="new-file-menu-btn-enabled"><translate>+ New</translate></oc-button>
-            <oc-drop drop-id="new-file-menu-drop" toggle="#new-file-menu-btn" mode="click" closeOnClick :options="{delayHide: 0}">
+            <oc-button id="new-file-menu-btn" key="new-file-menu-btn-enabled" variation="primary"
+              ><translate>+ New</translate></oc-button
+            >
+            <oc-drop
+              drop-id="new-file-menu-drop"
+              toggle="#new-file-menu-btn"
+              mode="click"
+              close-on-click
+              :options="{ delayHide: 0 }"
+            >
               <oc-nav>
-                <file-upload :path='currentPath' :headers="headers" @success="onFileSuccess" @error="onFileError" @progress="onFileProgress"></file-upload>
-                <folder-upload v-if="!isIE11()" :rootPath='item' :path='currentPath' :headers="headers" @success="onFileSuccess" @error="onFileError" @progress="onFileProgress"></folder-upload>
-                <oc-nav-item @click="showCreateFolderDialog" id="new-folder-btn" icon="create_new_folder"><translate>New folder…</translate></oc-nav-item>
-                <oc-nav-item v-for="(newFileHandler, key) in newFileHandlers"
+                <file-upload
+                  :path="currentPath"
+                  :headers="headers"
+                  @success="onFileSuccess"
+                  @error="onFileError"
+                  @progress="onFileProgress"
+                ></file-upload>
+                <folder-upload
+                  v-if="!isIE11()"
+                  :root-path="item"
+                  :path="currentPath"
+                  :headers="headers"
+                  @success="onFileSuccess"
+                  @error="onFileError"
+                  @progress="onFileProgress"
+                ></folder-upload>
+                <oc-nav-item
+                  id="new-folder-btn"
+                  icon="create_new_folder"
+                  @click="showCreateFolderDialog"
+                  ><translate>New folder…</translate></oc-nav-item
+                >
+                <oc-nav-item
+                  v-for="(newFileHandler, key) in newFileHandlers"
                   :key="key"
-                  @click="showCreateFileDialog(newFileHandler.ext, newFileHandler.action)"
                   :class="'new-file-btn-' + newFileHandler.ext"
                   icon="save"
-                >{{ newFileHandler.menuTitle($gettext) }}</oc-nav-item>
+                  @click="showCreateFileDialog(newFileHandler.ext, newFileHandler.action)"
+                  >{{ newFileHandler.menuTitle($gettext) }}</oc-nav-item
+                >
               </oc-nav>
             </oc-drop>
           </template>
           <!-- FIXME: Unite new file menu btn -->
-          <oc-button v-else disabled id="new-file-menu-btn" key="new-file-menu-btn-disabled" :uk-tooltip="_cannotCreateDialogText"><translate>+ New</translate></oc-button>
+          <oc-button
+            v-else
+            id="new-file-menu-btn"
+            key="new-file-menu-btn-disabled"
+            disabled
+            :uk-tooltip="_cannotCreateDialogText"
+            ><translate>+ New</translate></oc-button
+          >
         </template>
         <template v-if="$route.name === 'files-trashbin'">
-          <oc-button v-if="selectedFiles.length > 0" key="restore-btn" icon="restore" @click="$_ocTrashbin_restoreFiles()">
+          <oc-button
+            v-if="selectedFiles.length > 0"
+            key="restore-btn"
+            icon="restore"
+            @click="$_ocTrashbin_restoreFiles()"
+          >
             <translate>Restore selected</translate>
           </oc-button>
-          <oc-button id="delete-selected-btn" icon="delete" key="delete-btn" :disabled="files.length === 0" @click="selectedFiles.length < 1 ? $_ocTrashbin_empty() : $_ocTrashbin_deleteSelected()">
+          <oc-button
+            id="delete-selected-btn"
+            key="delete-btn"
+            icon="delete"
+            :disabled="files.length === 0"
+            @click="selectedFiles.length < 1 ? $_ocTrashbin_empty() : $_ocTrashbin_deleteSelected()"
+          >
             {{ $_ocAppBar_clearTrashbinButtonText }}
           </oc-button>
         </template>
-        <oc-button v-if="!publicPage()" class="uk-hidden@m" key="mobile-search-button" icon="search" aria-label="search" id="files-open-search-btn" @click="focusMobileSearchInput()"/>
-        <oc-drop toggle="#files-open-search-btn" boundary="#files-app-bar" pos="bottom-right" mode="click" class="uk-margin-remove">
+        <oc-button
+          v-if="!publicPage()"
+          id="files-open-search-btn"
+          key="mobile-search-button"
+          class="uk-hidden@m"
+          icon="search"
+          aria-label="search"
+          @click="focusMobileSearchInput()"
+        />
+        <oc-drop
+          toggle="#files-open-search-btn"
+          boundary="#files-app-bar"
+          pos="bottom-right"
+          mode="click"
+          class="uk-margin-remove"
+        >
           <oc-search-bar
             ref="mobileSearch"
-            @search="onFileSearch"
+            :key="searchBarKey"
             :label="$_searchLabel"
             :loading="isLoadingSearch"
+            @search="onFileSearch"
             @clear="onSearchClear"
-            :key="searchBarKey"
           />
         </oc-drop>
       </div>
@@ -82,37 +156,37 @@
       name="overwrite-dialog"
       :oc-active="overwriteDialogMessage !== null"
       :oc-has-input="false"
-      ocCancelId="files-overwrite-cancel"
-      ocConfirmId="files-overwrite-confirm"
-      :ocTitle="overwriteDialogTitle"
+      oc-cancel-id="files-overwrite-cancel"
+      oc-confirm-id="files-overwrite-confirm"
+      :oc-title="overwriteDialogTitle"
       :oc-content="overwriteDialogMessage"
       @oc-confirm="$_ocUpload_confirmOverwrite(true)"
       @oc-cancel="$_ocUpload_confirmOverwrite(false)"
     />
     <oc-dialog-prompt
+      v-model="newFolderName"
       name="new-folder-dialog"
       :oc-active="createFolder"
-      v-model="newFolderName"
-      ocInputId="new-folder-input"
-      ocConfirmId="new-folder-ok"
-      :ocLoading="fileFolderCreationLoading"
-      :ocError="newFolderErrorMessage"
-      :ocTitle="$_createFolderDialogTitle"
-      :ocInputPlaceholder="$_createFolderDialogPlaceholder"
-      :ocInputLabel="$_createFolderDialogLabel"
+      oc-input-id="new-folder-input"
+      oc-confirm-id="new-folder-ok"
+      :oc-loading="fileFolderCreationLoading"
+      :oc-error="newFolderErrorMessage"
+      :oc-title="$_createFolderDialogTitle"
+      :oc-input-placeholder="$_createFolderDialogPlaceholder"
+      :oc-input-label="$_createFolderDialogLabel"
       @oc-confirm="addNewFolder"
       @oc-cancel="createFolder = false"
     />
     <oc-dialog-prompt
+      v-model="newFileName"
       name="new-file-dialog"
       :oc-active="createFile"
-      v-model="newFileName"
-      ocInputId="new-file-input"
-      :ocLoading="fileFolderCreationLoading"
-      :ocError="newFileErrorMessage"
-      :ocTitle="$_createFileDialogTitle"
-      :ocInputPlaceholder="$_createFileDialogPlaceholder"
-      :ocInputLabel="$_createFileDialogLabel"
+      oc-input-id="new-file-input"
+      :oc-loading="fileFolderCreationLoading"
+      :oc-error="newFileErrorMessage"
+      :oc-title="$_createFileDialogTitle"
+      :oc-input-placeholder="$_createFileDialogPlaceholder"
+      :oc-input-label="$_createFileDialogLabel"
       @oc-confirm="addNewFile"
       @oc-cancel="createFile = false"
     />
@@ -136,10 +210,7 @@ export default {
     OcDialogPrompt,
     FileDrop
   },
-  mixins: [
-    Mixins,
-    FileActions
-  ],
+  mixins: [Mixins, FileActions],
   data: () => ({
     createFolder: false,
     isLoadingSearch: false,
@@ -156,30 +227,42 @@ export default {
   }),
   computed: {
     ...mapGetters(['getToken', 'configuration', 'newFileHandlers']),
-    ...mapGetters('Files', ['activeFiles', 'inProgress', 'searchTerm', 'atSearchPage', 'currentFolder', 'davProperties', 'quota', 'selectedFiles', 'overwriteDialogTitle', 'overwriteDialogMessage', 'publicLinkPassword']),
+    ...mapGetters('Files', [
+      'activeFiles',
+      'inProgress',
+      'searchTerm',
+      'atSearchPage',
+      'currentFolder',
+      'davProperties',
+      'quota',
+      'selectedFiles',
+      'overwriteDialogTitle',
+      'overwriteDialogMessage',
+      'publicLinkPassword'
+    ]),
     ...mapState(['route']),
-    $_searchLabel () {
+    $_searchLabel() {
       return this.$gettext('Search')
     },
-    $_createFolderDialogPlaceholder () {
+    $_createFolderDialogPlaceholder() {
       return this.$gettext('Enter new folder name…')
     },
-    $_createFolderDialogLabel () {
+    $_createFolderDialogLabel() {
       return this.$gettext('Folder name')
     },
-    $_createFolderDialogTitle () {
+    $_createFolderDialogTitle() {
       return this.$gettext('New folder…')
     },
-    $_createFileDialogPlaceholder () {
+    $_createFileDialogPlaceholder() {
       return this.$gettext('Enter new file name…')
     },
-    $_createFileDialogLabel () {
+    $_createFileDialogLabel() {
       return this.$gettext('File name')
     },
-    $_createFileDialogTitle () {
+    $_createFileDialogTitle() {
       return this.$gettext('New file…')
     },
-    _cannotCreateDialogText () {
+    _cannotCreateDialogText() {
       if (!this.canUpload) {
         return this.$gettext('You have no permission to upload!')
       }
@@ -188,19 +271,23 @@ export default {
       }
       return null
     },
-    item () {
-      return this.$route.params.item === undefined ? (this.configuration.rootFolder !== '/' ? `${this.configuration.rootFolder}/` : '/') : this.$route.params.item + '/'
+    item() {
+      return this.$route.params.item === undefined
+        ? this.configuration.rootFolder !== '/'
+          ? `${this.configuration.rootFolder}/`
+          : '/'
+        : this.$route.params.item + '/'
     },
-    currentPath () {
+    currentPath() {
       return this.item === '/' ? '' : this.item
     },
-    newFolderErrorMessage () {
+    newFolderErrorMessage() {
       return this.checkNewFolderName(this.newFolderName)
     },
-    newFileErrorMessage () {
+    newFileErrorMessage() {
       return this.checkNewFileName(this.newFileName)
     },
-    headers () {
+    headers() {
       if (this.publicPage()) {
         const password = this.publicLinkPassword
 
@@ -214,37 +301,41 @@ export default {
         Authorization: 'Bearer ' + this.getToken
       }
     },
-    canUpload () {
+    canUpload() {
       if (this.currentFolder === null) {
         return false
       }
       return this.currentFolder.canUpload()
     },
-    $_ocFilesAppBar_showActions () {
+    $_ocFilesAppBar_showActions() {
       return this.$route.meta.hideFilelistActions !== true
     },
 
-    $_ocAppBar_clearTrashbinButtonText () {
-      return this.selectedFiles.length < 1 ? this.$gettext('Empty trash bin') : this.$gettext('Delete selected')
+    $_ocAppBar_clearTrashbinButtonText() {
+      return this.selectedFiles.length < 1
+        ? this.$gettext('Empty trash bin')
+        : this.$gettext('Delete selected')
     },
 
-    showBreadcrumb () {
-      return (this.$route.name === 'public-files' || this.$route.name === 'files-list')
+    showBreadcrumb() {
+      return this.$route.name === 'public-files' || this.$route.name === 'files-list'
     },
-    pageIcon () {
+    pageIcon() {
       return this.$route.meta.pageIcon
     },
-    pageTitle () {
+    pageTitle() {
       const title = this.route.meta.pageTitle
       return this.$gettext(title)
     },
 
-    breadcrumbs () {
-      let breadcrumbs = [{
-        index: 0,
-        text: this.$gettext('Home'),
-        to: '/files/list'
-      }]
+    breadcrumbs() {
+      let breadcrumbs = [
+        {
+          index: 0,
+          text: this.$gettext('Home'),
+          to: '/files/list'
+        }
+      ]
 
       if (!this.currentFolder) return breadcrumbs
 
@@ -252,11 +343,11 @@ export default {
       let baseUrl = '/files/list/'
 
       const pathSplit = this.currentFolder.path
-        ? this.currentFolder.path.split('/').filter((val) => {
-          if (rootFolder === '/') return val
+        ? this.currentFolder.path.split('/').filter(val => {
+            if (rootFolder === '/') return val
 
-          return val !== rootFolder
-        })
+            return val !== rootFolder
+          })
         : []
 
       if (rootFolder && rootFolder !== '/') {
@@ -269,16 +360,19 @@ export default {
       if (this.publicPage()) {
         baseUrl = '/files/public-files/'
         startIndex = 1
-        breadcrumbs = [{
-          index: 0,
-          text: this.$gettext('Home'),
-          to: baseUrl + pathSplit[0]
-        }]
+        breadcrumbs = [
+          {
+            index: 0,
+            text: this.$gettext('Home'),
+            to: baseUrl + pathSplit[0]
+          }
+        ]
       }
 
       for (let i = startIndex; i < pathSplit.length; i++) {
         let clickHandler = null
-        let itemPath = baseUrl + encodeURIComponent(pathUtil.join.apply(null, pathSplit.slice(0, i + 1)))
+        let itemPath =
+          baseUrl + encodeURIComponent(pathUtil.join.apply(null, pathSplit.slice(0, i + 1)))
         if (i === pathSplit.length - 1) {
           itemPath = null
           clickHandler = () => this.$router.go()
@@ -295,18 +389,20 @@ export default {
       return breadcrumbs
     },
 
-    hasFreeSpace () {
-      return (this.quota && this.quota.free > 0) ||
+    hasFreeSpace() {
+      return (
+        (this.quota && this.quota.free > 0) ||
         (this.currentFolder && this.currentFolder.permissions.indexOf('M') >= 0) ||
         this.publicPage()
+      )
     },
 
-    displayBulkActions () {
+    displayBulkActions() {
       return this.$route.meta.hasBulkActions && this.selectedFiles.length > 0
     }
   },
   watch: {
-    $route (to, from) {
+    $route(to, from) {
       // note: the search bars are not available on all views
       if (this.$refs.mobileSearch) {
         this.$refs.mobileSearch.value = null
@@ -317,10 +413,19 @@ export default {
     }
   },
   methods: {
-    ...mapActions('Files', ['resetFileSelection', 'loadFiles', 'addFiles', 'updateFileProgress', 'searchForFile',
-      'loadFolder', 'setTrashbinDeleteMessage', 'removeFilesFromTrashbin', 'resetSearch']),
+    ...mapActions('Files', [
+      'resetFileSelection',
+      'loadFiles',
+      'addFiles',
+      'updateFileProgress',
+      'searchForFile',
+      'loadFolder',
+      'setTrashbinDeleteMessage',
+      'removeFilesFromTrashbin',
+      'resetSearch'
+    ]),
     ...mapActions(['openFile', 'showMessage']),
-    onFileSearch (searchTerm = '') {
+    onFileSearch(searchTerm = '') {
       if (searchTerm === '') {
         this.isLoadingSearch = false
       } else {
@@ -342,7 +447,7 @@ export default {
           this.isLoadingSearch = false
         })
     },
-    focusMobileSearchInput () {
+    focusMobileSearchInput() {
       this.$refs.mobileSearch.$el.querySelector('input').focus()
       // nested vuetify VList animation will block native autofocus, so we use this workaround...
 
@@ -351,17 +456,20 @@ export default {
         this.$refs.mobileSearch.$el.querySelector('input').focus()
       }, 50)
     },
-    $_ocFilesFolder_getFolder () {
+    $_ocFilesFolder_getFolder() {
       this.path = []
 
-      const absolutePath = this.$route.params.item === '' || this.$route.params.item === undefined ? this.configuration.rootFolder : this.route.params.item
+      const absolutePath =
+        this.$route.params.item === '' || this.$route.params.item === undefined
+          ? this.configuration.rootFolder
+          : this.route.params.item
 
       this.loadFolder({
         client: this.$client,
         absolutePath: absolutePath,
         $gettext: this.$gettext,
         routeName: this.$route.name
-      }).catch((error) => {
+      }).catch(error => {
         // TODO: 401 public link handling necessary???
         this.showMessage({
           title: this.$gettext('Loading folder failed…'),
@@ -370,17 +478,26 @@ export default {
         })
       })
     },
-    showCreateFolderDialog () {
+    showCreateFolderDialog() {
       this.createFolder = true
       this.newFolderName = this.$gettext('New folder')
     },
-    addNewFolder (folderName) {
+    addNewFolder(folderName) {
       if (folderName !== '') {
         this.fileFolderCreationLoading = true
-        const path = this.item === '' ? (this.configuration.rootFolder ? `${this.configuration.rootFolder}/` : '/') : `${this.item}/`
+        const path =
+          this.item === ''
+            ? this.configuration.rootFolder
+              ? `${this.configuration.rootFolder}/`
+              : '/'
+            : `${this.item}/`
         let p = this.$client.files.createFolder(path + folderName)
         if (this.publicPage()) {
-          p = this.$client.publicFiles.createFolder(path + folderName, null, this.publicLinkPassword)
+          p = this.$client.publicFiles.createFolder(
+            path + folderName,
+            null,
+            this.publicLinkPassword
+          )
         }
 
         p.then(() => {
@@ -399,7 +516,7 @@ export default {
           })
       }
     },
-    checkNewFolderName (folderName) {
+    checkNewFolderName(folderName) {
       if (folderName === '') {
         return this.$gettext('Folder name cannot be empty')
       }
@@ -429,15 +546,20 @@ export default {
 
       return null
     },
-    showCreateFileDialog (ext = 'txt', openAction = null) {
+    showCreateFileDialog(ext = 'txt', openAction = null) {
       this.createFile = true
       this.newFileAction = openAction
       this.newFileName = this.$gettext('New file') + '.' + ext
     },
-    addNewFile (fileName) {
+    addNewFile(fileName) {
       if (fileName !== '') {
         this.fileFolderCreationLoading = true
-        const path = this.item === '' ? (this.configuration.rootFolder ? `${this.configuration.rootFolder}/` : '/') : `${this.item}/`
+        const path =
+          this.item === ''
+            ? this.configuration.rootFolder
+              ? `${this.configuration.rootFolder}/`
+              : '/'
+            : `${this.item}/`
         const filePath = pathUtil.join(path, fileName)
         let p = this.$client.files.putFileContents(filePath, '')
         if (this.publicPage()) {
@@ -456,18 +578,17 @@ export default {
               this.openFileAction(this.newFileAction, filePath)
             })
           }
-        })
-          .catch(error => {
-            this.fileFolderCreationLoading = false
-            this.showMessage({
-              title: this.$gettext('Creating file failed…'),
-              desc: error,
-              status: 'danger'
-            })
+        }).catch(error => {
+          this.fileFolderCreationLoading = false
+          this.showMessage({
+            title: this.$gettext('Creating file failed…'),
+            desc: error,
+            status: 'danger'
           })
+        })
       }
     },
-    checkNewFileName (fileName) {
+    checkNewFileName(fileName) {
       if (fileName === '') {
         return this.$gettext('File name cannot be empty')
       }
@@ -497,34 +618,45 @@ export default {
 
       return null
     },
-    onFileSuccess (event, file) {
+    onFileSuccess(event, file) {
       if (file.name) {
         file = file.name
       }
       this.$nextTick().then(() => {
-        const path = this.item === '' ? (this.configuration.rootFolder ? `${this.configuration.rootFolder}/` : '/') : `${this.item}/`
+        const path =
+          this.item === ''
+            ? this.configuration.rootFolder
+              ? `${this.configuration.rootFolder}/`
+              : '/'
+            : `${this.item}/`
         const filePath = pathUtil.join(path, file)
         if (this.publicPage()) {
-          this.$client.publicFiles.list(filePath, this.publicLinkPassword, this.davProperties, '0').then(files => {
-            this.addFiles({
-              files: files
+          this.$client.publicFiles
+            .list(filePath, this.publicLinkPassword, this.davProperties, '0')
+            .then(files => {
+              this.addFiles({
+                files: files
+              })
             })
-          }).catch(() => {
-            this.$_ocFilesFolder_getFolder()
-          })
+            .catch(() => {
+              this.$_ocFilesFolder_getFolder()
+            })
         } else {
-          this.$client.files.fileInfo(filePath, this.davProperties).then(fileInfo => {
-            this.addFiles({
-              files: [fileInfo]
+          this.$client.files
+            .fileInfo(filePath, this.davProperties)
+            .then(fileInfo => {
+              this.addFiles({
+                files: [fileInfo]
+              })
             })
-          }).catch(() => {
-            this.$_ocFilesFolder_getFolder()
-          })
+            .catch(() => {
+              this.$_ocFilesFolder_getFolder()
+            })
         }
       })
     },
 
-    onFileError (error) {
+    onFileError(error) {
       this.showMessage({
         title: this.$gettext('File upload failed…'),
         desc: error.message,
@@ -532,36 +664,47 @@ export default {
       })
     },
 
-    onFileProgress (progress) {
+    onFileProgress(progress) {
       this.updateFileProgress(progress)
     },
 
-    $_ocTrashbin_deleteSelected () {
+    $_ocTrashbin_deleteSelected() {
       const translated = this.$ngettext(
         "%{numberOfFiles} item will be deleted immediately. You can't undo this action.",
         "%{numberOfFiles} items will be deleted immediately. You can't undo this action.",
         this.selectedFiles.length
       )
-      this.setTrashbinDeleteMessage(this.$gettextInterpolate(translated, { numberOfFiles: this.selectedFiles.length }, false))
+      this.setTrashbinDeleteMessage(
+        this.$gettextInterpolate(translated, { numberOfFiles: this.selectedFiles.length }, false)
+      )
     },
 
-    $_ocFiles_deleteSelected () {
-      const translated = this.$ngettext('%{numberOfFiles} item will be deleted.', '%{numberOfFiles} items will be deleted.', this.selectedFiles.length)
+    $_ocFiles_deleteSelected() {
+      const translated = this.$ngettext(
+        '%{numberOfFiles} item will be deleted.',
+        '%{numberOfFiles} items will be deleted.',
+        this.selectedFiles.length
+      )
       this.promptFileDelete({
-        message: this.$gettextInterpolate(translated, { numberOfFiles: this.selectedFiles.length }, false),
+        message: this.$gettextInterpolate(
+          translated,
+          { numberOfFiles: this.selectedFiles.length },
+          false
+        ),
         items: this.selectedFiles
       })
     },
 
-    $_ocTrashbin_empty () {
-      this.$client.fileTrash.clearTrashBin()
+    $_ocTrashbin_empty() {
+      this.$client.fileTrash
+        .clearTrashBin()
         .then(() => {
           this.showMessage({
             title: this.$gettext('Trash bin was successfully emptied')
           })
           this.removeFilesFromTrashbin(this.activeFiles)
         })
-        .catch((error) => {
+        .catch(error => {
           this.showMessage({
             title: this.$gettext("Trash bin couldn't be emptied"),
             desc: error.message,
@@ -570,9 +713,10 @@ export default {
         })
     },
 
-    $_ocTrashbin_restoreFiles (files = this.selectedFiles) {
+    $_ocTrashbin_restoreFiles(files = this.selectedFiles) {
       for (const file of files) {
-        this.$client.fileTrash.restore(file.id, file.originalLocation)
+        this.$client.fileTrash
+          .restore(file.id, file.originalLocation)
           .then(() => {
             const translated = this.$gettext('%{file} was restored successfully')
             this.showMessage({
@@ -593,7 +737,7 @@ export default {
       this.setHighlightedFile(null)
     },
 
-    onSearchClear () {
+    onSearchClear() {
       this.resetSearch()
       // Forces update of search bar
       this.searchBarKey++

--- a/apps/files/src/components/FilesLists/Indicators.vue
+++ b/apps/files/src/components/FilesLists/Indicators.vue
@@ -1,15 +1,18 @@
 <template>
   <span>
-    <div v-if="displayDefaultIndicators" :class="{ 'uk-margin-xsmall-right' : customIndicators }"
-         @click="openSidebar">
+    <div
+      v-if="displayDefaultIndicators"
+      :class="{ 'uk-margin-xsmall-right': customIndicators }"
+      @click="openSidebar"
+    >
       <oc-button
         v-for="(indicator, index) in defaultIndicators"
         :key="index"
         class="file-row-share-indicator uk-text-middle"
-        :class="{ 'uk-margin-xsmall-left' : index > 0, 'uk-invisible' : !indicator.visible }"
+        :class="{ 'uk-margin-xsmall-left': index > 0, 'uk-invisible': !indicator.visible }"
         :aria-label="indicator.label"
-        @click="indicator.handler(item, indicator.id)"
         variation="raw"
+        @click="indicator.handler(item, indicator.id)"
       >
         <oc-icon
           :name="indicator.icon"
@@ -21,8 +24,8 @@
     </div>
     <template v-if="customIndicators">
       <component
-        v-for="(indicator, index) in customIndicators"
         :is="indicator.component"
+        v-for="(indicator, index) in customIndicators"
         :key="index"
       />
     </template>
@@ -50,18 +53,18 @@ export default {
   computed: {
     ...mapGetters(['configuration', 'customFilesListIndicators']),
 
-    displayDefaultIndicators () {
+    displayDefaultIndicators() {
       return !this.configuration.theme.filesList.hideDefaultStatusIndicators
     },
 
-    customIndicators () {
+    customIndicators() {
       return this.customFilesListIndicators
     }
   },
 
   methods: {
     // TODO: Adjust to send the event via store
-    openSidebar (item, indicatorId) {
+    openSidebar(item, indicatorId) {
       this.$emit('click', item, indicatorId)
     }
   }

--- a/apps/files/src/components/FilesLists/RowActionsDropdown.vue
+++ b/apps/files/src/components/FilesLists/RowActionsDropdown.vue
@@ -1,20 +1,23 @@
 <template>
   <oc-drop
     v-if="displayed"
+    id="files-list-row-actions-dropdown"
     :boundary="`#files-file-list-action-button-${item.viewId}-active`"
     :options="{ offset: 0 }"
     :toggle="`#files-file-list-action-button-${item.viewId}-active`"
     position="bottom-right"
-    id="files-list-row-actions-dropdown"
     class="uk-open uk-drop-stack"
   >
     <ul class="uk-list">
       <li v-for="action in actions" :key="action.ariaLabel">
         <oc-button
           class="uk-width-1-1"
-          @click.native.stop="action.handler(item, action.handlerData); actionClicked()"
           :icon="action.icon"
-          :ariaLabel="action.ariaLabel"
+          :aria-label="action.ariaLabel"
+          @click.native.stop="
+            action.handler(item, action.handlerData)
+            actionClicked()
+          "
         >
           {{ action.ariaLabel }}
         </oc-button>
@@ -56,11 +59,11 @@ export default {
     ...mapGetters('Files', ['isDialogOpen'])
   },
   methods: {
-    actionClicked () {
+    actionClicked() {
       this.$emit('actionClicked')
     },
     // FIXME: Remove as soon as trashbin has virtual scroll
-    nameForDropdownData (name) {
+    nameForDropdownData(name) {
       // Escape double quotes inside of selector
       if (name.indexOf('"') > -1) {
         name = name.replace(/\\([\s\S])|(")/g, '&quot;')

--- a/apps/files/src/components/FilesLists/SortableColumnHeader.vue
+++ b/apps/files/src/components/FilesLists/SortableColumnHeader.vue
@@ -1,11 +1,11 @@
 <template>
   <oc-button
     variation="raw"
-    @click="$_onClick"
     :aria-label="ariaLabel"
     class="uk-flex uk-flex-middle oc-sortable-column-header"
     :class="{ 'oc-sortable-column-header-desc': isDesc, 'oc-sortable-column-header-asc': !isDesc }"
-    >
+    @click="$_onClick"
+  >
     <span class="uk-flex uk-flex-middle">
       <slot />
       <oc-icon
@@ -37,12 +37,12 @@ export default {
     }
   },
   computed: {
-    $_indicatorIconName () {
+    $_indicatorIconName() {
       return this.isDesc ? 'expand_less' : 'expand_more'
     }
   },
   methods: {
-    $_onClick () {
+    $_onClick() {
       this.$emit('click', arguments)
     }
   }

--- a/apps/files/src/components/FolderUpload.vue
+++ b/apps/files/src/components/FolderUpload.vue
@@ -1,18 +1,25 @@
 <template>
-    <oc-nav-item v-if="checkIfBrowserSupportsFolderUpload" icon="cloud_upload" @click="triggerUpload">
-        <span v-translate>Upload Folder</span>
-        <div slot="outer-content">
-            <input id="folderUploadInput" type="file" name="folder" @change="$_ocUpload_addDirectoryToQue" webkitdirectory mozdirectory allowdirs ref="input" />
-        </div>
-    </oc-nav-item>
+  <oc-nav-item v-if="checkIfBrowserSupportsFolderUpload" icon="cloud_upload" @click="triggerUpload">
+    <span v-translate>Upload Folder</span>
+    <div slot="outer-content">
+      <input
+        id="folderUploadInput"
+        ref="input"
+        type="file"
+        name="folder"
+        webkitdirectory
+        mozdirectory
+        allowdirs
+        @change="$_ocUpload_addDirectoryToQue"
+      />
+    </div>
+  </oc-nav-item>
 </template>
 
 <script>
 import Mixins from '../mixins'
 export default {
-  mixins: [
-    Mixins
-  ],
+  mixins: [Mixins],
   props: {
     rootPath: { type: String, required: true },
     path: { type: String, required: true },
@@ -31,7 +38,7 @@ export default {
     requestType: { type: String, default: 'PUT' }
   },
   methods: {
-    triggerUpload () {
+    triggerUpload() {
       this.$refs.input.click()
     }
   }
@@ -39,8 +46,8 @@ export default {
 </script>
 
 <style scoped="true">
-    #folderUploadInput {
-        position: absolute;
-        left: -99999px;
-    }
+#folderUploadInput {
+  position: absolute;
+  left: -99999px;
+}
 </style>

--- a/apps/files/src/components/PrivateLink.vue
+++ b/apps/files/src/components/PrivateLink.vue
@@ -1,15 +1,17 @@
 <template>
   <div class="oc-login" uk-height-viewport>
     <div class="oc-login-card uk-position-center">
-      <h1 class="oc-login-logo" v-translate>
+      <h1 v-translate class="oc-login-logo">
         ownCloud
       </h1>
-      <div class="oc-login-card-body" v-if="loading">
+      <div v-if="loading" class="oc-login-card-body">
         <h3 class="oc-login-card-title" :aria-hidden="true">{{ $_resolvingPrivateLinkTitle }}</h3>
         <oc-spinner :aria-label="$_resolvingPrivateLinkTitle"></oc-spinner>
       </div>
-      <div class="oc-login-card-body" v-if="errorMessage">
-        <h3 class="oc-login-card-title"><translate>An error occurred while resolving the private link</translate></h3>
+      <div v-if="errorMessage" class="oc-login-card-body">
+        <h3 class="oc-login-card-title">
+          <translate>An error occurred while resolving the private link</translate>
+        </h3>
         <span>{{ errorMessage }}</span>
       </div>
     </div>
@@ -18,39 +20,42 @@
 
 <script>
 export default {
-  data () {
+  data() {
     return {
       loading: true,
       errorMessage: null
     }
   },
   computed: {
-    $_resolvingPrivateLinkTitle () {
+    $_resolvingPrivateLinkTitle() {
       return this.$gettext('Resolving private link…')
     }
   },
-  mounted () {
+  mounted() {
     // query oc10 server to translate fileId to real path
     this.loading = true
-    this.$client.files.getPathForFileId(this.$route.params.fileId).then(path => {
-      const lastSlash = path.lastIndexOf('/')
-      const folder = path.substring(0, lastSlash).replace(/^(\/)/, '')
-      const file = path.substring(lastSlash + 1)
-      this.$router.push({
-        name: 'files-list',
-        params: {
-          item: folder
-        },
-        query: {
-          scrollTo: file
-        }
+    this.$client.files
+      .getPathForFileId(this.$route.params.fileId)
+      .then(path => {
+        const lastSlash = path.lastIndexOf('/')
+        const folder = path.substring(0, lastSlash).replace(/^(\/)/, '')
+        const file = path.substring(lastSlash + 1)
+        this.$router.push({
+          name: 'files-list',
+          params: {
+            item: folder
+          },
+          query: {
+            scrollTo: file
+          }
+        })
       })
-    }).catch(error => {
-      this.errorMessage = error
-    }).finally(() => {
-      this.loading = false
-    })
+      .catch(error => {
+        this.errorMessage = error
+      })
+      .finally(() => {
+        this.loading = false
+      })
   }
-
 }
 </script>

--- a/apps/files/src/components/PublicLinksSidebar/EditPublicLink.vue
+++ b/apps/files/src/components/PublicLinksSidebar/EditPublicLink.vue
@@ -1,42 +1,79 @@
 <template>
   <div class="oc-files-edit-public-link oc-files-file-link-form">
     <form @submit.prevent>
-      <transition enter-active-class="uk-animation-slide-top-small" leave-active-class="uk-animation-slide-top-small uk-animation-reverse"
-                  name="custom-classes-transition">
+      <transition
+        enter-active-class="uk-animation-slide-top-small"
+        leave-active-class="uk-animation-slide-top-small uk-animation-reverse"
+        name="custom-classes-transition"
+      >
         <oc-alert v-if="errors" class="oc-files-file-link-error-alert" variation="danger">
           {{ errors }}
         </oc-alert>
       </transition>
       <div class="uk-margin">
         <label class="oc-label"><span v-translate>Name:</span></label>
-        <input class="uk-input" id="oc-files-file-link-name" v-model="name"/>
+        <input id="oc-files-file-link-name" v-model="name" class="uk-input" />
       </div>
-      <oc-grid childWidth="1-1" gutter="small">
-        <roles-select :roles="$_roles" :selectedRole="$_selectedRole" @roleSelected="$_selectRole" mode="file-link"/>
+      <oc-grid child-width="1-1" gutter="small">
+        <roles-select
+          :roles="$_roles"
+          :selected-role="$_selectedRole"
+          mode="file-link"
+          @roleSelected="$_selectRole"
+        />
       </oc-grid>
       <div class="uk-margin uk-grid-small uk-flex uk-flex-middle" uk-grid>
-        <div class="uk-width-1-1 uk-width-2-5@m" v-if="$_expirationDate">
+        <div v-if="$_expirationDate" class="uk-width-1-1 uk-width-2-5@m">
           <label class="oc-label" for="oc-files-file-link-expire-date">
             <span v-translate>Expiration date:</span>
             <translate v-if="$_expirationDate.enforced" tag="em">(required)</translate>
           </label>
           <div class="uk-position-relative">
-            <oc-datepicker :class="{ 'uk-form-danger': !$_expirationIsValid }" :date="expireDate" :key="'oc-datepicker-' + expireDate"
-                           :maxDatetime="$_maxExpirationDate" :minDatetime="$_minExpirationDate"
-                           :placeholder="placeholder.expireDate" @input="expireDate = $event" id="oc-files-file-link-expire-date"/>
-            <div :uk-tooltip="$_expirationDateRemoveText" @click="expireDate=null" class="uk-position-small uk-position-center-right oc-cursor-pointer" uk-close
-                 id="oc-files-file-link-expire-date-delete" v-if="!$_expirationDate.enforced && !!expireDate"/>
+            <oc-datepicker
+              id="oc-files-file-link-expire-date"
+              :key="'oc-datepicker-' + expireDate"
+              :class="{ 'uk-form-danger': !$_expirationIsValid }"
+              :date="expireDate"
+              :max-datetime="$_maxExpirationDate"
+              :min-datetime="$_minExpirationDate"
+              :placeholder="placeholder.expireDate"
+              @input="expireDate = $event"
+            />
+            <div
+              v-if="!$_expirationDate.enforced && !!expireDate"
+              id="oc-files-file-link-expire-date-delete"
+              :uk-tooltip="$_expirationDateRemoveText"
+              class="uk-position-small uk-position-center-right oc-cursor-pointer"
+              uk-close
+              @click="expireDate = null"
+            />
           </div>
         </div>
         <div class="uk-width-1-1 uk-width-3-5@m">
           <label class="oc-label" for="oc-files-file-link-password">
-            <span v-translate>Password:</span><em class="uk-margin-small-left" v-if="$_passwordEnforced">(<span v-translate>required</span>)</em>
+            <span v-translate>Password:</span
+            ><em v-if="$_passwordEnforced" class="uk-margin-small-left"
+              >(<span v-translate>required</span>)</em
+            >
           </label>
           <div class="uk-position-relative">
-            <input :class="{ 'uk-form-danger': !$_passwordIsValid }" :placeholder="hasPassword && password === null? '********' : placeholder.password"
-                   autocomplete="new-password" class="uk-input" id="oc-files-file-link-password" type="password" v-model="password"/>
-            <div :uk-tooltip="$_passwordRemoveText" @click="password=''" class="uk-position-small uk-position-center-right oc-cursor-pointer" uk-close
-                 id="oc-files-file-link-password-delete" v-if="!$_passwordEnforced && hasPassword"/>
+            <input
+              id="oc-files-file-link-password"
+              v-model="password"
+              :class="{ 'uk-form-danger': !$_passwordIsValid }"
+              :placeholder="hasPassword && password === null ? '********' : placeholder.password"
+              autocomplete="new-password"
+              class="uk-input"
+              type="password"
+            />
+            <div
+              v-if="!$_passwordEnforced && hasPassword"
+              id="oc-files-file-link-password-delete"
+              :uk-tooltip="$_passwordRemoveText"
+              class="uk-position-small uk-position-center-right oc-cursor-pointer"
+              uk-close
+              @click="password = ''"
+            />
           </div>
         </div>
       </div>
@@ -57,27 +94,51 @@
             </div>
         </template>
         -->
-      <hr class="divider"/>
+      <hr class="divider" />
       <oc-grid class="uk-margin-bottom" gutter="small">
         <div>
-          <oc-button :disabled="saving" @click="$_closeForm" id="oc-files-file-link-cancel">
+          <oc-button id="oc-files-file-link-cancel" :disabled="saving" @click="$_closeForm">
             <translate>Cancel</translate>
           </oc-button>
           <button v-if="saving" class="uk-button uk-button-default uk-position-relative" disabled>
             <template v-if="$_isNew">
-              <oc-spinner :ariaLabel="$gettext('Creating Public Link')" class="uk-position-small uk-position-center-left" size="xsmall"/>
-              <span :aria-hidden="true" class="uk-margin-small-left" v-translate>Creating Public Link</span>
+              <oc-spinner
+                :aria-label="$gettext('Creating Public Link')"
+                class="uk-position-small uk-position-center-left"
+                size="xsmall"
+              />
+              <span v-translate :aria-hidden="true" class="uk-margin-small-left"
+                >Creating Public Link</span
+              >
             </template>
             <template v-else>
-              <oc-spinner :ariaLabel="$gettext('Saving Public Link')" class="uk-position-small uk-position-center-left" size="xsmall"/>
-              <span :aria-hidden="true" class="uk-margin-small-left" v-translate>Saving Public Link</span>
+              <oc-spinner
+                :aria-label="$gettext('Saving Public Link')"
+                class="uk-position-small uk-position-center-left"
+                size="xsmall"
+              />
+              <span v-translate :aria-hidden="true" class="uk-margin-small-left"
+                >Saving Public Link</span
+              >
             </template>
           </button>
           <template v-else>
-            <oc-button v-if="$_isNew" :disabled="!$_isValid" @click="$_addLink" variation="primary" id="oc-files-file-link-create">
+            <oc-button
+              v-if="$_isNew"
+              id="oc-files-file-link-create"
+              :disabled="!$_isValid"
+              variation="primary"
+              @click="$_addLink"
+            >
               <translate>Create Public Link</translate>
             </oc-button>
-            <oc-button v-else :disabled="!$_isValid || !$_hasChanges" @click="$_updateLink" variation="primary" id="oc-files-file-link-save">
+            <oc-button
+              v-else
+              id="oc-files-file-link-save"
+              :disabled="!$_isValid || !$_hasChanges"
+              variation="primary"
+              @click="$_updateLink"
+            >
               <translate>Save Public Link</translate>
             </oc-button>
           </template>
@@ -101,8 +162,13 @@ export default {
     RolesSelect
   },
   mixins: [mixins],
-  props: ['params'],
-  data () {
+  props: {
+    params: {
+      type: Object,
+      required: true
+    }
+  },
+  data() {
     return {
       saving: false,
       password: null,
@@ -117,39 +183,45 @@ export default {
       }
     }
   },
-  title: ($gettext) => {
+  title: $gettext => {
     return $gettext('Links')
   },
   computed: {
     ...mapGetters('Files', ['highlightedFile']),
     ...mapGetters(['getToken', 'capabilities']),
 
-    $_isNew () {
+    $_isNew() {
       return !this.params.id
     },
 
-    $_isFolder () {
+    $_isFolder() {
       return this.highlightedFile.type === 'folder'
     },
 
-    $_isFile () {
+    $_isFile() {
       return !this.$_isFolder
     },
 
-    $_hasChanges () {
-      const expireDateBefore = this.params.expireDate ? moment(this.params.expireDate).format('DD-MM-YYYY') : null
+    $_hasChanges() {
+      const expireDateBefore = this.params.expireDate
+        ? moment(this.params.expireDate).format('DD-MM-YYYY')
+        : null
       const expireDateNow = this.expireDate ? moment(this.expireDate).format('DD-MM-YYYY') : null
-      return (expireDateNow !== expireDateBefore) ||
-          (this.name !== this.params.name) ||
-          (this.permissions !== this.params.permissions) ||
-          (this.params.hasPassword ? this.password !== null : (this.password !== null && this.password.trim().length > 0))
+      return (
+        expireDateNow !== expireDateBefore ||
+        this.name !== this.params.name ||
+        this.permissions !== this.params.permissions ||
+        (this.params.hasPassword
+          ? this.password !== null
+          : this.password !== null && this.password.trim().length > 0)
+      )
     },
 
-    $_sendMailEnabled () {
+    $_sendMailEnabled() {
       return Object.keys(this.capabilities.files_sharing.public.send_mail).length > 0
     },
 
-    $_roles () {
+    $_roles() {
       const $gettext = this.$gettext
       return publicLinkRoles({
         $gettext,
@@ -157,7 +229,7 @@ export default {
       })
     },
 
-    $_selectedRole () {
+    $_selectedRole() {
       const permissions = parseInt(this.permissions, 10)
       if (permissions) {
         const matchingRoles = filter(this.$_roles, r => r.permissions === permissions)
@@ -168,35 +240,41 @@ export default {
       return this.$_roles.viewer
     },
 
-    $_expirationDate () {
+    $_expirationDate() {
       const expireDate = this.capabilities.files_sharing.public.expire_date
 
       return {
         enabled: !!expireDate.enabled,
-        days: (expireDate.days) ? expireDate.days : false,
+        days: expireDate.days ? expireDate.days : false,
         enforced: !!expireDate.enforced
       }
     },
 
-    $_minExpirationDate () {
-      return moment().add(1, 'days').endOf('day').toISOString()
+    $_minExpirationDate() {
+      return moment()
+        .add(1, 'days')
+        .endOf('day')
+        .toISOString()
     },
 
-    $_maxExpirationDate () {
+    $_maxExpirationDate() {
       if (!this.$_expirationDate.enforced) {
         return null
       }
 
       const days = parseInt(this.$_expirationDate.days, 10)
 
-      return moment().add(days, 'days').endOf('day').toISOString()
+      return moment()
+        .add(days, 'days')
+        .endOf('day')
+        .toISOString()
     },
 
-    $_expirationIsValid () {
+    $_expirationIsValid() {
       return !(this.$_expirationDate.enforced && this.expireDate === '')
     },
 
-    $_passwordIsValid () {
+    $_passwordIsValid() {
       if (this.hasPassword) {
         return true
       }
@@ -204,11 +282,11 @@ export default {
       return !(this.$_passwordEnforced && (this.password === '' || this.password === null))
     },
 
-    $_isValid () {
+    $_isValid() {
       return this.$_expirationIsValid && this.$_passwordIsValid
     },
 
-    $_passwordEnforced () {
+    $_passwordEnforced() {
       const permissions = parseInt(this.permissions, 10)
       const password = this.capabilities.files_sharing.public.password.enforced_for
 
@@ -225,21 +303,21 @@ export default {
       return false
     },
 
-    $_expirationDateRemoveText () {
+    $_expirationDateRemoveText() {
       return this.$gettext('Remove expiration date')
     },
 
-    $_passwordRemoveText () {
+    $_passwordRemoveText() {
       return this.$gettext('Remove password')
     }
   },
   methods: {
     ...mapActions('Files', ['addLink', 'updateLink']),
-    $_selectRole (role) {
+    $_selectRole(role) {
       this.permissions = role.permissions
     },
 
-    $_addLink () {
+    $_addLink() {
       this.saving = true
 
       const params = {
@@ -257,17 +335,19 @@ export default {
         client: this.$client,
         $gettext: this.$gettext,
         params
-      }).then(e => {
-        this.saving = false
-        this.errors = false
-        this.$_closeForm()
-      }).catch(e => {
-        this.saving = false
-        this.errors = e
       })
+        .then(e => {
+          this.saving = false
+          this.errors = false
+          this.$_closeForm()
+        })
+        .catch(e => {
+          this.saving = false
+          this.errors = e
+        })
     },
 
-    $_updateLink () {
+    $_updateLink() {
       this.saving = true
 
       const params = {
@@ -285,17 +365,19 @@ export default {
         client: this.$client,
         $gettext: this.$gettext,
         params
-      }).then(() => {
-        this.saving = false
-        this.errors = false
-        this.$_closeForm()
-      }).catch(e => {
-        this.saving = false
-        this.errors = e
       })
+        .then(() => {
+          this.saving = false
+          this.errors = false
+          this.$_closeForm()
+        })
+        .catch(e => {
+          this.saving = false
+          this.errors = e
+        })
     },
 
-    $_closeForm () {
+    $_closeForm() {
       this.$emit('close')
     }
   }

--- a/apps/files/src/components/PublicLinksSidebar/PublicLinkListItem.vue
+++ b/apps/files/src/components/PublicLinksSidebar/PublicLinkListItem.vue
@@ -2,35 +2,78 @@
   <oc-table middle class="files-file-links-link">
     <oc-table-row class="files-file-links-link-table-row-info">
       <oc-table-cell shrink>
-        <oc-button v-if="$_deleteButtonVisible" :aria-label="$_deleteButtonLabel" @click="$_removeLink" variation="raw" class="oc-files-file-link-delete">
+        <oc-button
+          v-if="$_deleteButtonVisible"
+          :aria-label="$_deleteButtonLabel"
+          variation="raw"
+          class="oc-files-file-link-delete"
+          @click="$_removeLink"
+        >
           <oc-icon name="close" />
         </oc-button>
-        <oc-spinner v-else-if="$_loadingSpinnerVisible" :aria-label="$gettext('Removing public link…')" size="small" />
+        <oc-spinner
+          v-else-if="$_loadingSpinnerVisible"
+          :aria-label="$gettext('Removing public link…')"
+          size="small"
+        />
         <oc-icon v-else name="lock" class="uk-invisible" />
       </oc-table-cell>
       <oc-table-cell>
-        <a :href="link.url" target="_blank" :uk-tooltip="$_tooltipTextLink" class="uk-text-bold uk-text-truncate oc-files-file-link-url">{{ link.name }}</a>
-        <br>
+        <a
+          :href="link.url"
+          target="_blank"
+          :uk-tooltip="$_tooltipTextLink"
+          class="uk-text-bold uk-text-truncate oc-files-file-link-url"
+          >{{ link.name }}</a
+        >
+        <br />
         <span class="uk-text-meta uk-text-break">
           <span class="oc-files-file-link-role">{{ link.description }}</span>
-          <template v-if="link.expiration"> |
-            <oc-icon size="xsmall" name="text-calendar" class="fix-icon-baseline" :aria-hidden="true" />
+          <template v-if="link.expiration">
+            |
+            <oc-icon
+              size="xsmall"
+              name="text-calendar"
+              class="fix-icon-baseline"
+              :aria-hidden="true"
+            />
             <span v-translate>Expires</span> {{ formDateFromNow(link.expiration) }}
           </template>
-          <template v-if="link.password"> |
+          <template v-if="link.password">
+            |
             <oc-icon size="xsmall" name="lock" class="fix-icon-baseline" :aria-hidden="true" />
             <span v-translate>Password protected</span>
           </template>
         </span>
       </oc-table-cell>
       <oc-table-cell shrink class="uk-text-nowrap">
-        <oc-button v-if="$_editButtonVisible" :aria-label="$_editButtonLabel" @click="$emit('onEdit', link)" variation="raw" class="oc-files-file-link-edit">
-          <oc-icon name="edit" size="small"/>
+        <oc-button
+          v-if="$_editButtonVisible"
+          :aria-label="$_editButtonLabel"
+          variation="raw"
+          class="oc-files-file-link-edit"
+          @click="$emit('onEdit', link)"
+        >
+          <oc-icon name="edit" size="small" />
         </oc-button>
-        <oc-button :aria-label="$_publicLinkCopyLabel" variation="raw" class="oc-files-file-link-copy-url">
-          <oc-icon v-if="!linksCopied[link.url]"  name="copy_to_clipboard" size="small"
-                   v-clipboard:copy="link.url" v-clipboard:success="$_clipboardSuccessHandler"/>
-          <oc-icon v-else name="ready" size="small" class="oc-files-file-link-copied-url _clipboard-success-animation"/>
+        <oc-button
+          :aria-label="$_publicLinkCopyLabel"
+          variation="raw"
+          class="oc-files-file-link-copy-url"
+        >
+          <oc-icon
+            v-if="!linksCopied[link.url]"
+            v-clipboard:copy="link.url"
+            v-clipboard:success="$_clipboardSuccessHandler"
+            name="copy_to_clipboard"
+            size="small"
+          />
+          <oc-icon
+            v-else
+            name="ready"
+            size="small"
+            class="oc-files-file-link-copied-url _clipboard-success-animation"
+          />
         </oc-button>
       </oc-table-cell>
     </oc-table-row>
@@ -38,10 +81,16 @@
       <oc-table-cell shrink></oc-table-cell>
       <oc-table-cell colspan="2">
         <div class="uk-text-meta">
-          <router-link :to="$_viaRouterParams" :aria-label="$gettext('Navigate to parent')"
-                       class="oc-files-file-link-via uk-flex uk-flex-middle">
+          <router-link
+            :to="$_viaRouterParams"
+            :aria-label="$gettext('Navigate to parent')"
+            class="oc-files-file-link-via uk-flex uk-flex-middle"
+          >
             <oc-icon name="exit_to_app" size="small" class="uk-preserve-width" />
-            <span class="oc-file-name uk-padding-remove uk-margin-xsmall-left uk-text-truncate files-file-links-link-via-label">{{ $_viaLabel }}</span>
+            <span
+              class="oc-file-name uk-padding-remove uk-margin-xsmall-left uk-text-truncate files-file-links-link-via-label"
+              >{{ $_viaLabel }}</span
+            >
           </router-link>
         </div>
       </oc-table-cell>
@@ -74,29 +123,29 @@ export default {
       default: () => {}
     }
   },
-  data () {
+  data() {
     return {
       removalInProgress: false
     }
   },
   computed: {
-    $_loadingSpinnerVisible () {
+    $_loadingSpinnerVisible() {
       return this.modifiable && this.removalInProgress
     },
-    $_deleteButtonVisible () {
+    $_deleteButtonVisible() {
       return this.modifiable && !this.removalInProgress
     },
-    $_editButtonVisible () {
+    $_editButtonVisible() {
       return this.modifiable && !this.removalInProgress
     },
-    $_viaLabel () {
+    $_viaLabel() {
       if (!this.indirect) {
         return null
       }
       const translated = this.$gettext('Via %{folderName}')
       return this.$gettextInterpolate(translated, { folderName: basename(this.link.path) }, true)
     },
-    $_viaRouterParams () {
+    $_viaRouterParams() {
       const viaPath = this.link.path
       return {
         name: 'files-list',
@@ -108,24 +157,24 @@ export default {
         }
       }
     },
-    $_tooltipTextLink () {
+    $_tooltipTextLink() {
       return `title: ${this.$gettext('Click to open the link')}; pos: bottom`
     },
-    $_deleteButtonLabel () {
+    $_deleteButtonLabel() {
       return this.$gettext('Delete public link')
     },
-    $_editButtonLabel () {
+    $_editButtonLabel() {
       return this.$gettext('Edit public link')
     },
-    $_publicLinkCopyLabel () {
+    $_publicLinkCopyLabel() {
       return this.$gettext('Copy public link url')
     }
   },
   methods: {
-    $_clipboardSuccessHandler (event) {
+    $_clipboardSuccessHandler(event) {
       this.$emit('onCopy', event)
     },
-    $_removeLink () {
+    $_removeLink() {
       this.removalInProgress = true
       this.$emit('onDelete', this.link)
     }
@@ -134,17 +183,17 @@ export default {
 </script>
 
 <style scoped="scoped">
-  /* FIXME: Move to ODS somehow */
-  .files-file-links-link-table-row-info > td {
-    padding: 0 10px 0 0;
-  }
-  .files-file-links-link-table-row-bottom > td {
-    padding: 3px 10px 0 0;
-  }
-  .files-file-links-link-via-label {
-    max-width: 65%;
-  }
-  .fix-icon-baseline {
-    margin-bottom: -2px;
-  }
+/* FIXME: Move to ODS somehow */
+.files-file-links-link-table-row-info > td {
+  padding: 0 10px 0 0;
+}
+.files-file-links-link-table-row-bottom > td {
+  padding: 3px 10px 0 0;
+}
+.files-file-links-link-via-label {
+  max-width: 65%;
+}
+.fix-icon-baseline {
+  margin-bottom: -2px;
+}
 </style>

--- a/apps/files/src/components/Roles/RoleItem.vue
+++ b/apps/files/src/components/Roles/RoleItem.vue
@@ -18,8 +18,8 @@ export default {
 </script>
 
 <style>
-  /* FIXME: move into ODS? */
-  .roles-select-role-item {
-    text-transform: none;
-  }
+/* FIXME: move into ODS? */
+.roles-select-role-item {
+  text-transform: none;
+}
 </style>

--- a/apps/files/src/components/Roles/RolesSelect.vue
+++ b/apps/files/src/components/Roles/RolesSelect.vue
@@ -3,15 +3,12 @@
     <label class="oc-label">
       <translate>Role:</translate>
     </label>
-    <oc-button
-      :id="`files-${mode}-role-button`"
-      :class="`uk-width-1-1 files-${mode}-role-button`"
-    >
+    <oc-button :id="`files-${mode}-role-button`" :class="`uk-width-1-1 files-${mode}-role-button`">
       <role-item :role="selectedRole" class="uk-margin-small-bottom" />
     </oc-button>
     <oc-drop
-      closeOnClick
-      :dropId="`files-${mode}-roles-dropdown`"
+      close-on-click
+      :drop-id="`files-${mode}-roles-dropdown`"
       :toggle="`#files-${mode}-role-button`"
       mode="click"
       position="bottom-justify"
@@ -21,8 +18,8 @@
       <ul class="oc-autocomplete-suggestion-list">
         <li
           v-for="role in roles"
-          :key="role.name"
           :id="`files-${mode}-role-${role.name}`"
+          :key="role.name"
           class="oc-autocomplete-suggestion"
           :class="{ 'oc-autocomplete-suggestion-selected': role.name === selectedRole.name }"
           @click="selectRole(role)"
@@ -43,7 +40,7 @@ export default {
     mode: {
       type: String,
       required: true,
-      validator (value) {
+      validator(value) {
         return ['collaborators', 'file-link'].indexOf(value) !== -1
       }
     },
@@ -57,7 +54,7 @@ export default {
     }
   },
   methods: {
-    selectRole (role) {
+    selectRole(role) {
       this.$emit('roleSelected', role)
     }
   }

--- a/apps/files/src/components/Trashbin.vue
+++ b/apps/files/src/components/Trashbin.vue
@@ -3,57 +3,74 @@
     <div class="uk-overflow-auto uk-height-1-1">
       <file-list
         id="files-list"
-        :fileData="fileData"
+        :file-data="fileData"
         :loading="loadingFolder"
         :actions="actions"
-        :isActionEnabled="isActionEnabled"
-        :selectableRow="false"
+        :is-action-enabled="isActionEnabled"
+        :selectable-row="false"
       >
         <template #headerColumns>
           <div class="uk-text-truncate uk-text-meta uk-width-expand">
-            <sortable-column-header @click="toggleSort('name')" :aria-label="$gettext('Sort files by name')" :is-active="fileSortField == 'name'" :is-desc="fileSortDirectionDesc">
+            <sortable-column-header
+              :aria-label="$gettext('Sort files by name')"
+              :is-active="fileSortField === 'name'"
+              :is-desc="fileSortDirectionDesc"
+              @click="toggleSort('name')"
+            >
               <translate translate-context="Name column in files table">Name</translate>
             </sortable-column-header>
           </div>
           <div
-            :class="{ 'uk-visible@s' : !_sidebarOpen, 'uk-hidden'  : _sidebarOpen }"
+            :class="{ 'uk-visible@s': !_sidebarOpen, 'uk-hidden': _sidebarOpen }"
             class="uk-text-nowrap uk-text-meta uk-width-small"
           >
             <sortable-column-header
               class="uk-align-right uk-margin-right"
-              @click="toggleSort('deleteTimestampMoment')"
               :aria-label="$gettext('Sort files by deletion time')"
-              :is-active="fileSortField == 'deleteTimestampMoment'"
+              :is-active="fileSortField === 'deleteTimestampMoment'"
               :is-desc="fileSortDirectionDesc"
+              @click="toggleSort('deleteTimestampMoment')"
             >
-              <translate translate-context="Deletion time column in trashbin files table">Deletion Time</translate>
+              <translate translate-context="Deletion time column in trashbin files table"
+                >Deletion Time</translate
+              >
             </sortable-column-header>
           </div>
         </template>
         <template #rowColumns="{ item }">
           <div class="uk-text-truncate uk-width-expand">
             <file-item
+              :key="item.viewId"
               :item="item"
               :name="$_ocTrashbin_fileName(item)"
               class="file-row-name"
-              :key="item.viewId"
             />
           </div>
-          <div class="uk-text-meta uk-text-nowrap uk-width-small uk-text-right" :class="{ 'uk-visible@s' : !_sidebarOpen, 'uk-hidden'  : _sidebarOpen }">
+          <div
+            class="uk-text-meta uk-text-nowrap uk-width-small uk-text-right"
+            :class="{ 'uk-visible@s': !_sidebarOpen, 'uk-hidden': _sidebarOpen }"
+          >
             {{ formDateFromNow(item.deleteTimestamp) }}
           </div>
         </template>
         <template #noContentMessage>
           <no-content-message icon="delete">
-            <template #message><span v-translate>Your trash bin is empty.</span></template>
+            <template #message
+              ><span v-translate>Your trash bin is empty.</span></template
+            >
           </no-content-message>
         </template>
       </file-list>
     </div>
-    <oc-dialog-prompt name="delete-file-confirmation-dialog" :oc-active="trashbinDeleteMessage !== ''"
-                      :oc-content="trashbinDeleteMessage" :oc-has-input="false" :ocTitle="_deleteDialogTitle"
-                      ocConfirmId="oc-dialog-delete-confirm" @oc-confirm="$_ocTrashbin_clearTrashbinConfirmation"
-                      @oc-cancel="$_ocTrashbin_cancelTrashbinConfirmation"
+    <oc-dialog-prompt
+      name="delete-file-confirmation-dialog"
+      :oc-active="trashbinDeleteMessage !== ''"
+      :oc-content="trashbinDeleteMessage"
+      :oc-has-input="false"
+      :oc-title="_deleteDialogTitle"
+      oc-confirm-id="oc-dialog-delete-confirm"
+      @oc-confirm="$_ocTrashbin_clearTrashbinConfirmation"
+      @oc-cancel="$_ocTrashbin_cancelTrashbinConfirmation"
     />
   </div>
 </template>
@@ -78,12 +95,15 @@ export default {
     SortableColumnHeader
   },
 
-  mixins: [
-    Mixins
-  ],
-  props: ['fileData'],
+  mixins: [Mixins],
+  props: {
+    fileData: {
+      type: Array,
+      required: true
+    }
+  },
 
-  data () {
+  data() {
     return {
       queue: new PQueue({ concurrency: 4 }),
       ocDialogIsOpen: false
@@ -93,7 +113,7 @@ export default {
   computed: {
     ...mapGetters('Files', ['loadingFolder', 'selectedFiles', 'trashbinDeleteMessage']),
 
-    _deleteDialogTitle () {
+    _deleteDialogTitle() {
       const files = this.selectedFiles
       let translated
 
@@ -106,7 +126,7 @@ export default {
       return this.$gettextInterpolate(translated, { numberOfFiles: files.length }, false)
     },
 
-    actions () {
+    actions() {
       return [
         {
           icon: 'restore',
@@ -124,37 +144,47 @@ export default {
     }
   },
 
-  beforeMount () {
+  beforeMount() {
     this.$_ocTrashbin_getFiles()
   },
 
   methods: {
-    ...mapActions('Files', ['loadTrashbin', 'addFileSelection', 'removeFileSelection', 'resetFileSelection', 'setTrashbinDeleteMessage', 'removeFilesFromTrashbin']),
+    ...mapActions('Files', [
+      'loadTrashbin',
+      'addFileSelection',
+      'removeFileSelection',
+      'resetFileSelection',
+      'setTrashbinDeleteMessage',
+      'removeFilesFromTrashbin'
+    ]),
     ...mapActions(['showMessage']),
 
-    $_ocTrashbin_getFiles () {
+    $_ocTrashbin_getFiles() {
       this.loadTrashbin({
         client: this.$client,
         $gettext: this.$gettext
       })
     },
-    $_ocTrashbin_deleteFile (item) {
+    $_ocTrashbin_deleteFile(item) {
       this.ocDialogIsOpen = true
       this.resetFileSelection()
       this.addFileSelection(item)
 
-      this.setTrashbinDeleteMessage(this.$gettext('This item will be deleted permanently. You can’t undo this action.'))
+      this.setTrashbinDeleteMessage(
+        this.$gettext('This item will be deleted permanently. You can’t undo this action.')
+      )
     },
 
-    $_ocTrashbin_clearTrashbinConfirmation (files = this.selectedFiles) {
+    $_ocTrashbin_clearTrashbinConfirmation(files = this.selectedFiles) {
       // TODO: use clear all if all files are selected
       this.ocDialogIsOpen = false
       const deleteOps = []
 
       const self = this
-      function deleteFile (file) {
+      function deleteFile(file) {
         return () => {
-          return self.$client.fileTrash.clearTrashBin(file.id)
+          return self.$client.fileTrash
+            .clearTrashBin(file.id)
             .then(() => {
               self.$_ocTrashbin_removeFileFromList([file])
               const translated = self.$gettext('%{file} was successfully deleted')
@@ -190,15 +220,16 @@ export default {
       })
     },
 
-    $_ocTrashbin_cancelTrashbinConfirmation () {
+    $_ocTrashbin_cancelTrashbinConfirmation() {
       this.setTrashbinDeleteMessage('')
       this.ocDialogIsOpen = false
     },
 
-    $_ocTrashbin_restoreFile (file) {
+    $_ocTrashbin_restoreFile(file) {
       this.resetFileSelection()
       this.addFileSelection(file)
-      this.$client.fileTrash.restore(file.id, file.originalLocation)
+      this.$client.fileTrash
+        .restore(file.id, file.originalLocation)
         .then(() => {
           this.$_ocTrashbin_removeFileFromList([file])
           const translated = this.$gettext('%{file} was restored successfully')
@@ -217,11 +248,11 @@ export default {
       this.resetFileSelection()
     },
 
-    $_ocTrashbin_removeFileFromList (files) {
+    $_ocTrashbin_removeFileFromList(files) {
       this.removeFilesFromTrashbin(files)
     },
 
-    $_ocTrashbin_fileName (item) {
+    $_ocTrashbin_fileName(item) {
       if (item && item.originalLocation) {
         const pathSplit = item.originalLocation.split('/')
         if (pathSplit.length === 2) return `${pathSplit[pathSplit.length - 2]}/${item.basename}`
@@ -230,7 +261,7 @@ export default {
       return item.basename
     },
 
-    isActionEnabled (item, action) {
+    isActionEnabled(item, action) {
       return action.isEnabled(item, this.parentFolder)
     }
   }

--- a/apps/files/src/components/UploadMenu.vue
+++ b/apps/files/src/components/UploadMenu.vue
@@ -29,13 +29,11 @@ import Mixins from '../mixins'
 
 export default {
   filters: {
-    toInt (value) {
+    toInt(value) {
       return parseInt(value)
     }
   },
-  mixins: [
-    Mixins
-  ],
+  mixins: [Mixins],
   props: {
     items: {
       type: Array,

--- a/apps/files/src/components/UploadProgress.vue
+++ b/apps/files/src/components/UploadProgress.vue
@@ -1,48 +1,70 @@
 <template>
-  <div class="uk-clearfix uk-padding-remove-vertical" id="files-upload-progress">
+  <div id="files-upload-progress" class="uk-clearfix uk-padding-remove-vertical">
     <div class="uk-margin-remove uk-position-relative uk-width-expand">
       <oc-progress
+        ref="progressbar"
         :aria-hidden="true"
         :max="100"
         :value="totalUploadProgress"
         class="uk-width-expand uk-margin-remove"
-        ref="progressbar"
       />
       <span :aria-hidden="true" class="uk-position-center oc-progress-text">
         {{ totalUploadProgress | roundNumber }} %
       </span>
       <oc-hidden-announcer :announcement="announcement" level="assertive" />
     </div>
-    <oc-grid flex class="uk-margin-small-top uk-margin-small-bottom uk-text-meta oc-cursor-pointer"
-             @click.native="$_toggleExpanded" :aria-label="$gettext('Click row to toggle upload progress details')">
-      <oc-icon class="uk-width-auto" :name="expanded ? 'expand_less' : 'expand_more'" size="small" />
+    <oc-grid
+      flex
+      class="uk-margin-small-top uk-margin-small-bottom uk-text-meta oc-cursor-pointer"
+      :aria-label="$gettext('Click row to toggle upload progress details')"
+      @click.native="$_toggleExpanded"
+    >
+      <oc-icon
+        class="uk-width-auto"
+        :name="expanded ? 'expand_less' : 'expand_more'"
+        size="small"
+      />
       <div class="uk-width-expand uk-text-truncate">
-        <translate :translate-params="{ fileName: inProgress[0].name }"
-                   translate-comment="Upload progress when only uploading one file shows the name of the file."
-                   key="upload-progress-single"
-                   v-if="count === 1">
+        <translate
+          v-if="count === 1"
+          key="upload-progress-single"
+          :translate-params="{ fileName: inProgress[0].name }"
+          translate-comment="Upload progress when only uploading one file shows the name of the file."
+        >
           Uploading "%{ fileName }"
         </translate>
         <translate
+          v-else
+          key="upload-progress-multi"
           :translate-n="count"
           translate-plural="Uploading %{ count } items"
           translate-comment="Upload progress when uploading multiple files only shows the number of uploads."
-          key="upload-progress-multi"
-          v-else
         >
           Uploading %{ count } item
         </translate>
       </div>
       <div class="uk-width-auto">
-        <translate v-if="expanded" key="upload-progress-collapse-details" translate-comment="Hide details panel of upload progress">
+        <translate
+          v-if="expanded"
+          key="upload-progress-collapse-details"
+          translate-comment="Hide details panel of upload progress"
+        >
           Hide Details
         </translate>
-        <translate v-else key="upload-progress-expand-details" translate-comment="Show details panel of upload progress">
+        <translate
+          v-else
+          key="upload-progress-expand-details"
+          translate-comment="Show details panel of upload progress"
+        >
           Show Details
         </translate>
       </div>
     </oc-grid>
-    <upload-menu v-if="expanded" :items="inProgress" class="uk-width-expand oc-upload-menu-scrollable" />
+    <upload-menu
+      v-if="expanded"
+      :items="inProgress"
+      class="uk-width-expand oc-upload-menu-scrollable"
+    />
   </div>
 </template>
 
@@ -57,7 +79,7 @@ export default {
     UploadMenu
   },
   mixins: [Mixins],
-  data () {
+  data() {
     return {
       expanded: false,
       announcement: '',
@@ -67,17 +89,17 @@ export default {
   computed: {
     ...mapGetters('Files', ['inProgress', 'uploaded']),
 
-    count () {
+    count() {
       return this.inProgress.length
     },
 
-    totalUploadProgress () {
+    totalUploadProgress() {
       let totalSizeSum = 0
       let progressSizeSum = 0
 
       for (const item of this.inProgress) {
         totalSizeSum += item.size
-        progressSizeSum += (item.size * item.progress / 100)
+        progressSizeSum += (item.size * item.progress) / 100
       }
 
       for (const item of this.uploaded) {
@@ -93,14 +115,14 @@ export default {
     }
   },
   watch: {
-    totalUploadProgress (value) {
+    totalUploadProgress(value) {
       if (value === 100) {
         this.expanded = false
         this.announcement = this.announcementOnComplete
       }
     }
   },
-  created () {
+  created() {
     this.$root.$on('upload-start', () => {
       this.$nextTick(() => {
         this.delayForScreenreader(() => this.$refs.progressbar.$el.focus())
@@ -108,7 +130,7 @@ export default {
     })
   },
   methods: {
-    $_toggleExpanded () {
+    $_toggleExpanded() {
       this.expanded = !this.expanded
     }
   }
@@ -116,21 +138,21 @@ export default {
 </script>
 
 <style>
-  /* FIXME: move whole text part to ODS. it is useful to have a text component available for the progress bar. */
-  #files-upload-progress .oc-progress-text {
-    font-size: 0.75em;
-    color: #aaa;
-  }
-  #files-upload-progress .uk-progress {
-    box-shadow: 0 0 2px #ccc;
-  }
+/* FIXME: move whole text part to ODS. it is useful to have a text component available for the progress bar. */
+#files-upload-progress .oc-progress-text {
+  font-size: 0.75em;
+  color: #aaa;
+}
+#files-upload-progress .uk-progress {
+  box-shadow: 0 0 2px #ccc;
+}
 </style>
 <style scoped>
-  /* FIXME: move to ODS somehow? with the very specific max-height it probably doesn't make a generic css class from it... */
-  .oc-upload-menu-scrollable {
-    max-height: 200px;
-    overflow: auto;
-    -webkit-overflow-scrolling: touch;
-    resize: both;
-  }
+/* FIXME: move to ODS somehow? with the very specific max-height it probably doesn't make a generic css class from it... */
+.oc-upload-menu-scrollable {
+  max-height: 200px;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+  resize: both;
+}
 </style>

--- a/apps/files/src/components/ocDialogPrompt.vue
+++ b/apps/files/src/components/ocDialogPrompt.vue
@@ -1,29 +1,35 @@
 <template>
-  <oc-dialog :name="name" v-model="ocActive" :title="ocTitle">
+  <oc-dialog v-model="ocActive" :name="name" :title="ocTitle">
     <template slot="content">
       <span v-if="ocContent" class="uk-text-break">{{ ocContent }}</span>
-      <oc-text-input v-if="ocHasInput"
+      <oc-text-input
+        v-if="ocHasInput"
+        :id="ocInputId"
+        ref="input"
+        v-model="inputValue"
         :disabled="ocLoading"
         :placeholder="ocInputPlaceholder"
         :label="ocInputLabel"
         autofocus
-        :id="ocInputId"
-        v-model="inputValue"
-        ref="input"
-        @keydown.enter.native="onConfirm"
         :error-message="ocErrorDelayed"
         :fix-message-line="true"
         class="oc-dialog-prompt-input-offset"
+        @keydown.enter.native="onConfirm"
       ></oc-text-input>
       <oc-loader v-if="ocLoading"></oc-loader>
     </template>
     <template slot="footer">
-        <oc-button :id="ocCancelId" :disabled="ocLoading" @click.stop="onCancel">{{ _ocCancelText }}</oc-button>
-        <oc-button :disabled="ocLoading || !!ocError || inputValue === '' || clicked"
-               :id="ocConfirmId"
-               ref="confirmButton"
-               :autofocus="!ocHasInput"
-               @click.stop="onConfirm">{{ _ocConfirmText }}</oc-button>
+      <oc-button :id="ocCancelId" :disabled="ocLoading" @click.stop="onCancel">{{
+        _ocCancelText
+      }}</oc-button>
+      <oc-button
+        :id="ocConfirmId"
+        ref="confirmButton"
+        :disabled="ocLoading || !!ocError || inputValue === '' || clicked"
+        :autofocus="!ocHasInput"
+        @click.stop="onConfirm"
+        >{{ _ocConfirmText }}</oc-button
+      >
     </template>
   </oc-dialog>
 </template>
@@ -33,24 +39,46 @@ import debounce from 'lodash/debounce'
 export default {
   name: 'OcDialogPrompt',
   props: {
-    name: { type: String },
+    name: { type: String, required: true },
     ocActive: { type: Boolean, default: false },
-    value: {},
-    ocTitle: String,
+    value: {
+      type: [Object, String],
+      default: undefined
+    },
+    ocTitle: {
+      type: String,
+      default: undefined
+    },
     ocHasInput: { type: Boolean, default: true },
-    ocInputId: String,
-    ocInputName: String,
-    ocInputMaxlength: [String, Number],
-    ocInputPlaceholder: [String, Number],
-    ocInputLabel: [String, Number],
-    ocContent: String,
+    ocInputId: {
+      type: String,
+      default: undefined
+    },
+    ocInputPlaceholder: {
+      type: [String, Number],
+      default: undefined
+    },
+    ocInputLabel: {
+      type: [String, Number],
+      default: undefined
+    },
+    ocContent: {
+      type: String,
+      default: undefined
+    },
     ocError: {
       type: String,
-      default: null
+      default: undefined
     },
     ocLoading: { type: Boolean, default: false },
-    ocCancelId: String,
-    ocConfirmId: String,
+    ocCancelId: {
+      type: String,
+      default: undefined
+    },
+    ocConfirmId: {
+      type: String,
+      default: undefined
+    },
     ocConfirmText: {
       type: String,
       default: null
@@ -66,21 +94,21 @@ export default {
     ocErrorDelayed: null
   }),
   computed: {
-    _ocConfirmText () {
+    _ocConfirmText() {
       return this.ocConfirmText ? this.ocConfirmText : this.$gettext('Ok')
     },
-    _ocCancelText () {
+    _ocCancelText() {
       return this.ocCancelText ? this.ocConfirmText : this.$gettext('Cancel')
     }
   },
   watch: {
-    value () {
+    value() {
       this.inputValue = this.value
     },
-    inputValue () {
+    inputValue() {
       this.$emit('input', this.inputValue)
     },
-    ocActive (isActive) {
+    ocActive(isActive) {
       this.clicked = false
       this.inputValue = this.value
 
@@ -94,18 +122,18 @@ export default {
         }
       })
     },
-    ocError: debounce(function (error) {
+    ocError: debounce(function(error) {
       this.ocErrorDelayed = error
     }, 400)
   },
-  created () {
+  created() {
     this.inputValue = this.value
   },
   methods: {
-    onCancel () {
+    onCancel() {
       this.$emit('oc-cancel')
     },
-    onConfirm () {
+    onConfirm() {
       if (!this.ocError && this.inputValue !== '') {
         this.clicked = true
         this.$emit('oc-confirm', this.inputValue)
@@ -116,8 +144,8 @@ export default {
 </script>
 
 <style scoped>
-  /* FIXME: this is ugly, but required so that the bottom padding doesn't look off when reserving vertical space for error messages below the input. */
-  .oc-dialog-prompt-input-offset {
-    margin-bottom: -20px;
-  }
+/* FIXME: this is ugly, but required so that the bottom padding doesn't look off when reserving vertical space for error messages below the input. */
+.oc-dialog-prompt-input-offset {
+  margin-bottom: -20px;
+}
 </style>

--- a/apps/files/src/default.js
+++ b/apps/files/src/default.js
@@ -14,7 +14,7 @@ import translationsJson from '../l10n/translations.json'
 const store = require('./store')
 
 // just a dummy function to trick gettext tools
-function $gettext (msg) {
+function $gettext(msg) {
   return msg
 }
 const filesConfig = window.phoenixConfig.files || []
@@ -42,13 +42,14 @@ const appInfo = {
     {
       app: 'files-version',
       component: FileInfoVersions,
-      enabled (capabilities, highlightedFile) {
+      enabled(capabilities, highlightedFile) {
         return !!capabilities.core && highlightedFile && highlightedFile.type !== 'folder'
       }
-    }, {
+    },
+    {
       app: 'files-sharing',
       component: FileSharingSidebar,
-      enabled (capabilities) {
+      enabled(capabilities) {
         if (capabilities.files_sharing) {
           return capabilities.files_sharing.api_enabled
         }
@@ -58,16 +59,18 @@ const appInfo = {
         icon: 'group',
         ariaLabel: $gettext('Collaborators')
       }
-    }, {
+    },
+    {
       app: 'file-link',
       component: FileLinkSidebar,
-      enabled (capabilities) {
+      enabled(capabilities) {
         if (capabilities.files_sharing) {
           return capabilities.files_sharing.public.enabled
         }
         return false
       }
-    }, ...sidebarsFromConfig
+    },
+    ...sidebarsFromConfig
   ]
 }
 const navItems = [
@@ -105,7 +108,7 @@ const navItems = [
   {
     name: $gettext('Trash bin'),
     iconMaterial: 'delete',
-    enabled (capabilities) {
+    enabled(capabilities) {
       if (capabilities && capabilities.dav) {
         return capabilities.dav.trashbin === '1.0'
       }

--- a/apps/files/src/fileSortFunctions.js
+++ b/apps/files/src/fileSortFunctions.js
@@ -1,6 +1,6 @@
 import { textUtils } from './helpers/textUtils'
 
-function name (fileInfo1, fileInfo2) {
+function name(fileInfo1, fileInfo2) {
   if (fileInfo1.type === 'folder' && fileInfo2.type !== 'folder') {
     return -1
   }
@@ -10,31 +10,31 @@ function name (fileInfo1, fileInfo2) {
   return textUtils.naturalSortCompare(fileInfo1.name, fileInfo2.name)
 }
 
-function size (fileInfo1, fileInfo2) {
+function size(fileInfo1, fileInfo2) {
   if (fileInfo1.size === fileInfo2.size) {
     return name(fileInfo1, fileInfo2)
   }
   return fileInfo1.size - fileInfo2.size
 }
 
-function _getMomentComparator (field) {
-  return function (fileInfo1, fileInfo2) {
-    const isUndef1 = (typeof fileInfo1[field] === 'undefined')
-    const isUndef2 = (typeof fileInfo2[field] === 'undefined')
+function _getMomentComparator(field) {
+  return function(fileInfo1, fileInfo2) {
+    const isUndef1 = typeof fileInfo1[field] === 'undefined'
+    const isUndef2 = typeof fileInfo2[field] === 'undefined'
     if (!isUndef1 && isUndef2) {
       return -1
     }
     if (isUndef1 && !isUndef2) {
       return -1
     }
-    if ((isUndef1 && isUndef2) || (fileInfo1[field].isSame(fileInfo2[field]))) {
+    if ((isUndef1 && isUndef2) || fileInfo1[field].isSame(fileInfo2[field])) {
       return name(fileInfo1, fileInfo2)
     }
     return fileInfo1[field].isAfter(fileInfo2[field]) ? 1 : -1
   }
 }
 
-function _reverseComparator (func) {
+function _reverseComparator(func) {
   return (a, b) => -func(a, b)
 }
 

--- a/apps/files/src/fileactions.js
+++ b/apps/files/src/fileactions.js
@@ -3,19 +3,26 @@ import { mapActions, mapGetters } from 'vuex'
 export default {
   computed: {
     ...mapGetters('Files', [
-      'renameDialogSelectedFile', 'renameDialogOpen', 'renameDialogNewName', 'renameDialogOriginalName',
-      'deleteDialogOpen', 'deleteDialogSelectedFiles',
-      'actionsInProgress', 'activeFiles', 'selectedFiles', 'highlightedFile'
+      'renameDialogSelectedFile',
+      'renameDialogOpen',
+      'renameDialogNewName',
+      'renameDialogOriginalName',
+      'deleteDialogOpen',
+      'deleteDialogSelectedFiles',
+      'actionsInProgress',
+      'activeFiles',
+      'selectedFiles',
+      'highlightedFile'
     ]),
     ...mapGetters(['capabilities', 'fileSideBars']),
     // Files lists
-    actions () {
+    actions() {
       const actions = [
         {
           icon: 'edit',
           ariaLabel: this.$gettext('Rename'),
           handler: this.promptFileRename,
-          isEnabled: function (item, parent) {
+          isEnabled: function(item, parent) {
             if (parent && !parent.canRename()) {
               return false
             }
@@ -26,7 +33,7 @@ export default {
           icon: 'file_download',
           handler: this.downloadFile,
           ariaLabel: this.$gettext('Download'),
-          isEnabled: function (item) {
+          isEnabled: function(item) {
             return item.canDownload()
           }
         },
@@ -34,7 +41,7 @@ export default {
           icon: 'delete',
           ariaLabel: this.$gettext('Delete'),
           handler: this.deleteFile,
-          isEnabled: function (item, parent) {
+          isEnabled: function(item, parent) {
             if (parent && !parent.canBeDeleted()) {
               return false
             }
@@ -53,7 +60,7 @@ export default {
             ariaLabel: sideBar.quickAccess.ariaLabel,
             handler: this.openSideBar,
             handlerData: sideBar.app,
-            isEnabled: function (item) {
+            isEnabled: function(item) {
               return true
             }
           })
@@ -65,16 +72,20 @@ export default {
   },
   methods: {
     ...mapActions('Files', [
-      'renameFile', 'promptFileRename', 'closePromptFileRename',
-      'deleteFiles', 'promptFileDelete', 'closePromptFileDelete'
+      'renameFile',
+      'promptFileRename',
+      'closePromptFileRename',
+      'deleteFiles',
+      'promptFileDelete',
+      'closePromptFileDelete'
     ]),
     ...mapActions(['showMessage']),
 
-    actionInProgress (item) {
+    actionInProgress(item) {
       return this.actionsInProgress.some(itemInProgress => itemInProgress.id === item.id)
     },
 
-    disabledActionTooltip (item) {
+    disabledActionTooltip(item) {
       if (this.actionInProgress(item)) {
         if (item.type === 'folder') {
           return this.$gettext('There is currently an action in progress for this folder')
@@ -86,46 +97,56 @@ export default {
       return null
     },
 
-    cancelRenameFile () {
+    cancelRenameFile() {
       this.closePromptFileRename()
     },
 
-    doRenameFile (newName) {
+    doRenameFile(newName) {
       this.renameFile({
         client: this.$client,
         // selected file from prompt
         file: this.renameDialogSelectedFile,
         newValue: newName,
         publicPage: this.publicPage()
-      }).then(() => {
-        this.closePromptFileRename()
-      }).catch(error => {
-        let translated = this.$gettext('Error while renaming "%{file}" to "%{newName}"')
-        if (error.statusCode === 423) {
-          translated = this.$gettext('Error while renaming "%{file}" to "%{newName}" - the file is locked')
-        }
-        const title = this.$gettextInterpolate(translated, { file: this.renameDialogSelectedFile.name, newName: newName }, true)
-        this.showMessage({
-          title: title,
-          status: 'danger'
-        })
-        this.closePromptFileRename()
       })
+        .then(() => {
+          this.closePromptFileRename()
+        })
+        .catch(error => {
+          let translated = this.$gettext('Error while renaming "%{file}" to "%{newName}"')
+          if (error.statusCode === 423) {
+            translated = this.$gettext(
+              'Error while renaming "%{file}" to "%{newName}" - the file is locked'
+            )
+          }
+          const title = this.$gettextInterpolate(
+            translated,
+            { file: this.renameDialogSelectedFile.name, newName: newName },
+            true
+          )
+          this.showMessage({
+            title: title,
+            status: 'danger'
+          })
+          this.closePromptFileRename()
+        })
     },
 
-    cancelDeleteFile () {
+    cancelDeleteFile() {
       this.closePromptFileDelete()
     },
 
-    deleteFile (file) {
+    deleteFile(file) {
       const translated = this.$gettext('Please confirm the deletion of %{ fileName }')
       this.promptFileDelete({
         message: this.$gettextInterpolate(translated, { fileName: file.name }, true),
         items: file
       })
     },
-    reallyDeleteFiles () {
-      let files = this.deleteDialogSelectedFiles ? this.deleteDialogSelectedFiles : this.selectedFiles
+    reallyDeleteFiles() {
+      let files = this.deleteDialogSelectedFiles
+        ? this.deleteDialogSelectedFiles
+        : this.selectedFiles
       if (!Array.isArray(files)) {
         files = [files]
       }
@@ -135,16 +156,18 @@ export default {
         publicPage: this.publicPage(),
         $gettext: this.$gettext,
         $gettextInterpolate: this.$gettextInterpolate
-      }).then(() => {
-        this.closePromptFileDelete()
-        this.setHighlightedFile(null)
-      }).catch(error => {
-        console.log(error)
-        this.closePromptFileDelete()
       })
+        .then(() => {
+          this.closePromptFileDelete()
+          this.setHighlightedFile(null)
+        })
+        .catch(error => {
+          console.log(error)
+          this.closePromptFileDelete()
+        })
     },
 
-    validateFileName (name) {
+    validateFileName(name) {
       if (/[/]/.test(name)) return this.$gettext('The name cannot contain "/"')
 
       if (name === '.') return this.$gettext('The name cannot be equal to "."')
@@ -154,7 +177,7 @@ export default {
       if (/\s+$/.test(name)) return this.$gettext('The name cannot end with whitespace')
 
       if (!this.flatFileList) {
-        const exists = this.activeFiles.find((n) => {
+        const exists = this.activeFiles.find(n => {
           if (n.name === name && this.renameDialogOriginalName !== name) {
             return n
           }
@@ -168,13 +191,13 @@ export default {
       return null
     },
     // Files lists
-    openFileActionBar (file) {
+    openFileActionBar(file) {
       this.$emit('FileAction', file)
     },
-    openSideBar (file, sideBarName) {
+    openSideBar(file, sideBarName) {
       this.$emit('sideBarOpen', file, sideBarName)
     },
-    navigateTo (param) {
+    navigateTo(param) {
       if (this.searchTerm !== '' && this.$route.params.item === param) {
         this.resetSearch()
       }
@@ -189,7 +212,7 @@ export default {
         }
       })
     },
-    openFileAction (action, filePath) {
+    openFileAction(action, filePath) {
       if (action.version === 3) {
         // TODO: replace more placeholder in the final version
         const finalUrl = action.url
@@ -203,7 +226,10 @@ export default {
         return
       }
       if (action.newTab) {
-        const path = this.$router.resolve({ name: action.routeName, params: { filePath: filePath } }).href
+        const path = this.$router.resolve({
+          name: action.routeName,
+          params: { filePath: filePath }
+        }).href
         const url = window.location.origin + '/' + path
         const target = `${action.routeName}-${filePath}`
         const win = window.open(url, target)

--- a/apps/files/src/helpers/collaboratorRolesDefinition.js
+++ b/apps/files/src/helpers/collaboratorRolesDefinition.js
@@ -1,15 +1,15 @@
 // Return original string in case no translate function is provided
-function returnOriginal (string) {
+function returnOriginal(string) {
   return string
 }
 
 // TODO: Bring default role in here. Later might go to the roles API
 /**
-   * Returns object with collaborator roles
-   * @param {boolean} isFolder  Defines if the item is folder
-   * @param {function} $gettext  Function to translate neccessary strings
-   * @returns {object}  Collaborator roles
-   */
+ * Returns object with collaborator roles
+ * @param {boolean} isFolder  Defines if the item is folder
+ * @param {function} $gettext  Function to translate neccessary strings
+ * @returns {object}  Collaborator roles
+ */
 export default ({ isFolder = false, $gettext = returnOriginal }) => {
   if (isFolder) {
     return {

--- a/apps/files/src/helpers/collaborators.js
+++ b/apps/files/src/helpers/collaborators.js
@@ -18,7 +18,7 @@ export const permissionsBitmask = {
  * @param {array} additionalPermissions  Array of selected additional permissions
  * @returns {integer}  Role bitmask
  */
-export function roleToBitmask (role, additionalPermissions = []) {
+export function roleToBitmask(role, additionalPermissions = []) {
   let bitmask = 0
 
   for (const permission of role.permissions) {
@@ -42,7 +42,7 @@ export function roleToBitmask (role, additionalPermissions = []) {
  * @param {boolean} isFolder Defines if the item is folder
  * @returns {object} Role mapped to the bitmask
  */
-export function bitmaskToRole (bitmask, isFolder) {
+export function bitmaskToRole(bitmask, isFolder) {
   // TODO: inject the result of "roles()" in the function header and have the caller of bitmaskToRole call roles() with appropriate arguments including translation
   // Not passing in translation as we don't need it
   const currentRoles = roles({ isFolder: isFolder })
@@ -67,10 +67,7 @@ export function bitmaskToRole (bitmask, isFolder) {
     }
 
     // TODO: Use bitmask to cover cases of more then one additional permission
-    if (
-      rolePermissionsBitmask === bitmask ||
-      roleBasicPermissionsBitmask === bitmask
-    ) {
+    if (rolePermissionsBitmask === bitmask || roleBasicPermissionsBitmask === bitmask) {
       return currentRole
     }
   }

--- a/apps/files/src/helpers/path.js
+++ b/apps/files/src/helpers/path.js
@@ -10,7 +10,7 @@
  * @param {Boolean} includeCurrent whether to include the current path (with leading slash)
  * @return {Array.<String>} parent paths
  */
-export function getParentPaths (path, includeCurrent = false) {
+export function getParentPaths(path, includeCurrent = false) {
   if (path === '' || path === '/') {
     return []
   }

--- a/apps/files/src/helpers/publicLinkRolesDefinition.js
+++ b/apps/files/src/helpers/publicLinkRolesDefinition.js
@@ -1,5 +1,5 @@
 // Return original string in case no translate function is provided
-function returnOriginal (string) {
+function returnOriginal(string) {
   return string
 }
 

--- a/apps/files/src/helpers/shareTypes.js
+++ b/apps/files/src/helpers/shareTypes.js
@@ -10,4 +10,9 @@ export const shareTypes = {
   remote: 6
 }
 
-export const userShareTypes = [shareTypes.user, shareTypes.group, shareTypes.guest, shareTypes.remote]
+export const userShareTypes = [
+  shareTypes.user,
+  shareTypes.group,
+  shareTypes.guest,
+  shareTypes.remote
+]

--- a/apps/files/src/helpers/textUtils.js
+++ b/apps/files/src/helpers/textUtils.js
@@ -1,11 +1,15 @@
-function _chunkify (t) {
+function _chunkify(t) {
   // Adapted from http://my.opera.com/GreyWyvern/blog/show.dml/1671288
-  const tz = []; let x = 0; let y = -1; let n = 0; let c
+  const tz = []
+  let x = 0
+  let y = -1
+  let n = 0
+  let c
 
   while (x < t.length) {
     c = t.charAt(x)
     // only include the dot in strings
-    const m = ((!n && c === '.') || (c >= '0' && c <= '9'))
+    const m = (!n && c === '.') || (c >= '0' && c <= '9')
     if (m !== n) {
       // next chunk
       y++
@@ -25,7 +29,7 @@ function _chunkify (t) {
  * @return number Negative integer if b comes before a, positive integer if a comes before b
  * or 0 if the strings are identical
  */
-function naturalSortCompare (a, b) {
+function naturalSortCompare(a, b) {
   const aa = _chunkify(a)
   const bb = _chunkify(b)
   let x, aNum, bNum

--- a/apps/files/src/mixins.js
+++ b/apps/files/src/mixins.js
@@ -7,7 +7,7 @@ const { default: PQueue } = require('p-queue')
 
 export default {
   filters: {
-    fileSize (int) {
+    fileSize(int) {
       if (int < 0) {
         return ''
       }
@@ -24,7 +24,7 @@ export default {
       })
     },
 
-    roundNumber (int) {
+    roundNumber(int) {
       return parseInt(int.toFixed(0))
     }
   },
@@ -44,11 +44,11 @@ export default {
     ]),
     ...mapGetters(['getToken', 'capabilities']),
 
-    _sidebarOpen () {
+    _sidebarOpen() {
       return this.highlightedFile !== null
     },
 
-    requestHeaders () {
+    requestHeaders() {
       if (!this.publicPage()) {
         return null
       }
@@ -58,7 +58,10 @@ export default {
 
       const password = this.publicLinkPassword
       if (password) {
-        headers.append('Authorization', 'Basic ' + Buffer.from('public:' + password).toString('base64'))
+        headers.append(
+          'Authorization',
+          'Basic ' + Buffer.from('public:' + password).toString('base64')
+        )
       }
       return headers
     }
@@ -75,7 +78,7 @@ export default {
     ]),
     ...mapActions(['showMessage']),
 
-    toggleSort (fieldId) {
+    toggleSort(fieldId) {
       if (this.fileSortField === fieldId) {
         // reverse direction
         this.setFilesSort({ field: fieldId, directionIsDesc: !this.fileSortDirectionDesc })
@@ -84,16 +87,18 @@ export default {
         this.setFilesSort({ field: fieldId, directionIsDesc: false })
       }
     },
-    formDateFromNow (date) {
-      return moment(date).locale(this.$language.current).fromNow()
+    formDateFromNow(date) {
+      return moment(date)
+        .locale(this.$language.current)
+        .fromNow()
     },
-    delayForScreenreader (func, delay = 500) {
+    delayForScreenreader(func, delay = 500) {
       /*
-      * Delay for screen readers Virtual buffers
-      */
+       * Delay for screen readers Virtual buffers
+       */
       setTimeout(() => func(), delay)
     },
-    fileTypeIcon (file) {
+    fileTypeIcon(file) {
       if (file) {
         if (file.type === 'folder') {
           return 'folder'
@@ -103,7 +108,7 @@ export default {
       }
       return 'x-office-document'
     },
-    label (string) {
+    label(string) {
       const cssClass = ['uk-label']
 
       switch (parseInt(string)) {
@@ -119,25 +124,29 @@ export default {
 
       return '<span class="' + cssClass.join(' ') + '">' + string + '</span>'
     },
-    checkIfBrowserSupportsFolderUpload () {
+    checkIfBrowserSupportsFolderUpload() {
       const el = document.createElement('input')
       el.type = 'file'
-      return typeof el.webkitdirectory !== 'undefined' || typeof el.mozdirectory !== 'undefined' || typeof el.directory !== 'undefined'
+      return (
+        typeof el.webkitdirectory !== 'undefined' ||
+        typeof el.mozdirectory !== 'undefined' ||
+        typeof el.directory !== 'undefined'
+      )
     },
-    checkIfElementExists (element) {
+    checkIfElementExists(element) {
       const name = element.name || element
-      return this.files.find((n) => {
+      return this.files.find(n => {
         if (n.name === name) {
           return n
         }
       })
     },
-    processDirectoryEntryRecursively (directory) {
+    processDirectoryEntryRecursively(directory) {
       return this.$client.files.createFolder(this.rootPath + directory.fullPath).then(() => {
         const directoryReader = directory.createReader()
         const ctrl = this
-        directoryReader.readEntries(function (entries) {
-          entries.forEach(function (entry) {
+        directoryReader.readEntries(function(entries) {
+          entries.forEach(function(entry) {
             if (entry.isDirectory) {
               ctrl.processDirectoryEntryRecursively(entry)
             } else {
@@ -149,8 +158,9 @@ export default {
         })
       })
     },
-    compareIds (a, b) {
-      if (!isNaN(a)) { // OC10 autoincrement id
+    compareIds(a, b) {
+      if (!isNaN(a)) {
+        // OC10 autoincrement id
         return parseInt(a, 10) === parseInt(b, 10)
       } else if (this.isOcisId(b)) {
         return a === this.extractOpaqueId(b)
@@ -158,13 +168,13 @@ export default {
 
       return false
     },
-    isOcisId (id) {
+    isOcisId(id) {
       return atob(id).split(':').length === 2
     },
-    extractOpaqueId (id) {
+    extractOpaqueId(id) {
       return atob(id).split(':')[1]
     },
-    async $_ocUpload_addDropToQue (e) {
+    async $_ocUpload_addDropToQue(e) {
       const items = e.dataTransfer.items || e.dataTransfer.files
 
       // A list of files is being dropped ...
@@ -182,7 +192,11 @@ export default {
             })
           } else {
             this.showMessage({
-              title: this.$gettextInterpolate(this.$gettext('Folder %{folder} already exists.'), { folder: item.name }, true),
+              title: this.$gettextInterpolate(
+                this.$gettext('Folder %{folder} already exists.'),
+                { folder: item.name },
+                true
+              ),
               status: 'danger'
             })
           }
@@ -193,7 +207,9 @@ export default {
             })
           } else {
             const translated = this.$gettext('File %{file} already exists.')
-            this.setOverwriteDialogTitle(this.$gettextInterpolate(translated, { file: item.name }, true))
+            this.setOverwriteDialogTitle(
+              this.$gettextInterpolate(translated, { file: item.name }, true)
+            )
 
             if (this.capabilities.files.versioning) {
               this.setOverwriteDialogMessage(this.$gettext('Do you want to create a new version?'))
@@ -212,19 +228,21 @@ export default {
         }
       }
     },
-    async $_ocUpload_addFileToQue (e) {
+    async $_ocUpload_addFileToQue(e) {
       const files = e.target.files
       if (!files.length) return
       for (let i = 0; i < files.length; i++) {
         const exists = this.checkIfElementExists(files[i])
         if (!exists) {
           this.$_ocUpload(files[i], files[i].name)
-          if ((i + 1) === files.length) this.$_ocUploadInput_clean()
+          if (i + 1 === files.length) this.$_ocUploadInput_clean()
           continue
         }
 
         const translated = this.$gettext('File %{file} already exists.')
-        this.setOverwriteDialogTitle(this.$gettextInterpolate(translated, { file: files[i].name }, true))
+        this.setOverwriteDialogTitle(
+          this.$gettextInterpolate(translated, { file: files[i].name }, true)
+        )
 
         if (this.capabilities.files.versioning) {
           this.setOverwriteDialogMessage(this.$gettext('Do you want to create a new version?'))
@@ -235,14 +253,14 @@ export default {
         const overwrite = await this.$_ocUpload_confirmOverwrite()
         if (overwrite === true) {
           this.$_ocUpload(files[i], files[i].name, exists.etag)
-          if ((i + 1) === files.length) this.$_ocUploadInput_clean()
+          if (i + 1 === files.length) this.$_ocUploadInput_clean()
         } else {
-          if ((i + 1) === files.length) this.$_ocUploadInput_clean()
+          if (i + 1 === files.length) this.$_ocUploadInput_clean()
         }
         this.setOverwriteDialogMessage(null)
       }
     },
-    $_ocUpload_addDirectoryToQue (e) {
+    $_ocUpload_addDirectoryToQue(e) {
       if (this.isIE11()) {
         this.showMessage({
           title: this.$gettext('Upload failed'),
@@ -262,7 +280,11 @@ export default {
 
       if (directoryExists) {
         this.showMessage({
-          title: this.$gettextInterpolate(this.$gettext('Folder %{folder} already exists.'), { folder: directoryName }, true),
+          title: this.$gettextInterpolate(
+            this.$gettext('Folder %{folder} already exists.'),
+            { folder: directoryName },
+            true
+          ),
           status: 'danger'
         })
       } else {
@@ -302,9 +324,17 @@ export default {
           let p
 
           if (this.publicPage()) {
-            p = this.directoryQueue.add(() => this.$client.publicFiles.createFolder(this.rootPath, directory, this.publicLinkPassword))
+            p = this.directoryQueue.add(() =>
+              this.$client.publicFiles.createFolder(
+                this.rootPath,
+                directory,
+                this.publicLinkPassword
+              )
+            )
           } else {
-            p = this.directoryQueue.add(() => this.$client.files.createFolder(this.rootPath + directory))
+            p = this.directoryQueue.add(() =>
+              this.$client.files.createFolder(this.rootPath + directory)
+            )
           }
 
           createFolderPromises.push(p)
@@ -323,7 +353,7 @@ export default {
         })
       }
     },
-    $_ocUpload_confirmOverwrite () {
+    $_ocUpload_confirmOverwrite() {
       return new Promise(resolve => {
         const confirmButton = document.querySelector('#files-overwrite-confirm')
         const cancelButton = document.querySelector('#files-overwrite-cancel')
@@ -340,13 +370,13 @@ export default {
      * Adds file into the progress queue and assigns it unique id
      * @param {Object} file File which is to be added into progress
      */
-    $_addFileToUploadProgress (file) {
+    $_addFileToUploadProgress(file) {
       file.id = this.uploadFileUniqueId
       this.uploadFileUniqueId++
       this.addFileToProgress(file)
     },
 
-    $_ocUpload (file, path, overwrite = null, emitSuccess = true, addToProgress = true) {
+    $_ocUpload(file, path, overwrite = null, emitSuccess = true, addToProgress = true) {
       this.$root.$emit('upload-start')
       let basePath = this.path || ''
       let relativePath = path
@@ -361,43 +391,55 @@ export default {
         const token = basePath.substr(0, tokenSplit)
         basePath = basePath.substr(tokenSplit + 1) || ''
         relativePath = pathUtil.join(basePath, relativePath)
-        promise = this.uploadQueue.add(() => this.$client.publicFiles.putFileContents(token, relativePath, this.publicLinkPassword, file, {
-          onProgress: (progress) => {
-            this.$_ocUpload_onProgress(progress, file)
-          },
-          overwrite: overwrite
-        }))
+        promise = this.uploadQueue.add(() =>
+          this.$client.publicFiles.putFileContents(
+            token,
+            relativePath,
+            this.publicLinkPassword,
+            file,
+            {
+              onProgress: progress => {
+                this.$_ocUpload_onProgress(progress, file)
+              },
+              overwrite: overwrite
+            }
+          )
+        )
       } else {
         basePath = this.path || ''
         relativePath = pathUtil.join(basePath, relativePath)
-        promise = this.uploadQueue.add(() => this.$client.files.putFileContents(relativePath, file, {
-          onProgress: (progress) => {
-            this.$_ocUpload_onProgress(progress, file)
-          },
-          overwrite: overwrite
-        }))
+        promise = this.uploadQueue.add(() =>
+          this.$client.files.putFileContents(relativePath, file, {
+            onProgress: progress => {
+              this.$_ocUpload_onProgress(progress, file)
+            },
+            overwrite: overwrite
+          })
+        )
       }
 
-      promise.then(e => {
-        this.$root.$emit('upload-end')
-        this.removeFileFromProgress(file)
-        if (emitSuccess) {
-          this.$emit('success', e, file)
-        }
-      }).catch(e => {
-        this.removeFileFromProgress(file)
-        this.$emit('error', e)
-      })
+      promise
+        .then(e => {
+          this.$root.$emit('upload-end')
+          this.removeFileFromProgress(file)
+          if (emitSuccess) {
+            this.$emit('success', e, file)
+          }
+        })
+        .catch(e => {
+          this.removeFileFromProgress(file)
+          this.$emit('error', e)
+        })
     },
-    $_ocUpload_onProgress (e, file) {
-      const progress = parseInt(e.loaded * 100 / e.total)
+    $_ocUpload_onProgress(e, file) {
+      const progress = parseInt((e.loaded * 100) / e.total)
       this.$emit('progress', {
         id: file.id,
         fileName: file.name,
         progress
       })
     },
-    $_ocUploadInput_clean () {
+    $_ocUploadInput_clean() {
       const input = this.$refs.input
       if (input) {
         input.value = ''

--- a/apps/files/src/mixins/collaborators.js
+++ b/apps/files/src/mixins/collaborators.js
@@ -6,21 +6,21 @@ export default {
     ...mapGetters(['getToken']),
     ...mapGetters('Files', ['highlightedFile']),
 
-    ownerRole () {
+    ownerRole() {
       return {
         name: 'owner',
         label: this.$gettext('Owner')
       }
     },
 
-    resharerRole () {
+    resharerRole() {
       return {
         name: 'resharer',
         label: this.$gettext('Resharer')
       }
     },
 
-    advancedRole () {
+    advancedRole() {
       const advancedRole = {
         name: 'advancedRole',
         label: this.$gettext('Advanced permissions'),
@@ -53,7 +53,7 @@ export default {
       return advancedRole
     },
 
-    roles () {
+    roles() {
       const isFolder = this.highlightedFile.type === 'folder'
       const $gettext = this.$gettext
       const collaboratorRoles = roles({ $gettext, isFolder: isFolder })
@@ -61,7 +61,7 @@ export default {
 
       return collaboratorRoles
     },
-    displayRoles () {
+    displayRoles() {
       const result = this.roles
       result[this.resharerRole.name] = this.resharerRole
       result[this.ownerRole.name] = this.ownerRole
@@ -69,7 +69,7 @@ export default {
     }
   },
   methods: {
-    collaboratorOptionChanged ({ role, permissions, expirationDate }) {
+    collaboratorOptionChanged({ role, permissions, expirationDate }) {
       this.selectedRole = role
       this.additionalPermissions = permissions
       this.expirationDate = expirationDate

--- a/apps/files/src/store/actions.js
+++ b/apps/files/src/store/actions.js
@@ -6,7 +6,7 @@ import { shareTypes } from '../helpers/shareTypes'
 import path from 'path'
 const { default: PQueue } = require('p-queue')
 
-function _extName (fileName) {
+function _extName(fileName) {
   let ext = ''
   const ex = fileName.match(/\.[0-9a-z]+$/i)
   if (ex) {
@@ -15,10 +15,10 @@ function _extName (fileName) {
   return ext
 }
 
-function _buildFile (file) {
-  const ext = (file.type !== 'dir') ? _extName(file.name) : ''
-  return ({
-    type: (file.type === 'dir') ? 'folder' : file.type,
+function _buildFile(file) {
+  const ext = file.type !== 'dir' ? _extName(file.name) : ''
+  return {
+    type: file.type === 'dir' ? 'folder' : file.type,
     // actual file id (string)
     id: file.fileInfo['{http://owncloud.org/ns}fileid'],
     // temporary list id, to be used for view only and for uniqueness inside the list
@@ -26,21 +26,21 @@ function _buildFile (file) {
     starred: file.fileInfo['{http://owncloud.org/ns}favorite'] !== '0',
     mdate: file.fileInfo['{DAV:}getlastmodified'],
     mdateMoment: moment(file.fileInfo['{DAV:}getlastmodified']),
-    size: (function () {
+    size: (function() {
       if (file.type === 'dir') {
         return file.fileInfo['{http://owncloud.org/ns}size']
       } else {
         return file.fileInfo['{DAV:}getcontentlength']
       }
-    }()),
-    extension: (function () {
+    })(),
+    extension: (function() {
       return ext
-    }()),
-    name: (function () {
+    })(),
+    name: (function() {
       const pathList = file.name.split('/').filter(e => e !== '')
       return pathList.length === 0 ? '' : pathList[pathList.length - 1]
-    }()),
-    basename: (function () {
+    })(),
+    basename: (function() {
       const pathList = file.name.split('/').filter(e => e !== '')
       const name = pathList.length === 0 ? '' : pathList[pathList.length - 1]
       // FIXME: this is really just a view/formatting thing, should better
@@ -49,67 +49,74 @@ function _buildFile (file) {
         return name.substring(0, name.length - ext.length - 1)
       }
       return name
-    }()),
+    })(),
     path: file.name,
     permissions: file.fileInfo['{http://owncloud.org/ns}permissions'] || '',
     etag: file.fileInfo['{DAV:}getetag'],
     sharePermissions: file.fileInfo['{http://open-collaboration-services.org/ns}share-permissions'],
-    shareTypes: (function () {
+    shareTypes: (function() {
       let shareTypes = file.fileInfo['{http://owncloud.org/ns}share-types']
       if (shareTypes) {
-        shareTypes = _.chain(shareTypes).filter((xmlvalue) =>
-          (xmlvalue.namespaceURI === 'http://owncloud.org/ns' && xmlvalue.nodeName.split(':')[1] === 'share-type')
-        ).map((xmlvalue) =>
-          parseInt(xmlvalue.textContent || xmlvalue.text, 10)
-        ).value()
+        shareTypes = _.chain(shareTypes)
+          .filter(
+            xmlvalue =>
+              xmlvalue.namespaceURI === 'http://owncloud.org/ns' &&
+              xmlvalue.nodeName.split(':')[1] === 'share-type'
+          )
+          .map(xmlvalue => parseInt(xmlvalue.textContent || xmlvalue.text, 10))
+          .value()
       }
       return shareTypes || []
-    }()),
+    })(),
     privateLink: file.fileInfo['{http://owncloud.org/ns}privatelink'],
     owner: {
       username: file.fileInfo['{http://owncloud.org/ns}owner-id'],
       displayName: file.fileInfo['{http://owncloud.org/ns}owner-display-name']
     },
-    canUpload: function () {
+    canUpload: function() {
       return this.permissions.indexOf('C') >= 0
     },
-    canDownload: function () {
+    canDownload: function() {
       return this.type !== 'folder'
     },
-    canBeDeleted: function () {
+    canBeDeleted: function() {
       return this.permissions.indexOf('D') >= 0
     },
-    canRename: function () {
+    canRename: function() {
       return this.permissions.indexOf('N') >= 0
     },
-    canShare: function () {
+    canShare: function() {
       return this.permissions.indexOf('R') >= 0
     },
-    isMounted: function () {
+    isMounted: function() {
       return this.permissions.indexOf('M') >= 0
     },
-    isReceivedShare: function () {
+    isReceivedShare: function() {
       return this.permissions.indexOf('S') >= 0
     }
-  })
+  }
 }
 
-function _buildFileInTrashbin (file) {
+function _buildFileInTrashbin(file) {
   let ext = ''
   if (file.type !== 'dir') {
-    const ex = file.fileInfo['{http://owncloud.org/ns}trashbin-original-filename'].match(/\.[0-9a-z]+$/i)
+    const ex = file.fileInfo['{http://owncloud.org/ns}trashbin-original-filename'].match(
+      /\.[0-9a-z]+$/i
+    )
     if (ex !== null) {
       ext = ex[0].substr(1)
     }
   }
-  return ({
-    type: (file.type === 'dir') ? 'folder' : file.type,
+  return {
+    type: file.type === 'dir' ? 'folder' : file.type,
     deleteTimestamp: file.fileInfo['{http://owncloud.org/ns}trashbin-delete-datetime'],
-    deleteTimestampMoment: moment(file.fileInfo['{http://owncloud.org/ns}trashbin-delete-datetime']),
-    extension: (function () {
+    deleteTimestampMoment: moment(
+      file.fileInfo['{http://owncloud.org/ns}trashbin-delete-datetime']
+    ),
+    extension: (function() {
       return ext
-    }()),
-    basename: (function () {
+    })(),
+    basename: (function() {
       const fullName = file.fileInfo['{http://owncloud.org/ns}trashbin-original-filename']
       const pathList = fullName.split('/').filter(e => e !== '')
       const name = pathList.length === 0 ? '' : pathList[pathList.length - 1]
@@ -118,20 +125,20 @@ function _buildFileInTrashbin (file) {
       }
       return name
     })(),
-    name: (function () {
+    name: (function() {
       const fullName = file.fileInfo['{http://owncloud.org/ns}trashbin-original-filename']
       const pathList = fullName.split('/').filter(e => e !== '')
       return pathList.length === 0 ? '' : pathList[pathList.length - 1]
     })(),
     originalLocation: file.fileInfo['{http://owncloud.org/ns}trashbin-original-location'],
-    id: (function () {
+    id: (function() {
       const pathList = file.name.split('/').filter(e => e !== '')
       return pathList.length === 0 ? '' : pathList[pathList.length - 1]
     })()
-  })
+  }
 }
 
-function _aggregateFileShares (data, incomingShares = false) {
+function _aggregateFileShares(data, incomingShares = false) {
   // borrowed from owncloud's apps/files_sharing/js/sharedfilelist.js#_makeFilesFromShares(data)
   var files = data
   files = _.chain(files)
@@ -173,7 +180,7 @@ function _aggregateFileShares (data, incomingShares = false) {
       file.canShare = () => true
       file.isMounted = () => false
       file.canDownload = () => file.item_type !== 'folder'
-      file.extension = (file.type !== 'folder') ? _extName(file.name) : ''
+      file.extension = file.type !== 'folder' ? _extName(file.name) : ''
       if (file.extension) {
         // remove extension from basename like _buildFile does
         file.basename = file.basename.substring(0, file.basename.length - file.extension.length - 1)
@@ -216,28 +223,28 @@ function _aggregateFileShares (data, incomingShares = false) {
   return files
 }
 
-function _buildShare (s, file, $gettext) {
+function _buildShare(s, file, $gettext) {
   if (parseInt(s.share_type, 10) === shareTypes.link) {
     return _buildLink(s, $gettext)
   }
   return _buildCollaboratorShare(s, file)
 }
 
-function _buildLink (link, $gettext) {
+function _buildLink(link, $gettext) {
   let description = ''
 
   // FIXME: use bitmask matching with constants
   switch (link.permissions) {
-    case ('1'): // read (1)
+    case '1': // read (1)
       description = $gettext('Viewer')
       break
-    case ('5'): // read (1) + create (4)
+    case '5': // read (1) + create (4)
       description = $gettext('Contributor')
       break
-    case ('4'): // create (4)
+    case '4': // create (4)
       description = $gettext('Uploader')
       break
-    case ('15'): // read (1) + update (2) + create (4) + delete (8)
+    case '15': // read (1) + update (2) + create (4) + delete (8)
       description = $gettext('Editor')
       break
   }
@@ -253,7 +260,8 @@ function _buildLink (link, $gettext) {
     stime: link.stime,
     name: link.name,
     password: !!(link.share_with && link.share_with_displayname),
-    expiration: (typeof link.expiration === 'string') ? moment(link.expiration).format('YYYY-MM-DD') : null,
+    expiration:
+      typeof link.expiration === 'string' ? moment(link.expiration).format('YYYY-MM-DD') : null,
     itemSource: link.item_source,
     file: {
       parent: link.file_parent,
@@ -263,25 +271,25 @@ function _buildLink (link, $gettext) {
   }
 }
 
-function _fixAdditionalInfo (data) {
+function _fixAdditionalInfo(data) {
   if (typeof data !== 'string') {
     return null
   }
   return data
 }
 
-function _buildCollaboratorShare (s, file) {
+function _buildCollaboratorShare(s, file) {
   const share = {
     shareType: parseInt(s.share_type, 10),
     id: s.id
   }
   switch (share.shareType) {
-    case (shareTypes.user): // user share
+    case shareTypes.user: // user share
     // TODO differentiate groups from users?
     // fall through
-    case (shareTypes.remote):
+    case shareTypes.remote:
     // fall through
-    case (shareTypes.group): // group share
+    case shareTypes.group: // group share
       share.role = bitmaskToRole(s.permissions, file.type === 'folder')
       share.permissions = s.permissions
       // FIXME: SDK is returning empty object for additional info when empty
@@ -322,7 +330,7 @@ function _buildCollaboratorShare (s, file) {
 }
 
 export default {
-  loadFolder (context, { client, absolutePath, $gettext, routeName, loadSharesTree = false }) {
+  loadFolder(context, { client, absolutePath, $gettext, routeName, loadSharesTree = false }) {
     context.commit('UPDATE_FOLDER_LOADING', true)
     context.commit('CLEAR_CURRENT_FILES_LIST')
 
@@ -339,196 +347,232 @@ export default {
       } else {
         promise = client.files.list(absolutePath, 1, context.getters.davProperties)
       }
-      promise.then(res => {
-        if (res === null) {
-          context.dispatch('showMessage', {
-            title: $gettext('Loading folder failed…'),
-            status: 'danger'
-          }, { root: true })
-        } else {
-          if (favorite) {
-            client.files.fileInfo('', context.getters.davProperties).then(rootFolder => {
-              rootFolder.fileInfo['{http://owncloud.org/ns}permissions'] = 'R'
-              context.dispatch('loadFiles', {
-                currentFolder: rootFolder,
-                files: res
-              })
-            })
+      promise
+        .then(res => {
+          if (res === null) {
+            context.dispatch(
+              'showMessage',
+              {
+                title: $gettext('Loading folder failed…'),
+                status: 'danger'
+              },
+              { root: true }
+            )
           } else {
-            context.dispatch('loadFiles', {
-              currentFolder: res[0],
-              files: res.splice(1)
-            })
-            if (loadSharesTree) {
-              context.dispatch('loadSharesTree', {
-                client,
-                path: absolutePath,
-                $gettext
+            if (favorite) {
+              client.files.fileInfo('', context.getters.davProperties).then(rootFolder => {
+                rootFolder.fileInfo['{http://owncloud.org/ns}permissions'] = 'R'
+                context.dispatch('loadFiles', {
+                  currentFolder: rootFolder,
+                  files: res
+                })
               })
+            } else {
+              context.dispatch('loadFiles', {
+                currentFolder: res[0],
+                files: res.splice(1)
+              })
+              if (loadSharesTree) {
+                context.dispatch('loadSharesTree', {
+                  client,
+                  path: absolutePath,
+                  $gettext
+                })
+              }
             }
           }
-        }
-        context.dispatch('resetFileSelection')
-        context.dispatch('setHighlightedFile', null)
-        if (context.getters.searchTerm !== '') {
-          context.dispatch('resetSearch')
-        }
-      }).catch(error => {
-        reject(error)
-      }).finally(() => {
-        context.commit('UPDATE_FOLDER_LOADING', false)
-        client.users.getUser(context.rootGetters.user.id).then(res => {
-          context.commit('CHECK_QUOTA', res.quota)
-          resolve()
+          context.dispatch('resetFileSelection')
+          context.dispatch('setHighlightedFile', null)
+          if (context.getters.searchTerm !== '') {
+            context.dispatch('resetSearch')
+          }
         })
-      })
+        .catch(error => {
+          reject(error)
+        })
+        .finally(() => {
+          context.commit('UPDATE_FOLDER_LOADING', false)
+          client.users.getUser(context.rootGetters.user.id).then(res => {
+            context.commit('CHECK_QUOTA', res.quota)
+            resolve()
+          })
+        })
     })
   },
-  loadTrashbin (context, { client, $gettext }) {
+  loadTrashbin(context, { client, $gettext }) {
     context.commit('UPDATE_FOLDER_LOADING', true)
     context.commit('CLEAR_CURRENT_FILES_LIST')
 
-    client.fileTrash.list('', '1', [
-      '{http://owncloud.org/ns}trashbin-original-filename',
-      '{http://owncloud.org/ns}trashbin-original-location',
-      '{http://owncloud.org/ns}trashbin-delete-datetime',
-      '{DAV:}getcontentlength',
-      '{DAV:}resourcetype'
-    ]).then(res => {
-      if (res === null) {
-        context.dispatch('showMessage', {
-          title: $gettext('Loading trash bin failed…'),
-          status: 'danger'
-        }, { root: true })
-      } else {
-        context.dispatch('loadDeletedFiles', {
-          currentFolder: res[0],
-          files: res.splice(1)
-        })
-      }
-      context.dispatch('resetFileSelection')
-      context.dispatch('setHighlightedFile', null)
-    }).catch((e) => {
-      context.dispatch('showMessage', {
-        title: $gettext('Loading trash bin failed…'),
-        desc: e.message,
-        status: 'danger'
-      }, { root: true })
-    }).finally(() => {
-      context.commit('UPDATE_FOLDER_LOADING', false)
-    })
+    client.fileTrash
+      .list('', '1', [
+        '{http://owncloud.org/ns}trashbin-original-filename',
+        '{http://owncloud.org/ns}trashbin-original-location',
+        '{http://owncloud.org/ns}trashbin-delete-datetime',
+        '{DAV:}getcontentlength',
+        '{DAV:}resourcetype'
+      ])
+      .then(res => {
+        if (res === null) {
+          context.dispatch(
+            'showMessage',
+            {
+              title: $gettext('Loading trash bin failed…'),
+              status: 'danger'
+            },
+            { root: true }
+          )
+        } else {
+          context.dispatch('loadDeletedFiles', {
+            currentFolder: res[0],
+            files: res.splice(1)
+          })
+        }
+        context.dispatch('resetFileSelection')
+        context.dispatch('setHighlightedFile', null)
+      })
+      .catch(e => {
+        context.dispatch(
+          'showMessage',
+          {
+            title: $gettext('Loading trash bin failed…'),
+            desc: e.message,
+            status: 'danger'
+          },
+          { root: true }
+        )
+      })
+      .finally(() => {
+        context.commit('UPDATE_FOLDER_LOADING', false)
+      })
   },
-  loadFolderSharedFromMe (context, { client, $gettext }) {
+  loadFolderSharedFromMe(context, { client, $gettext }) {
     context.commit('UPDATE_FOLDER_LOADING', true)
     context.commit('CLEAR_CURRENT_FILES_LIST')
 
     // TODO: Move request to owncloud-sdk
-    client.requests.ocs({
-      service: 'apps/files_sharing',
-      action: '/api/v1/shares?format=json&reshares=true&include_tags=false',
-      method: 'GET'
-    }).then(res => {
-      res.json().then(json => {
-        if (json.ocs.data.length < 1) {
-          context.commit('UPDATE_FOLDER_LOADING', false)
-          return
-        }
-
-        const files = json.ocs.data
-        const uniqueFiles = _aggregateFileShares(files, false)
-        context.dispatch('buildFilesSharedFromMe', uniqueFiles)
+    client.requests
+      .ocs({
+        service: 'apps/files_sharing',
+        action: '/api/v1/shares?format=json&reshares=true&include_tags=false',
+        method: 'GET'
       })
-    }).catch((e) => {
-      context.dispatch('showMessage', {
-        title: $gettext('Loading shared files failed…'),
-        desc: e.message,
-        status: 'danger'
-      }, { root: true })
-    }).finally(() => {
-      context.commit('UPDATE_FOLDER_LOADING', false)
-    })
+      .then(res => {
+        res.json().then(json => {
+          if (json.ocs.data.length < 1) {
+            context.commit('UPDATE_FOLDER_LOADING', false)
+            return
+          }
+
+          const files = json.ocs.data
+          const uniqueFiles = _aggregateFileShares(files, false)
+          context.dispatch('buildFilesSharedFromMe', uniqueFiles)
+        })
+      })
+      .catch(e => {
+        context.dispatch(
+          'showMessage',
+          {
+            title: $gettext('Loading shared files failed…'),
+            desc: e.message,
+            status: 'danger'
+          },
+          { root: true }
+        )
+      })
+      .finally(() => {
+        context.commit('UPDATE_FOLDER_LOADING', false)
+      })
   },
-  loadFolderSharedWithMe (context, { client, $gettext }) {
+  loadFolderSharedWithMe(context, { client, $gettext }) {
     context.commit('UPDATE_FOLDER_LOADING', true)
     context.commit('CLEAR_CURRENT_FILES_LIST')
 
     // TODO: Move request to owncloud-sdk
     // TODO: Load remote shares as well
-    client.requests.ocs({
-      service: 'apps/files_sharing',
-      action: '/api/v1/shares?format=json&shared_with_me=true&state=all&include_tags=false',
-      method: 'GET'
-    }).then(res => {
-      res.json().then(json => {
-        if (json.ocs.data.length < 1) {
-          context.commit('UPDATE_FOLDER_LOADING', false)
-          return
-        }
-        const files = json.ocs.data
-        const uniqueFiles = _aggregateFileShares(files, true)
-        context.dispatch('buildFilesSharedFromMe', uniqueFiles)
+    client.requests
+      .ocs({
+        service: 'apps/files_sharing',
+        action: '/api/v1/shares?format=json&shared_with_me=true&state=all&include_tags=false',
+        method: 'GET'
       })
-    }).catch((e) => {
-      context.dispatch('showMessage', {
-        title: $gettext('Loading shared files failed…'),
-        desc: e.message,
-        status: 'danger'
-      }, { root: true })
-    }).finally(() => {
-      context.commit('UPDATE_FOLDER_LOADING', false)
-    })
+      .then(res => {
+        res.json().then(json => {
+          if (json.ocs.data.length < 1) {
+            context.commit('UPDATE_FOLDER_LOADING', false)
+            return
+          }
+          const files = json.ocs.data
+          const uniqueFiles = _aggregateFileShares(files, true)
+          context.dispatch('buildFilesSharedFromMe', uniqueFiles)
+        })
+      })
+      .catch(e => {
+        context.dispatch(
+          'showMessage',
+          {
+            title: $gettext('Loading shared files failed…'),
+            desc: e.message,
+            status: 'danger'
+          },
+          { root: true }
+        )
+      })
+      .finally(() => {
+        context.commit('UPDATE_FOLDER_LOADING', false)
+      })
   },
-  updateFileProgress ({ commit, getters }, progress) {
+  updateFileProgress({ commit, getters }, progress) {
     commit('UPDATE_FILE_PROGRESS', progress)
   },
-  addFileToProgress ({ commit }, file) {
+  addFileToProgress({ commit }, file) {
     commit('ADD_FILE_TO_PROGRESS', file)
   },
 
-  removeFileFromProgress ({ commit }, file) {
+  removeFileFromProgress({ commit }, file) {
     commit('REMOVE_FILE_FROM_PROGRESS', file)
   },
 
-  loadFiles (context, { currentFolder, files }) {
+  loadFiles(context, { currentFolder, files }) {
     if (currentFolder) {
       currentFolder = _buildFile(currentFolder)
     }
     files = files.map(_buildFile)
     context.commit('LOAD_FILES', { currentFolder, files })
   },
-  loadDeletedFiles (context, { currentFolder, files }) {
+  loadDeletedFiles(context, { currentFolder, files }) {
     currentFolder = _buildFile(currentFolder)
     files = files.map(_buildFileInTrashbin)
     context.commit('LOAD_FILES', { currentFolder, files })
   },
-  buildFilesSharedFromMe (context, files) {
+  buildFilesSharedFromMe(context, files) {
     const currentFolder = files[0]
     context.commit('LOAD_FILES', { currentFolder, files })
   },
-  setFilesSort (context, { field, directionIsDesc }) {
+  setFilesSort(context, { field, directionIsDesc }) {
     context.commit('SET_FILES_SORT', { field, directionIsDesc })
   },
-  addFileSelection (context, file) {
+  addFileSelection(context, file) {
     context.commit('ADD_FILE_SELECTION', file)
   },
-  removeFileSelection (context, file) {
+  removeFileSelection(context, file) {
     context.commit('REMOVE_FILE_SELECTION', file)
   },
-  toggleFileSelection (context, file) {
+  toggleFileSelection(context, file) {
     if (context.state.selected.includes(file)) {
       context.commit('REMOVE_FILE_SELECTION', file)
     } else {
       context.commit('ADD_FILE_SELECTION', file)
     }
   },
-  resetFileSelection (context) {
+  resetFileSelection(context) {
     context.commit('RESET_SELECTION')
   },
-  markFavorite (context, payload) {
+  markFavorite(context, payload) {
     const file = payload.file
     const client = payload.client
     const newValue = !file.starred
-    client.files.favorite(file.path, newValue)
+    client.files
+      .favorite(file.path, newValue)
       .then(() => {
         context.commit('FAVORITE_FILE', file)
       })
@@ -536,13 +580,13 @@ export default {
         console.log(error)
       })
   },
-  addFiles (context, payload) {
+  addFiles(context, payload) {
     const files = payload.files
     for (const file of files) {
       context.commit('ADD_FILE', _buildFile(file))
     }
   },
-  deleteFiles (context, { files, client, publicPage, $gettext, $gettextInterpolate }) {
+  deleteFiles(context, { files, client, publicPage, $gettext, $gettextInterpolate }) {
     const promises = []
     for (const file of files) {
       let p = null
@@ -551,78 +595,97 @@ export default {
       } else {
         p = client.files.delete(file.path)
       }
-      const promise = p.then(() => {
-        context.commit('REMOVE_FILE', file)
-        context.commit('REMOVE_FILE_SELECTION', file)
-      }).catch(error => {
-        let translated = $gettext('Error while deleting "%{file}"')
-        if (error.statusCode === 423) {
-          translated = $gettext('Error while deleting "%{file}" - the file is locked')
-        }
-        const title = $gettextInterpolate(translated, { file: file.name }, true)
-        context.dispatch('showMessage', {
-          title: title,
-          status: 'danger'
-        }, { root: true })
-      })
+      const promise = p
+        .then(() => {
+          context.commit('REMOVE_FILE', file)
+          context.commit('REMOVE_FILE_SELECTION', file)
+        })
+        .catch(error => {
+          let translated = $gettext('Error while deleting "%{file}"')
+          if (error.statusCode === 423) {
+            translated = $gettext('Error while deleting "%{file}" - the file is locked')
+          }
+          const title = $gettextInterpolate(translated, { file: file.name }, true)
+          context.dispatch(
+            'showMessage',
+            {
+              title: title,
+              status: 'danger'
+            },
+            { root: true }
+          )
+        })
       promises.push(promise)
     }
     return Promise.all(promises)
   },
-  removeFilesFromTrashbin (context, files) {
+  removeFilesFromTrashbin(context, files) {
     for (const file of files) {
       context.commit('REMOVE_FILE', file)
     }
   },
-  renameFile (context, { file, newValue, client, publicPage }) {
+  renameFile(context, { file, newValue, client, publicPage }) {
     if (file !== undefined && newValue !== undefined && newValue !== file.name) {
       const newPath = file.path.substr(1, file.path.lastIndexOf('/'))
       if (publicPage) {
-        return client.publicFiles.move(file.path, (newPath + newValue), context.getters.publicLinkPassword).then(() => {
-          context.commit('RENAME_FILE', { file, newValue, newPath })
-        })
+        return client.publicFiles
+          .move(file.path, newPath + newValue, context.getters.publicLinkPassword)
+          .then(() => {
+            context.commit('RENAME_FILE', { file, newValue, newPath })
+          })
       }
-      return client.files.move(file.path, (newPath + newValue)).then(() => {
+      return client.files.move(file.path, newPath + newValue).then(() => {
         context.commit('RENAME_FILE', { file, newValue, newPath })
       })
     }
   },
-  searchForFile (context, payload) {
-    return new Promise(function (resolve, reject) {
+  searchForFile(context, payload) {
+    return new Promise(function(resolve, reject) {
       const client = payload.client
       const searchTerm = payload.searchTerm
       context.commit('SET_SEARCH_TERM', searchTerm)
       // TODO respect user selected listSize from state.config
       // do not search for empty strings
       if (!searchTerm) return
-      client.files.search(searchTerm, null, context.state.davProperties).then((filesSearched) => {
-        filesSearched = filesSearched.map((f) => {
-          return _buildFile(f)
+      client.files
+        .search(searchTerm, null, context.state.davProperties)
+        .then(filesSearched => {
+          filesSearched = filesSearched.map(f => {
+            return _buildFile(f)
+          })
+          context.commit('LOAD_FILES_SEARCHED', filesSearched)
+          resolve(filesSearched)
         })
-        context.commit('LOAD_FILES_SEARCHED', filesSearched)
-        resolve(filesSearched)
-      }).catch((error) => {
-        // TODO notification missing
-        context.dispatch('showMessage', {
-          title: this.$gettext('Error while searching.'),
-          desc: error.message,
-          status: 'danger'
-        }, { root: true })
-        reject(error)
-      })
+        .catch(error => {
+          // TODO notification missing
+          context.dispatch(
+            'showMessage',
+            {
+              title: this.$gettext('Error while searching.'),
+              desc: error.message,
+              status: 'danger'
+            },
+            { root: true }
+          )
+          reject(error)
+        })
     })
   },
-  loadCurrentFileOutgoingShares (context, { client, path, $gettext }) {
+  loadCurrentFileOutgoingShares(context, { client, path, $gettext }) {
     context.commit('CURRENT_FILE_OUTGOING_SHARES_SET', [])
     context.commit('CURRENT_FILE_OUTGOING_SHARES_ERROR', null)
     context.commit('CURRENT_FILE_OUTGOING_SHARES_LOADING', true)
 
     // see https://owncloud.github.io/js-owncloud-client/Shares.html
-    client.shares.getShares(path, { reshares: true })
+    client.shares
+      .getShares(path, { reshares: true })
       .then(data => {
-        context.commit('CURRENT_FILE_OUTGOING_SHARES_SET', data.map(element => {
-          return _buildShare(element.shareInfo, context.getters.highlightedFile, $gettext)
-        }))
+        context.commit(
+          'CURRENT_FILE_OUTGOING_SHARES_SET',
+          data.map(element => {
+            return _buildShare(element.shareInfo, context.getters.highlightedFile, $gettext)
+          })
+        )
         context.commit('UPDATE_CURRENT_FILE_SHARE_TYPES')
         context.commit('CURRENT_FILE_OUTGOING_SHARES_LOADING', false)
       })
@@ -631,7 +694,7 @@ export default {
         context.commit('CURRENT_FILE_OUTGOING_SHARES_LOADING', false)
       })
   },
-  loadIncomingShares (context, payload) {
+  loadIncomingShares(context, payload) {
     context.commit('INCOMING_SHARES_LOAD', [])
     context.commit('INCOMING_SHARES_ERROR', null)
     context.commit('INCOMING_SHARES_LOADING', true)
@@ -639,11 +702,15 @@ export default {
     // see https://owncloud.github.io/js-owncloud-client/Shares.html
     const client = payload.client
     const path = payload.path
-    client.shares.getShares(path, { shared_with_me: true })
+    client.shares
+      .getShares(path, { shared_with_me: true })
       .then(data => {
-        context.commit('INCOMING_SHARES_LOAD', data.map(element => {
-          return _buildCollaboratorShare(element.shareInfo, context.getters.highlightedFile)
-        }))
+        context.commit(
+          'INCOMING_SHARES_LOAD',
+          data.map(element => {
+            return _buildCollaboratorShare(element.shareInfo, context.getters.highlightedFile)
+          })
+        )
         context.commit('INCOMING_SHARES_LOADING', false)
       })
       .catch(error => {
@@ -651,15 +718,15 @@ export default {
         context.commit('INCOMING_SHARES_LOADING', false)
       })
   },
-  sharesClearState (context, payload) {
+  sharesClearState(context, payload) {
     context.commit('CURRENT_FILE_OUTGOING_SHARES_SET', [])
     context.commit('CURRENT_FILE_OUTGOING_SHARES_ERROR', null)
   },
-  incomingSharesClearState (context, payload) {
+  incomingSharesClearState(context, payload) {
     context.commit('INCOMING_SHARES_LOAD', [])
     context.commit('INCOMING_SHARES_ERROR', null)
   },
-  changeShare ({ commit, getters }, { client, share, role, permissions, expirationDate }) {
+  changeShare({ commit, getters }, { client, share, role, permissions, expirationDate }) {
     const params = {
       permissions: permissions,
       expireDate: expirationDate
@@ -672,8 +739,9 @@ export default {
     }
 
     return new Promise((resolve, reject) => {
-      client.shares.updateShare(share.id, params)
-        .then((updatedShare) => {
+      client.shares
+        .updateShare(share.id, params)
+        .then(updatedShare => {
           const share = _buildCollaboratorShare(updatedShare.shareInfo, getters.highlightedFile)
           commit('CURRENT_FILE_OUTGOING_SHARES_UPDATE', share)
           resolve(share)
@@ -683,39 +751,63 @@ export default {
         })
     })
   },
-  addShare (context, { client, path, $gettext, shareWith, shareType, permissions, expirationDate }) {
+  addShare(context, { client, path, $gettext, shareWith, shareType, permissions, expirationDate }) {
     if (shareType === shareTypes.group) {
-      client.shares.shareFileWithGroup(path, shareWith, { permissions: permissions, expirationDate: expirationDate })
+      client.shares
+        .shareFileWithGroup(path, shareWith, {
+          permissions: permissions,
+          expirationDate: expirationDate
+        })
         .then(share => {
-          context.commit('CURRENT_FILE_OUTGOING_SHARES_ADD', _buildCollaboratorShare(share.shareInfo, context.getters.highlightedFile))
+          context.commit(
+            'CURRENT_FILE_OUTGOING_SHARES_ADD',
+            _buildCollaboratorShare(share.shareInfo, context.getters.highlightedFile)
+          )
           context.commit('UPDATE_CURRENT_FILE_SHARE_TYPES')
         })
         .catch(e => {
-          context.dispatch('showMessage', {
-            title: $gettext('Error while sharing.'),
-            desc: e,
-            status: 'danger'
-          }, { root: true })
+          context.dispatch(
+            'showMessage',
+            {
+              title: $gettext('Error while sharing.'),
+              desc: e,
+              status: 'danger'
+            },
+            { root: true }
+          )
         })
       return
     }
 
     const remoteShare = shareType === shareTypes.remote
-    client.shares.shareFileWithUser(path, shareWith, { permissions: permissions, remoteUser: remoteShare, expirationDate: expirationDate })
+    client.shares
+      .shareFileWithUser(path, shareWith, {
+        permissions: permissions,
+        remoteUser: remoteShare,
+        expirationDate: expirationDate
+      })
       .then(share => {
-        context.commit('CURRENT_FILE_OUTGOING_SHARES_ADD', _buildCollaboratorShare(share.shareInfo, context.getters.highlightedFile))
+        context.commit(
+          'CURRENT_FILE_OUTGOING_SHARES_ADD',
+          _buildCollaboratorShare(share.shareInfo, context.getters.highlightedFile)
+        )
         context.commit('UPDATE_CURRENT_FILE_SHARE_TYPES')
       })
       .catch(e => {
-        context.dispatch('showMessage', {
-          title: $gettext('Error while sharing.'),
-          desc: e,
-          status: 'danger'
-        }, { root: true })
+        context.dispatch(
+          'showMessage',
+          {
+            title: $gettext('Error while sharing.'),
+            desc: e,
+            status: 'danger'
+          },
+          { root: true }
+        )
       })
   },
-  deleteShare (context, { client, share }) {
-    client.shares.deleteShare(share.id)
+  deleteShare(context, { client, share }) {
+    client.shares
+      .deleteShare(share.id)
       .then(() => {
         context.commit('CURRENT_FILE_OUTGOING_SHARES_REMOVE', share)
         context.commit('UPDATE_CURRENT_FILE_SHARE_TYPES')
@@ -724,14 +816,14 @@ export default {
         console.log(e)
       })
   },
-  resetSearch (context) {
+  resetSearch(context) {
     context.commit('SET_SEARCH_TERM', '')
   },
   /**
    * Prune all branches of the shares tree that are
    * unrelated to the given path
    */
-  pruneSharesTreeOutsidePath (context, path) {
+  pruneSharesTreeOutsidePath(context, path) {
     context.commit('SHARESTREE_PRUNE_OUTSIDE_PATH', path)
   },
   /**
@@ -739,7 +831,7 @@ export default {
    * This will add new entries into the shares tree and will
    * not remove unrelated existing ones.
    */
-  loadSharesTree (context, { client, path, $gettext }) {
+  loadSharesTree(context, { client, path, $gettext }) {
     context.commit('SHARESTREE_ERROR', null)
     // prune shares tree cache for all unrelated paths, keeping only
     // existing relevant parent entries
@@ -759,40 +851,54 @@ export default {
 
     const shareQueriesQueue = new PQueue({ concurrency: 2 })
     const shareQueriesPromises = []
-    parentPaths.forEach((queryPath) => {
+    parentPaths.forEach(queryPath => {
       // skip already cached paths
       if (context.getters.sharesTree[queryPath]) {
         return Promise.resolve()
       }
       sharesTree[queryPath] = []
       // query the outgoing share information for each of the parent paths
-      shareQueriesPromises.push(shareQueriesQueue.add(() =>
-        client.shares.getShares(queryPath, { reshares: true })
-          .then(data => {
-            data.forEach(element => {
-              sharesTree[queryPath].push({ ..._buildShare(element.shareInfo, { type: 'folder' }, $gettext), outgoing: true, indirect: true })
+      shareQueriesPromises.push(
+        shareQueriesQueue.add(() =>
+          client.shares
+            .getShares(queryPath, { reshares: true })
+            .then(data => {
+              data.forEach(element => {
+                sharesTree[queryPath].push({
+                  ..._buildShare(element.shareInfo, { type: 'folder' }, $gettext),
+                  outgoing: true,
+                  indirect: true
+                })
+              })
             })
-          })
-          .catch(error => {
-            console.error('SHARESTREE_ERROR', error)
-            context.commit('SHARESTREE_ERROR', error.message)
-            context.commit('SHARESTREE_LOADING', false)
-          })
-      ))
+            .catch(error => {
+              console.error('SHARESTREE_ERROR', error)
+              context.commit('SHARESTREE_ERROR', error.message)
+              context.commit('SHARESTREE_LOADING', false)
+            })
+        )
+      )
       // query the incoming share information for each of the parent paths
-      shareQueriesPromises.push(shareQueriesQueue.add(() =>
-        client.shares.getShares(queryPath, { shared_with_me: true })
-          .then(data => {
-            data.forEach(element => {
-              sharesTree[queryPath].push({ ..._buildCollaboratorShare(element.shareInfo, { type: 'folder' }), incoming: true, indirect: true })
+      shareQueriesPromises.push(
+        shareQueriesQueue.add(() =>
+          client.shares
+            .getShares(queryPath, { shared_with_me: true })
+            .then(data => {
+              data.forEach(element => {
+                sharesTree[queryPath].push({
+                  ..._buildCollaboratorShare(element.shareInfo, { type: 'folder' }),
+                  incoming: true,
+                  indirect: true
+                })
+              })
             })
-          })
-          .catch(error => {
-            console.error('SHARESTREE_ERROR', error)
-            context.commit('SHARESTREE_ERROR', error.message)
-            context.commit('SHARESTREE_LOADING', false)
-          })
-      ))
+            .catch(error => {
+              console.error('SHARESTREE_ERROR', error)
+              context.commit('SHARESTREE_ERROR', error.message)
+              context.commit('SHARESTREE_LOADING', false)
+            })
+        )
+      )
     })
 
     return Promise.all(shareQueriesPromises).then(() => {
@@ -800,40 +906,41 @@ export default {
       context.commit('SHARESTREE_LOADING', false)
     })
   },
-  dragOver (context, value) {
+  dragOver(context, value) {
     context.commit('DRAG_OVER', value)
   },
-  setTrashbinDeleteMessage (context, message) {
+  setTrashbinDeleteMessage(context, message) {
     context.commit('SET_TRASHBIN_DELETE_CONFIRMATION', message)
   },
-  promptFileRename (context, item) {
+  promptFileRename(context, item) {
     context.commit('PROMPT_FILE_RENAME', item)
   },
-  closePromptFileRename (context) {
+  closePromptFileRename(context) {
     context.commit('CLOSE_PROMPT_FILE_RENAME')
   },
-  promptFileDelete (context, { message, items }) {
+  promptFileDelete(context, { message, items }) {
     context.commit('PROMPT_FILE_DELETE', { message, items })
   },
-  closePromptFileDelete (context) {
+  closePromptFileDelete(context) {
     context.commit('CLOSE_PROMPT_FILE_DELETE')
   },
-  setOverwriteDialogTitle (context, title) {
+  setOverwriteDialogTitle(context, title) {
     context.commit('SET_OVERWRITE_DIALOG_TITLE', title)
   },
-  setOverwriteDialogMessage (context, message) {
+  setOverwriteDialogMessage(context, message) {
     context.commit('SET_OVERWRITE_DIALOG_MESSAGE', message)
   },
-  setHighlightedFile (context, file) {
+  setHighlightedFile(context, file) {
     context.commit('SET_HIGHLIGHTED_FILE', file)
   },
-  setPublicLinkPassword (context, password) {
+  setPublicLinkPassword(context, password) {
     context.commit('SET_PUBLIC_LINK_PASSWORD', password)
   },
 
-  addLink (context, { path, client, $gettext, params }) {
+  addLink(context, { path, client, $gettext, params }) {
     return new Promise((resolve, reject) => {
-      client.shares.shareFileWithLink(path, params)
+      client.shares
+        .shareFileWithLink(path, params)
         .then(data => {
           const link = _buildShare(data.shareInfo, null, $gettext)
           context.commit('CURRENT_FILE_OUTGOING_SHARES_ADD', link)
@@ -845,9 +952,10 @@ export default {
         })
     })
   },
-  updateLink (context, { id, client, $gettext, params }) {
+  updateLink(context, { id, client, $gettext, params }) {
     return new Promise((resolve, reject) => {
-      client.shares.updateShare(id, params)
+      client.shares
+        .updateShare(id, params)
         .then(data => {
           const link = _buildShare(data.shareInfo, null, $gettext)
           context.commit('CURRENT_FILE_OUTGOING_SHARES_UPDATE', link)
@@ -858,8 +966,9 @@ export default {
         })
     })
   },
-  removeLink (context, { share, client }) {
-    client.shares.deleteShare(share.id)
+  removeLink(context, { share, client }) {
+    client.shares
+      .deleteShare(share.id)
       .then(() => {
         context.commit('CURRENT_FILE_OUTGOING_SHARES_REMOVE', share)
         context.commit('UPDATE_CURRENT_FILE_SHARE_TYPES')
@@ -868,13 +977,14 @@ export default {
   },
 
   // TODO: Think of a better name
-  pendingShare (context, { client, item, type, $gettext }) {
+  pendingShare(context, { client, item, type, $gettext }) {
     // TODO: Move request to owncloud-sdk
-    client.requests.ocs({
-      service: 'apps/files_sharing',
-      action: `/api/v1/shares/pending/${item.shareId}`,
-      method: type
-    })
+    client.requests
+      .ocs({
+        service: 'apps/files_sharing',
+        action: `/api/v1/shares/pending/${item.shareId}`,
+        method: type
+      })
       .then(_ => {
         context.dispatch('loadFolderSharedWithMe', {
           client: client,
@@ -882,19 +992,23 @@ export default {
         })
       })
       .catch(e => {
-        context.dispatch('showMessage', {
-          title: $gettext('Error while changing share state'),
-          desc: e.message,
-          status: 'danger'
-        }, { root: true })
+        context.dispatch(
+          'showMessage',
+          {
+            title: $gettext('Error while changing share state'),
+            desc: e.message,
+            status: 'danger'
+          },
+          { root: true }
+        )
       })
   },
 
-  addActionToProgress ({ commit }, item) {
+  addActionToProgress({ commit }, item) {
     commit('ADD_ACTION_TO_PROGRESS', item)
   },
 
-  removeActionFromProgress ({ commit }, item) {
+  removeActionFromProgress({ commit }, item) {
     commit('REMOVE_ACTION_FROM_PROGRESS', item)
   }
 }

--- a/apps/files/src/store/getters.js
+++ b/apps/files/src/store/getters.js
@@ -33,7 +33,7 @@ export default {
     const files = state.searchTermGlobal ? state.filesSearched : state.files
     // make a copy of array for sorting as sort() would modify the original array
     const direction = state.fileSortDirectionDesc ? 'desc' : 'asc'
-    return ([].concat(files)).sort(fileSortFunctions[state.fileSortField][direction])
+    return [].concat(files).sort(fileSortFunctions[state.fileSortField][direction])
   },
   filesTotalSize: (state, getters) => {
     let totalSize = 0

--- a/apps/files/src/store/mutations.js
+++ b/apps/files/src/store/mutations.js
@@ -5,7 +5,7 @@ import _ from 'lodash'
  * @param {Array.<Object>} shares array of shares
  * @return {Array.<Integer>} array of share types
  */
-function computeShareTypes (shares) {
+function computeShareTypes(shares) {
   const shareTypes = new Set()
   shares.forEach(share => {
     shareTypes.add(share.shareType)
@@ -14,8 +14,8 @@ function computeShareTypes (shares) {
 }
 
 export default {
-  UPDATE_FILE_PROGRESS (state, file) {
-    const fileIndex = state.inProgress.findIndex((f) => {
+  UPDATE_FILE_PROGRESS(state, file) {
+    const fileIndex = state.inProgress.findIndex(f => {
       return f.id === file.id
     })
 
@@ -24,7 +24,7 @@ export default {
     state.inProgress[fileIndex].progress = file.progress
   },
 
-  ADD_FILE_TO_PROGRESS (state, file) {
+  ADD_FILE_TO_PROGRESS(state, file) {
     state.inProgress.push({
       id: file.id,
       name: file.name,
@@ -35,8 +35,8 @@ export default {
     })
   },
 
-  REMOVE_FILE_FROM_PROGRESS (state, file) {
-    const fileIndex = state.inProgress.findIndex((f) => {
+  REMOVE_FILE_FROM_PROGRESS(state, file) {
+    const fileIndex = state.inProgress.findIndex(f => {
       return f.id === file.id
     })
 
@@ -51,62 +51,62 @@ export default {
     state.uploaded.push(file)
   },
 
-  LOAD_FILES (state, { currentFolder, files }) {
+  LOAD_FILES(state, { currentFolder, files }) {
     state.currentFolder = currentFolder
     state.files = files
   },
-  LOAD_FILES_SEARCHED (state, files) {
+  LOAD_FILES_SEARCHED(state, files) {
     state.filesSearched = files
   },
-  SET_FILES_SORT (state, { field, directionIsDesc }) {
+  SET_FILES_SORT(state, { field, directionIsDesc }) {
     state.fileSortDirectionDesc = directionIsDesc
     state.fileSortField = field
   },
-  ADD_FILE_SELECTION (state, file) {
-    const fileIndex = state.selected.findIndex((f) => {
+  ADD_FILE_SELECTION(state, file) {
+    const fileIndex = state.selected.findIndex(f => {
       return f.id === file.id
     })
     if (fileIndex === -1) {
       state.selected.push(file)
     }
   },
-  REMOVE_FILE_SELECTION (state, file) {
+  REMOVE_FILE_SELECTION(state, file) {
     if (state.selected.length > 1) {
       state.selected = state.selected.filter(i => ![file].includes(i))
       return
     }
     state.selected = []
   },
-  RESET_SELECTION (state) {
+  RESET_SELECTION(state) {
     state.selected = []
   },
-  FAVORITE_FILE (state, item) {
-    const fileIndex = state.files.findIndex((f) => {
+  FAVORITE_FILE(state, item) {
+    const fileIndex = state.files.findIndex(f => {
       return f.id === item.id
     })
     state.files[fileIndex].starred = !item.starred
   },
-  ADD_FILE (state, file) {
+  ADD_FILE(state, file) {
     state.files = state.files.filter(i => file.id !== i.id)
     state.files.push(file)
   },
-  REMOVE_FILE (state, file) {
+  REMOVE_FILE(state, file) {
     state.files = state.files.filter(i => ![file].includes(i))
   },
-  SET_SEARCH_TERM (state, searchTerm) {
+  SET_SEARCH_TERM(state, searchTerm) {
     state.searchTermGlobal = searchTerm
   },
-  UPDATE_CURRENT_FILE_SHARE_TYPES (state) {
+  UPDATE_CURRENT_FILE_SHARE_TYPES(state) {
     if (!state.highlightedFile) {
       return
     }
-    const fileIndex = state.files.findIndex((f) => {
+    const fileIndex = state.files.findIndex(f => {
       return f.id === state.highlightedFile.id
     })
     state.files[fileIndex].shareTypes = computeShareTypes(state.currentFileOutgoingShares)
   },
-  RENAME_FILE (state, { file, newValue, newPath }) {
-    const fileIndex = state.files.findIndex((f) => {
+  RENAME_FILE(state, { file, newValue, newPath }) {
+    const fileIndex = state.files.findIndex(f => {
       return f.id === file.id
     })
     let ext = ''
@@ -125,20 +125,20 @@ export default {
     state.files[fileIndex].extension = ext
     state.files[fileIndex].path = '/' + newPath + newValue
   },
-  DRAG_OVER (state, value) {
+  DRAG_OVER(state, value) {
     state.dropzone = value
   },
-  CURRENT_FILE_OUTGOING_SHARES_SET (state, shares) {
+  CURRENT_FILE_OUTGOING_SHARES_SET(state, shares) {
     state.currentFileOutgoingShares = shares
   },
-  CURRENT_FILE_OUTGOING_SHARES_ADD (state, share) {
+  CURRENT_FILE_OUTGOING_SHARES_ADD(state, share) {
     state.currentFileOutgoingShares.push(share)
   },
-  CURRENT_FILE_OUTGOING_SHARES_REMOVE (state, share) {
+  CURRENT_FILE_OUTGOING_SHARES_REMOVE(state, share) {
     state.currentFileOutgoingShares = state.currentFileOutgoingShares.filter(s => share.id !== s.id)
   },
-  CURRENT_FILE_OUTGOING_SHARES_UPDATE (state, share) {
-    const fileIndex = state.currentFileOutgoingShares.findIndex((s) => {
+  CURRENT_FILE_OUTGOING_SHARES_UPDATE(state, share) {
+    const fileIndex = state.currentFileOutgoingShares.findIndex(s => {
       return s.id === share.id
     })
     if (fileIndex >= 0) {
@@ -148,24 +148,24 @@ export default {
       state.currentFileOutgoingShares.push(share)
     }
   },
-  CURRENT_FILE_OUTGOING_SHARES_ERROR (state, error) {
+  CURRENT_FILE_OUTGOING_SHARES_ERROR(state, error) {
     state.currentFileOutgoingShares = []
     state.currentFileOutgoingSharesError = error
   },
-  CURRENT_FILE_OUTGOING_SHARES_LOADING (state, loading) {
+  CURRENT_FILE_OUTGOING_SHARES_LOADING(state, loading) {
     state.currentFileOutgoingSharesLoading = loading
   },
-  INCOMING_SHARES_LOAD (state, shares) {
+  INCOMING_SHARES_LOAD(state, shares) {
     state.incomingShares = shares
   },
-  INCOMING_SHARES_ERROR (state, error) {
+  INCOMING_SHARES_ERROR(state, error) {
     state.incomingShares = []
     state.incomingSharesError = error
   },
-  INCOMING_SHARES_LOADING (state, loading) {
+  INCOMING_SHARES_LOADING(state, loading) {
     state.incomingSharesLoading = loading
   },
-  SHARESTREE_PRUNE_OUTSIDE_PATH (state, pathToKeep) {
+  SHARESTREE_PRUNE_OUTSIDE_PATH(state, pathToKeep) {
     if (pathToKeep !== '' && pathToKeep !== '/') {
       // clear all children unrelated to the given path
       //
@@ -189,55 +189,55 @@ export default {
       state.sharesTree = {}
     }
   },
-  SHARESTREE_ADD (state, sharesTree) {
+  SHARESTREE_ADD(state, sharesTree) {
     Object.assign(state.sharesTree, sharesTree)
   },
-  SHARESTREE_ERROR (state, error) {
+  SHARESTREE_ERROR(state, error) {
     state.sharesTreeError = error
   },
-  SHARESTREE_LOADING (state, loading) {
+  SHARESTREE_LOADING(state, loading) {
     state.sharesTreeLoading = loading
   },
-  UPDATE_FOLDER_LOADING (state, value) {
+  UPDATE_FOLDER_LOADING(state, value) {
     state.loadingFolder = value
   },
-  CHECK_QUOTA (state, quota) {
+  CHECK_QUOTA(state, quota) {
     state.quota = quota
   },
-  SET_TRASHBIN_DELETE_CONFIRMATION (state, message) {
+  SET_TRASHBIN_DELETE_CONFIRMATION(state, message) {
     state.trashbinDeleteMessage = message
   },
-  PROMPT_FILE_RENAME (state, file) {
+  PROMPT_FILE_RENAME(state, file) {
     state.renameDialogOpen = true
     state.renameDialogOriginalName = file.name
     state.renameDialogSelectedFile = file
     state.renameDialogNewName = file.name
   },
-  CLOSE_PROMPT_FILE_RENAME (state) {
+  CLOSE_PROMPT_FILE_RENAME(state) {
     state.renameDialogOpen = false
     state.renameDialogOriginalName = null
     state.renameDialogSelectedFile = null
     state.renameDialogNewName = null
   },
-  PROMPT_FILE_DELETE (state, { message, items }) {
+  PROMPT_FILE_DELETE(state, { message, items }) {
     state.deleteDialogOpen = true
     state.deleteDialogSelectedFiles = items
     state.deleteDialogMessage = message
   },
-  CLOSE_PROMPT_FILE_DELETE (state, item) {
+  CLOSE_PROMPT_FILE_DELETE(state, item) {
     state.deleteDialogOpen = false
     state.deleteDialogSelectedFiles = null
     state.deleteDialogMessage = null
   },
-  SET_OVERWRITE_DIALOG_TITLE (state, title) {
+  SET_OVERWRITE_DIALOG_TITLE(state, title) {
     state.overwriteDialogTitle = title
   },
-  SET_OVERWRITE_DIALOG_MESSAGE (state, message) {
+  SET_OVERWRITE_DIALOG_MESSAGE(state, message) {
     state.overwriteDialogMessage = message
   },
-  SET_HIGHLIGHTED_FILE (state, file) {
+  SET_HIGHLIGHTED_FILE(state, file) {
     if (typeof file === 'string') {
-      const fileIndex = state.files.findIndex((f) => {
+      const fileIndex = state.files.findIndex(f => {
         return f.name === file
       })
       if (fileIndex === -1) {
@@ -247,15 +247,15 @@ export default {
     }
     state.highlightedFile = file
   },
-  SET_PUBLIC_LINK_PASSWORD (state, password) {
+  SET_PUBLIC_LINK_PASSWORD(state, password) {
     state.publicLinkPassword = password
   },
 
-  ADD_ACTION_TO_PROGRESS (state, item) {
+  ADD_ACTION_TO_PROGRESS(state, item) {
     state.actionsInProgress.push(item)
   },
 
-  REMOVE_ACTION_FROM_PROGRESS (state, item) {
+  REMOVE_ACTION_FROM_PROGRESS(state, item) {
     const itemIndex = state.actionsInProgress.findIndex(i => {
       return i === item
     })
@@ -263,7 +263,7 @@ export default {
     state.actionsInProgress.splice(itemIndex, 1)
   },
 
-  CLEAR_CURRENT_FILES_LIST (state) {
+  CLEAR_CURRENT_FILES_LIST(state) {
     state.currentFolder = null
     // release blob urls
     state.files.forEach(item => {

--- a/apps/markdown-editor/src/MarkdownEditor.vue
+++ b/apps/markdown-editor/src/MarkdownEditor.vue
@@ -3,17 +3,22 @@
     <markdown-editor-app-bar />
     <oc-notifications>
       <oc-notification-message
-              v-if="lastError"
-              :message="lastError"
-              status="danger"
-              @close="clearLastError"
+        v-if="lastError"
+        :message="lastError"
+        status="danger"
+        @close="clearLastError"
       />
     </oc-notifications>
     <div class="uk-flex">
       <div class="uk-container uk-width-1-2">
-        <oc-textarea name="input"
-                full-width :value="currentContent"
-                @input="onType" class="uk-height-1-1" :rows="20">
+        <oc-textarea
+          name="input"
+          full-width
+          :value="currentContent"
+          class="uk-height-1-1"
+          :rows="20"
+          @input="onType"
+        >
         </oc-textarea>
       </div>
       <div class="uk-container uk-width-1-2">
@@ -35,11 +40,11 @@ export default {
   computed: {
     ...mapGetters(['activeFile']),
     ...mapGetters('MarkdownEditor', ['currentContent', 'lastError']),
-    renderedMarkdown () {
+    renderedMarkdown() {
       return this.currentContent ? marked(this.currentContent, { sanitize: true }) : null
     }
   },
-  mounted () {
+  mounted() {
     if (this.activeFile.path === '') {
       this.$router.push({
         path: '/files'
@@ -53,7 +58,7 @@ export default {
   },
   methods: {
     ...mapActions('MarkdownEditor', ['updateText', 'loadFile', 'clearLastError']),
-    onType (e) {
+    onType(e) {
       this.updateText(e)
     }
   }

--- a/apps/markdown-editor/src/MarkdownEditorAppBar.vue
+++ b/apps/markdown-editor/src/MarkdownEditorAppBar.vue
@@ -2,7 +2,7 @@
   <div id="markdown-editor-app-bar" class="oc-app-bar">
     <oc-grid flex gutter="small">
       <div class="uk-width-auto">
-        <oc-button icon="save" @click="saveContent" :disabled="!isTouched"></oc-button>
+        <oc-button icon="save" :disabled="!isTouched" @click="saveContent"></oc-button>
         <oc-spinner v-if="isLoading"></oc-spinner>
       </div>
       <div class="uk-width-expand uk-text-center">
@@ -24,12 +24,12 @@ export default {
   },
   methods: {
     ...mapActions('MarkdownEditor', ['saveFile']),
-    saveContent () {
+    saveContent() {
       this.saveFile({
         client: this.$client
       })
     },
-    closeApp () {
+    closeApp() {
       this.$router.push({
         path: '/files'
       })

--- a/apps/markdown-editor/src/app.js
+++ b/apps/markdown-editor/src/app.js
@@ -9,35 +9,38 @@ import t from '../l10n/translations'
 
 const store = require('./store.js')
 
-const routes = [{
-  path: '',
-  components: {
-    app: MarkdownEditor
-  },
-  name: 'markdown-editor'
-}]
+const routes = [
+  {
+    path: '',
+    components: {
+      app: MarkdownEditor
+    },
+    name: 'markdown-editor'
+  }
+]
 
 const appInfo = {
   name: 'MarkdownEditor',
   id: 'markdown-editor',
   icon: 'text',
   isFileEditor: true,
-  extensions: [{
-    extension: 'txt',
-    newFileMenu: {
-      menuTitle ($gettext) {
-        return $gettext('New plain text file…')
+  extensions: [
+    {
+      extension: 'txt',
+      newFileMenu: {
+        menuTitle($gettext) {
+          return $gettext('New plain text file…')
+        }
+      }
+    },
+    {
+      extension: 'md',
+      newFileMenu: {
+        menuTitle($gettext) {
+          return $gettext('New mark-down file…')
+        }
       }
     }
-  },
-  {
-    extension: 'md',
-    newFileMenu: {
-      menuTitle ($gettext) {
-        return $gettext('New mark-down file…')
-      }
-    }
-  }
   ]
 }
 

--- a/apps/markdown-editor/src/store.js
+++ b/apps/markdown-editor/src/store.js
@@ -10,20 +10,21 @@ const state = {
 }
 
 const actions = {
-  updateText ({ commit }, text) {
+  updateText({ commit }, text) {
     commit('TOUCHED', true)
     commit('UPDATE_TEXT', text)
   },
-  clearLastError ({ commit }) {
+  clearLastError({ commit }) {
     commit('ERROR', '')
   },
-  loadFile ({ commit }, payload) {
+  loadFile({ commit }, payload) {
     const filePath = payload.filePath
     const client = payload.client
 
     commit('LOADING', true)
     commit('CURRENT_FILE', filePath)
-    client.files.getFileContents(filePath, { resolveWithResponseObject: true })
+    client.files
+      .getFileContents(filePath, { resolveWithResponseObject: true })
       .then(resp => {
         commit('CURRENT_ETAG', resp.headers.ETag)
         commit('UPDATE_TEXT', resp.body)
@@ -34,40 +35,43 @@ const actions = {
         commit('LOADING', false)
       })
   },
-  saveFile ({ commit, state }, payload) {
+  saveFile({ commit, state }, payload) {
     commit('LOADING', true)
-    payload.client.files.putFileContents(state.currentFile, state.text, {
-      previousEntityTag: state.currentETag
-    }).then((resp) => {
-      commit('CURRENT_ETAG', resp.ETag)
+    payload.client.files
+      .putFileContents(state.currentFile, state.text, {
+        previousEntityTag: state.currentETag
+      })
+      .then(resp => {
+        commit('CURRENT_ETAG', resp.ETag)
 
-      // get etag & update
-      commit('TOUCHED', false)
-      commit('LOADING', false)
-    }).catch(error => {
-      commit('ERROR', error.message || error)
-      commit('LOADING', false)
-    })
+        // get etag & update
+        commit('TOUCHED', false)
+        commit('LOADING', false)
+      })
+      .catch(error => {
+        commit('ERROR', error.message || error)
+        commit('LOADING', false)
+      })
   }
 }
 
 const mutations = {
-  TOUCHED (state, flag) {
+  TOUCHED(state, flag) {
     state.touched = flag
   },
-  LOADING (state, loading) {
+  LOADING(state, loading) {
     state.loading = loading
   },
-  UPDATE_TEXT (state, text) {
+  UPDATE_TEXT(state, text) {
     state.text = text
   },
-  CURRENT_ETAG (state, etag) {
+  CURRENT_ETAG(state, etag) {
     state.currentETag = etag
   },
-  CURRENT_FILE (state, filePath) {
+  CURRENT_FILE(state, filePath) {
     state.currentFile = filePath
   },
-  ERROR (state, errorMessage) {
+  ERROR(state, errorMessage) {
     state.lastError = errorMessage
   }
 }

--- a/apps/media-viewer/src/Mediaviewer.vue
+++ b/apps/media-viewer/src/Mediaviewer.vue
@@ -1,23 +1,71 @@
 <template>
   <div id="mediaviewer" class="uk-position-relative">
     <div class="uk-position-center uk-padding-small">
-      <transition name="custom-classes-transition" :enter-active-class="activeClass.enter" :leave-active-class="activeClass.leave">
-        <img v-show="!loading && activeMediaFileCached" :src="image.url" :alt="image.name" :data-id="image.id" style="max-width:90vw;max-height:90vh" class="uk-box-shadow-medium">
+      <transition
+        name="custom-classes-transition"
+        :enter-active-class="activeClass.enter"
+        :leave-active-class="activeClass.leave"
+      >
+        <img
+          v-show="!loading && activeMediaFileCached"
+          :src="image.url"
+          :alt="image.name"
+          :data-id="image.id"
+          style="max-width:90vw;max-height:90vh"
+          class="uk-box-shadow-medium"
+        />
       </transition>
     </div>
-    <oc-spinner :ariaLabel="this.$gettext('Loading media')" class="uk-position-center" v-if="loading" size="large" />
-    <oc-icon v-if="failed" name="review" variation="danger" size="large" class="uk-position-center uk-z-index" />
+    <oc-spinner
+      v-if="loading"
+      :aria-label="this.$gettext('Loading media')"
+      class="uk-position-center"
+      size="large"
+    />
+    <oc-icon
+      v-if="failed"
+      name="review"
+      variation="danger"
+      size="large"
+      class="uk-position-center uk-z-index"
+    />
 
     <div class="uk-position-medium uk-position-bottom-center">
-      <div class="uk-overlay uk-overlay-default uk-padding-small uk-text-center uk-text-meta uk-text-truncate">{{ image.name }}</div>
+      <div
+        class="uk-overlay uk-overlay-default uk-padding-small uk-text-center uk-text-meta uk-text-truncate"
+      >
+        {{ image.name }}
+      </div>
       <div class="uk-overlay uk-overlay-primary uk-light uk-padding-small">
-        <div class="uk-width-large uk-flex uk-flex-middle uk-flex-center uk-flex-around" style="user-select:none;">
-          <oc-icon role="button" class="oc-cursor-pointer" size="medium" @click="prev" name="chevron_left" />
+        <div
+          class="uk-width-large uk-flex uk-flex-middle uk-flex-center uk-flex-around"
+          style="user-select:none;"
+        >
+          <oc-icon
+            role="button"
+            class="oc-cursor-pointer"
+            size="medium"
+            name="chevron_left"
+            @click="prev"
+          />
           <!-- @TODO: Bring back working uk-light -->
-          <span v-if="!$_loader_folderLoading" class="uk-text-small" style="color:#fff"> {{ activeIndex + 1 }} <span v-translate>of</span> {{ mediaFiles.length }} </span>
-          <oc-icon role="button" class="oc-cursor-pointer" size="medium" @click="next" name="chevron_right" />
-          <oc-icon role="button" class="oc-cursor-pointer" @click="downloadImage" name="file_download"  />
-          <oc-icon role="button" class="oc-cursor-pointer" @click="closeApp" name="close"/>
+          <span v-if="!$_loader_folderLoading" class="uk-text-small" style="color:#fff">
+            {{ activeIndex + 1 }} <span v-translate>of</span> {{ mediaFiles.length }}
+          </span>
+          <oc-icon
+            role="button"
+            class="oc-cursor-pointer"
+            size="medium"
+            name="chevron_right"
+            @click="next"
+          />
+          <oc-icon
+            role="button"
+            class="oc-cursor-pointer"
+            name="file_download"
+            @click="downloadImage"
+          />
+          <oc-icon role="button" class="oc-cursor-pointer" name="close" @click="closeApp" />
         </div>
       </div>
     </div>
@@ -29,10 +77,8 @@ import Loader from './mixins/loader.js'
 
 export default {
   name: 'Mediaviewer',
-  mixins: [
-    Loader
-  ],
-  data () {
+  mixins: [Loader],
+  data() {
     return {
       loading: true,
       failed: false,
@@ -52,38 +98,45 @@ export default {
     ...mapGetters('Files', ['activeFiles']),
     ...mapGetters(['getToken']),
 
-    mediaFiles () {
+    mediaFiles() {
       return this.activeFiles.filter(file => {
         return file.extension.toLowerCase().match(/(png|jpg|jpeg|gif)/)
       })
     },
-    activeMediaFile () {
+    activeMediaFile() {
       return this.mediaFiles[this.activeIndex]
     },
-    activeMediaFileCached () {
+    activeMediaFileCached() {
       const cached = this.images.find(i => i.id === this.activeMediaFile.id)
-      return (cached !== undefined) ? cached : false
+      return cached !== undefined ? cached : false
     },
-    activeClass () {
+    activeClass() {
       const direction = ['right', 'left']
 
-      if (this.direction === 'ltr') { direction.reverse() }
+      if (this.direction === 'ltr') {
+        direction.reverse()
+      }
 
       return {
         enter: `uk-animation-slide-${direction[0]}-small`,
         leave: `uk-animation-slide-${direction[1]}-medium uk-animation-reverse`
       }
     },
-    thumbDimensions () {
+    thumbDimensions() {
       switch (true) {
-        case (window.innerWidth <= 1024) : return 1024
-        case (window.innerWidth <= 1280) : return 1280
-        case (window.innerWidth <= 1920) : return 1920
-        case (window.innerWidth <= 2160) : return 2160
-        default: return 3840
+        case window.innerWidth <= 1024:
+          return 1024
+        case window.innerWidth <= 1280:
+          return 1280
+        case window.innerWidth <= 1920:
+          return 1920
+        case window.innerWidth <= 2160:
+          return 2160
+        default:
+          return 3840
       }
     },
-    thumbPath () {
+    thumbPath() {
       const query = {
         x: this.thumbDimensions,
         y: this.thumbDimensions,
@@ -99,14 +152,14 @@ export default {
   },
 
   watch: {
-    activeIndex (o, n) {
+    activeIndex(o, n) {
       if (o !== n) {
         this.loadImage()
       }
     }
   },
 
-  async mounted () {
+  async mounted() {
     document.addEventListener('keyup', this.handleKeyPress)
 
     // keep a local history for this component
@@ -117,7 +170,7 @@ export default {
     this.setCurrentFile(filePath)
   },
 
-  beforeDestroy () {
+  beforeDestroy() {
     document.removeEventListener('keyup', this.handleKeyPress)
 
     window.removeEventListener('popstate', this.handleLocalHistoryEvent)
@@ -128,7 +181,7 @@ export default {
   },
 
   methods: {
-    setCurrentFile (filePath) {
+    setCurrentFile(filePath) {
       for (let i = 0; i < this.mediaFiles.length; i++) {
         if (this.mediaFiles[i].path === filePath) {
           this.activeIndex = i
@@ -138,67 +191,75 @@ export default {
     },
 
     // react to PopStateEvent ()
-    handleLocalHistoryEvent () {
+    handleLocalHistoryEvent() {
       const result = this.$router.resolve(document.location)
       this.setCurrentFile(result.route.params.filePath)
     },
 
     // update route and url
-    updateLocalHistory () {
+    updateLocalHistory() {
       this.$route.params.filePath = this.activeMediaFile.path
       history.pushState({}, document.title, this.$router.resolve(this.$route).href)
     },
 
-    loadImage () {
+    loadImage() {
       this.loading = true
 
       // Don't bother loading if files i chached
       if (this.activeMediaFileCached) {
-        setTimeout(() => {
-          this.image = this.activeMediaFileCached
-          this.loading = false
-        },
-        // Delay to animate
-        this.animationDuration / 2)
+        setTimeout(
+          () => {
+            this.image = this.activeMediaFileCached
+            this.loading = false
+          },
+          // Delay to animate
+          this.animationDuration / 2
+        )
         return
       }
 
       // Fetch image
-      this.mediaSource(this.thumbPath, 'url', this.headers).then(imageUrl => {
-        this.images.push({
-          id: this.activeMediaFile.id,
-          name: this.activeMediaFile.name,
-          url: imageUrl
+      this.mediaSource(this.thumbPath, 'url', this.headers)
+        .then(imageUrl => {
+          this.images.push({
+            id: this.activeMediaFile.id,
+            name: this.activeMediaFile.name,
+            url: imageUrl
+          })
+          this.image = this.activeMediaFileCached
+          this.loading = false
+          this.failed = false
         })
-        this.image = this.activeMediaFileCached
-        this.loading = false
-        this.failed = false
-      }).catch(e => {
-        this.loading = false
-        this.failed = true
-      })
+        .catch(e => {
+          this.loading = false
+          this.failed = true
+        })
     },
 
-    downloadImage () {
+    downloadImage() {
       if (this.loading) {
         return
       }
 
       return this.downloadFile(this.mediaFiles[this.activeIndex], this.$_loader_publicContext)
     },
-    next () {
-      if (this.loading) { return }
+    next() {
+      if (this.loading) {
+        return
+      }
 
       this.direction = 'rtl'
-      if ((this.activeIndex + 1) >= this.mediaFiles.length) {
+      if (this.activeIndex + 1 >= this.mediaFiles.length) {
         this.activeIndex = 0
         return
       }
       this.activeIndex++
       this.updateLocalHistory()
     },
-    prev () {
-      if (this.loading) { return }
+    prev() {
+      if (this.loading) {
+        return
+      }
 
       this.direction = 'ltr'
       if (this.activeIndex === 0) {
@@ -208,15 +269,17 @@ export default {
       this.activeIndex--
       this.updateLocalHistory()
     },
-    handleKeyPress (e) {
+    handleKeyPress(e) {
       if (!e) return false
       else if (e.key === 'ArrowRight') this.next()
       else if (e.key === 'ArrowLeft') this.prev()
     },
-    closeApp () {
-      this.$_loader_navigateToContextRoute(this.$route.params.contextRouteName, this.$route.params.filePath)
+    closeApp() {
+      this.$_loader_navigateToContextRoute(
+        this.$route.params.contextRouteName,
+        this.$route.params.filePath
+      )
     }
   }
-
 }
 </script>

--- a/apps/media-viewer/src/app.js
+++ b/apps/media-viewer/src/app.js
@@ -3,32 +3,39 @@ import translationsJson from '../l10n/translations'
 
 import Mediaviewer from './Mediaviewer.vue'
 
-const routes = [{
-  path: '/:contextRouteName/:filePath',
-  components: {
-    app: Mediaviewer
-  },
-  name: 'mediaviewer/image',
-  meta: { auth: false }
-}]
+const routes = [
+  {
+    path: '/:contextRouteName/:filePath',
+    components: {
+      app: Mediaviewer
+    },
+    name: 'mediaviewer/image',
+    meta: { auth: false }
+  }
+]
 
 const appInfo = {
   name: 'Mediaviewer',
   id: 'mediaviewer',
   icon: 'image',
-  extensions: [{
-    extension: 'png',
-    routeName: 'image'
-  }, {
-    extension: 'jpg',
-    routeName: 'image'
-  }, {
-    extension: 'jpeg',
-    routeName: 'image'
-  }, {
-    extension: 'gif',
-    routeName: 'image'
-  }]
+  extensions: [
+    {
+      extension: 'png',
+      routeName: 'image'
+    },
+    {
+      extension: 'jpg',
+      routeName: 'image'
+    },
+    {
+      extension: 'jpeg',
+      routeName: 'image'
+    },
+    {
+      extension: 'gif',
+      routeName: 'image'
+    }
+  ]
 }
 
 const translations = translationsJson

--- a/apps/media-viewer/src/mixins/loader.js
+++ b/apps/media-viewer/src/mixins/loader.js
@@ -9,18 +9,18 @@ import { basename, dirname } from 'path'
 export default {
   computed: {
     ...mapGetters('Files', ['publicLinkPassword']),
-    $_loader_publicContext () {
+    $_loader_publicContext() {
       // TODO: Can we rely on not being "authenticated" while viewing a public link?
       // Currently it works. We cannot use publicPage() because that will still return
       // true when opening the mediaviewer from authenticated routes
       return !this.isAuthenticated
     },
-    $_loader_folderLoading () {
+    $_loader_folderLoading() {
       return this.$_internal_loader_folderLoading
     }
   },
 
-  data () {
+  data() {
     return {
       $_internal_loader_folderLoading: true
     }
@@ -30,7 +30,7 @@ export default {
     ...mapActions('Files', ['loadFolder']),
 
     // This methods ensures the folder is loaded if we don't have a folder loaded currently
-    async $_loader_loadFolder (contextRouteName, filePath) {
+    $_loader_loadFolder(contextRouteName, filePath) {
       // FIXME: handle public-files with passwords and everything, until then we redirect to the main public link page
       if (this.$store.getters.activeFile.path === '' && contextRouteName === 'public-files') {
         const path = this.$route.params.filePath.substring(1)
@@ -56,56 +56,47 @@ export default {
           $gettext: this.$gettext,
           routeName: contextRouteName,
           loadSharesTree: !this.publicPage()
-        }).then(() => {
-          this.$data.$_internal_loader_folderLoading = false
-        }).catch((error) => {
-          // FIXME: Loading of public link folders doesn't work at all and is disabled hence, so this code should be unreachable
-
-          // // password for public link shares is missing -> this is handled on the caller side
-          // if (this.$_loader_publicContext && error.statusCode === 401) {
-          //   this.$router.push({
-          //     name: 'public-link',
-          //     params: {
-          //       token: this.$route.params.item
-          //     }
-          //   })
-          //   return
-          // }
-
-          this.showMessage({
-            title: this.$gettext('Loading folder failed…'),
-            desc: error.message,
-            status: 'danger'
-          })
         })
+          .then(() => {
+            this.$data.$_internal_loader_folderLoading = false
+          })
+          .catch(error => {
+            // FIXME: Loading of public link folders doesn't work at all and is disabled hence, so this code should be unreachable
+
+            // // password for public link shares is missing -> this is handled on the caller side
+            // if (this.$_loader_publicContext && error.statusCode === 401) {
+            //   this.$router.push({
+            //     name: 'public-link',
+            //     params: {
+            //       token: this.$route.params.item
+            //     }
+            //   })
+            //   return
+            // }
+
+            this.showMessage({
+              title: this.$gettext('Loading folder failed…'),
+              desc: error.message,
+              status: 'danger'
+            })
+          })
       }
 
       // folder already loaded, nothing to do …
       this.$data.$_internal_loader_folderLoading = false
     },
 
-    $_loader_getDavFilePath (filePath, query) {
-      let path = [
-        '..',
-        'dav',
-        'public-files',
-        filePath
-      ].join('/')
+    $_loader_getDavFilePath(filePath, query) {
+      let path = ['..', 'dav', 'public-files', filePath].join('/')
 
       if (!this.$_loader_publicContext) {
-        path = [
-          '..',
-          'dav',
-          'files',
-          this.$store.getters.user.id,
-          filePath
-        ].join('/')
+        path = ['..', 'dav', 'files', this.$store.getters.user.id, filePath].join('/')
       }
 
       return this.$client.files.getFileUrl(path) + '?' + queryString.stringify(query)
     },
 
-    $_loader_headers () {
+    $_loader_headers() {
       if (!this.$_loader_publicContext) {
         return null
       }
@@ -115,12 +106,15 @@ export default {
 
       const password = this.publicLinkPassword
       if (password) {
-        headers.append('Authorization', 'Basic ' + Buffer.from('public:' + password).toString('base64'))
+        headers.append(
+          'Authorization',
+          'Basic ' + Buffer.from('public:' + password).toString('base64')
+        )
       }
       return headers
     },
 
-    $_loader_navigateToContextRoute (contextRouteName, filePath) {
+    $_loader_navigateToContextRoute(contextRouteName, filePath) {
       this.$router.push({
         name: contextRouteName,
         params: {

--- a/apps/pdf-viewer/src/PdfViewer.vue
+++ b/apps/pdf-viewer/src/PdfViewer.vue
@@ -2,7 +2,13 @@
   <div id="pdf-viewer">
     <pdf-viewer-app-bar />
     <oc-progress v-if="loading" :max="100" indeterminate></oc-progress>
-    <pdf v-if="!loading" :page="currentPage" @error="error" @num-pages="loadPages" :src="content"></pdf>
+    <pdf
+      v-if="!loading"
+      :page="currentPage"
+      :src="content"
+      @error="error"
+      @num-pages="loadPages"
+    ></pdf>
   </div>
 </template>
 <script>
@@ -24,11 +30,11 @@ export default {
   computed: {
     ...mapGetters(['getToken', 'activeFile']),
     ...mapGetters('PDFViewer', ['currentPage']),
-    loading () {
+    loading() {
       return this.content === ''
     }
   },
-  mounted () {
+  mounted() {
     if (this.activeFile.path === '') {
       this.closeApp()
       return
@@ -53,12 +59,12 @@ export default {
   methods: {
     ...mapActions('PDFViewer', ['loadPages', 'changePage']),
     ...mapActions(['showMessage']),
-    closeApp () {
+    closeApp() {
       this.$router.push({
         path: '/files'
       })
     },
-    error (error) {
+    error(error) {
       this.showMessage({
         title: this.$gettext('PDF could not be loaded…'),
         desc: error,

--- a/apps/pdf-viewer/src/PdfViewerAppBar.vue
+++ b/apps/pdf-viewer/src/PdfViewerAppBar.vue
@@ -4,8 +4,10 @@
       <div class="uk-width-expand">
         <oc-icon name="application-pdf" /> {{ activeFile.path.substr(1) }}
       </div>
-      <div class="uk-width-auto" v-if="!loading">
-        <oc-text-input v-model.number="page" type="number" :min="1" :max="pageCount" />&nbsp;/{{ pageCount }}
+      <div v-if="!loading" class="uk-width-auto">
+        <oc-text-input v-model.number="page" type="number" :min="1" :max="pageCount" />&nbsp;/{{
+          pageCount
+        }}
       </div>
       <div class="uk-width-auto">
         <oc-button icon="close" @click="closeApp"></oc-button>
@@ -17,26 +19,25 @@
 // TODO put active Page and max Pages into store
 import { mapGetters, mapActions } from 'vuex'
 export default {
-  data: () => ({
-  }),
+  data: () => ({}),
   computed: {
     ...mapGetters(['activeFile']),
     ...mapGetters('PDFViewer', ['pageCount', 'currentPage']),
     page: {
-      get () {
+      get() {
         return this.currentPage
       },
-      set (val) {
+      set(val) {
         this.changePage(val)
       }
     },
-    loading () {
+    loading() {
       return this.content === ''
     }
   },
   methods: {
     ...mapActions('PDFViewer', ['changePage']),
-    closeApp () {
+    closeApp() {
       this.$router.push({
         path: '/files/list'
       })

--- a/apps/pdf-viewer/src/app.js
+++ b/apps/pdf-viewer/src/app.js
@@ -8,22 +8,25 @@ const PdfViewer = () => ({
   component: pdf
 })
 
-const routes = [{
-  path: '/pdf-viewer',
-  components: {
-    app: PdfViewer
-  },
-  name: 'pdf-viewer'
-}]
+const routes = [
+  {
+    path: '/pdf-viewer',
+    components: {
+      app: PdfViewer
+    },
+    name: 'pdf-viewer'
+  }
+]
 
 const appInfo = {
   name: 'PDFViewer',
   id: 'pdf-viewer',
   icon: 'application-pdf',
   isFileEditor: true,
-  extensions: [{
-    extension: 'pdf'
-  }
+  extensions: [
+    {
+      extension: 'pdf'
+    }
   ]
 }
 

--- a/apps/pdf-viewer/src/store.js
+++ b/apps/pdf-viewer/src/store.js
@@ -6,19 +6,19 @@ const state = {
 }
 
 const actions = {
-  loadPages ({ commit }, pages) {
+  loadPages({ commit }, pages) {
     commit('LOAD_PAGES', pages)
   },
-  changePage ({ commit }, page) {
+  changePage({ commit }, page) {
     commit('CHANGE_PAGE', page)
   }
 }
 
 const mutations = {
-  CHANGE_PAGE (state, page) {
+  CHANGE_PAGE(state, page) {
     state.activePage = page
   },
-  LOAD_PAGES (state, pages) {
+  LOAD_PAGES(state, pages) {
     state.pageCount = pages
   }
 }

--- a/build/run-for-all.js
+++ b/build/run-for-all.js
@@ -20,22 +20,21 @@ var fullCommand = command + ' ' + commandArgs.join(' ')
 var lib = resolve(__dirname, '..', 'apps')
 
 // run command in all apps
-fs.readdirSync(lib)
-  .forEach(function (mod) {
-    var modPath = join(lib, mod)
-    // ensure path has package.json
-    if (!fs.existsSync(join(modPath, 'package.json'))) return
+fs.readdirSync(lib).forEach(function(mod) {
+  var modPath = join(lib, mod)
+  // ensure path has package.json
+  if (!fs.existsSync(join(modPath, 'package.json'))) return
 
-    // Run command
-    console.info(chalk.blue(fullCommand), chalk.red(mod))
-    runCommand(command, commandArgs, modPath)
-  })
+  // Run command
+  console.info(chalk.blue(fullCommand), chalk.red(mod))
+  runCommand(command, commandArgs, modPath)
+})
 
 // run command in core
 console.info(chalk.blue(fullCommand), chalk.red('Core'))
 runCommand(command, commandArgs, resolve(__dirname, '..'))
 
-function runCommand (command, args, modPath) {
+function runCommand(command, args, modPath) {
   try {
     if (runCommandsInParallel) {
       cp.spawn(command, args, { env: process.env, cwd: modPath, stdio: 'inherit' })

--- a/package.json
+++ b/package.json
@@ -114,7 +114,9 @@
     "webpack-version-file-plugin": "^0.4.0",
     "whatwg-fetch": "^3.0.0",
     "wicked-good-xpath": "^1.3.0",
-    "xml-js": "^1.6.11"
+    "xml-js": "^1.6.11",
+    "eslint-config-prettier": "^6.10.0",
+    "eslint-plugin-prettier": "^3.1.2"
   },
   "browserslist": [
     "last 2 version",

--- a/src/Phoenix.vue
+++ b/src/Phoenix.vue
@@ -8,11 +8,11 @@
       <template v-else>
         <message-bar :active-messages="activeMessages" @deleteMessage="$_deleteMessage" />
         <top-bar
-          :applicationsList="$_applicationsList"
-          :activeNotifications="activeNotifications"
+          :applications-list="$_applicationsList"
+          :active-notifications="activeNotifications"
           :user-id="user.id"
           :user-display-name="user.displayname"
-          :hasAppNavigation="appNavigationEntries.length > 1"
+          :has-app-navigation="appNavigationEntries.length > 1"
           @toggleAppNavigationVisibility="toggleAppNavigationVisibility"
         />
         <side-menu
@@ -43,7 +43,7 @@ export default {
     TopBar,
     SkipTo
   },
-  data () {
+  data() {
     return {
       appNavigationVisible: false,
       $_notificationsInterval: null
@@ -51,8 +51,14 @@ export default {
   },
   computed: {
     ...mapState(['route', 'user']),
-    ...mapGetters(['configuration', 'activeNotifications', 'activeMessages', 'capabilities', 'apps']),
-    $_applicationsList () {
+    ...mapGetters([
+      'configuration',
+      'activeNotifications',
+      'activeMessages',
+      'capabilities',
+      'apps'
+    ]),
+    $_applicationsList() {
       const list = []
 
       // Get extensions manually added into config
@@ -67,7 +73,7 @@ export default {
       return list.flat()
     },
 
-    appNavigationEntries () {
+    appNavigationEntries() {
       if (this.publicPage()) {
         return []
       }
@@ -92,18 +98,18 @@ export default {
       })
     },
 
-    showHeader () {
+    showHeader() {
       return this.$route.meta.hideHeadbar !== true
     },
-    favicon () {
+    favicon() {
       return this.configuration.theme.logo.favicon
     }
   },
   watch: {
-    $route () {
+    $route() {
       this.appNavigationVisible = false
     },
-    capabilities (caps) {
+    capabilities(caps) {
       if (!caps) {
         // capabilities not loaded yet
         return
@@ -120,52 +126,50 @@ export default {
       }
     }
   },
-  destroyed () {
+  destroyed() {
     if (this.$_notificationsInterval) {
       clearInterval(this.$_notificationsInterval)
     }
   },
-  metaInfo () {
+  metaInfo() {
     const metaInfo = {
       title: this.configuration.theme.general.name
     }
     if (this.favicon) {
-      metaInfo.link = [
-        { rel: 'icon', href: this.favicon }
-      ]
+      metaInfo.link = [{ rel: 'icon', href: this.favicon }]
     }
     return metaInfo
   },
-  beforeMount () {
+  beforeMount() {
     this.initAuth()
   },
   methods: {
     ...mapActions(['initAuth', 'fetchNotifications', 'deleteMessage']),
 
-    hideAppNavigation () {
+    hideAppNavigation() {
       this.appNavigationVisible = false
     },
 
-    toggleAppNavigationVisibility () {
+    toggleAppNavigationVisibility() {
       this.appNavigationVisible = !this.appNavigationVisible
     },
 
-    $_updateNotifications () {
-      this.fetchNotifications(this.$client).catch((error) => {
+    $_updateNotifications() {
+      this.fetchNotifications(this.$client).catch(error => {
         console.error('Error while loading notifications: ', error)
         clearInterval(this.$_notificationsInterval)
       })
     },
 
-    $_deleteMessage (item) {
+    $_deleteMessage(item) {
       this.deleteMessage(item)
     }
   }
 }
 </script>
 <style>
-  body {
-    height: 100vh;
-    overflow: hidden;
-  }
+body {
+  height: 100vh;
+  overflow: hidden;
+}
 </style>

--- a/src/components/ApplicationsMenu.vue
+++ b/src/components/ApplicationsMenu.vue
@@ -1,17 +1,24 @@
 <template>
   <div v-if="!!applicationsList.length">
-    <oc-button id="_appSwitcherButton" icon="apps" variation="primary" class="oc-topbar-menu-burger uk-height-1-1" :aria-label="$gettext('Application Switcher')" ref="menubutton" />
+    <oc-button
+      id="_appSwitcherButton"
+      ref="menubutton"
+      icon="apps"
+      variation="primary"
+      class="oc-topbar-menu-burger uk-height-1-1"
+      :aria-label="$gettext('Application Switcher')"
+    />
     <oc-drop
-      dropId="app-switcher-dropdown"
+      ref="menu"
+      drop-id="app-switcher-dropdown"
       toggle="#_appSwitcherButton"
       mode="click"
-      :options="{pos:'bottom-right', delayHide: 0}"
+      :options="{ pos: 'bottom-right', delayHide: 0 }"
       class="uk-width-large"
-      ref="menu"
-      closeOnClick
+      close-on-click
     >
       <div class="uk-grid-small uk-text-center" uk-grid>
-        <div class="uk-width-1-3" v-for="(n, nid) in $_applicationsList" :key="nid">
+        <div v-for="(n, nid) in $_applicationsList" :key="nid" class="uk-width-1-3">
           <a v-if="n.url" key="external-link" target="_blank" :href="n.url">
             <oc-icon v-if="n.iconMaterial" :name="n.iconMaterial" size="large" />
             <oc-icon v-if="n.iconUrl" :url="n.iconUrl" size="large" />
@@ -43,7 +50,7 @@ export default {
     }
   },
   computed: {
-    $_applicationsList () {
+    $_applicationsList() {
       return this.applicationsList.map(item => {
         const lang = this.$language.current
         // TODO: move language resolution to a common function
@@ -83,7 +90,7 @@ export default {
     }
   },
   watch: {
-    visible (val) {
+    visible(val) {
       if (val) {
         this.focusFirstLink()
       } else {
@@ -92,16 +99,16 @@ export default {
     }
   },
   methods: {
-    logout () {
+    logout() {
       this.visible = false
       this.$store.dispatch('logout')
     },
-    focusFirstLink () {
+    focusFirstLink() {
       /*
-      * Delay for two reasons:
-      * - for screen readers Virtual buffer
-      * - to outsmart uikit's focus management
-      */
+       * Delay for two reasons:
+       * - for screen readers Virtual buffer
+       * - to outsmart uikit's focus management
+       */
       setTimeout(() => {
         this.$refs.menu.$el.querySelector('a:first-of-type').focus()
       }, 500)

--- a/src/components/Avatar.vue
+++ b/src/components/Avatar.vue
@@ -1,8 +1,19 @@
 <template>
   <component :is="type" v-if="enabled">
-    <oc-spinner v-if="loading" size="small" key="avatar-loading" :aria-label="$gettext('Loading')"
-     :style="`width: ${width}px; height: ${width}px;`" />
-    <oc-avatar v-else key="avatar-loaded" :width="width" :src="avatarSource" :userName="userName" />
+    <oc-spinner
+      v-if="loading"
+      key="avatar-loading"
+      size="small"
+      :aria-label="$gettext('Loading')"
+      :style="`width: ${width}px; height: ${width}px;`"
+    />
+    <oc-avatar
+      v-else
+      key="avatar-loaded"
+      :width="width"
+      :src="avatarSource"
+      :user-name="userName"
+    />
   </component>
 </template>
 <script>
@@ -12,9 +23,9 @@ export default {
   name: 'Avatar',
   props: {
     /**
-         * The html element used for the avatar container.
-         * `div, span`
-         */
+     * The html element used for the avatar container.
+     * `div, span`
+     */
     type: {
       type: String,
       default: 'div',
@@ -28,8 +39,9 @@ export default {
     },
     userid: {
       /**
-           * Allow empty string to show placeholder
-           */
+       * Allow empty string to show placeholder
+       */
+      type: String,
       default: ''
     },
     width: {
@@ -38,7 +50,7 @@ export default {
       default: 42
     }
   },
-  data () {
+  data() {
     return {
       /**
        * Set to object URL when loaded, or on failure, icon placeholder is shown
@@ -52,16 +64,16 @@ export default {
   },
   computed: {
     ...mapGetters(['getToken']),
-    enabled: function () {
+    enabled: function() {
       return this.$root.config.enableAvatars || true
     }
   },
   watch: {
-    userid: function (userid, old) {
+    userid: function(userid, old) {
       this.setUser(userid)
     }
   },
-  mounted: function () {
+  mounted: function() {
     // Handled mounted situation. Userid might not be set yet so try placeholder
     if (this.userid !== '') {
       this.setUser(this.userid)
@@ -73,7 +85,7 @@ export default {
     /**
      * Load a new avatar from this userid
      */
-    setUser (userid) {
+    setUser(userid) {
       this.loading = true
       this.avatarSource = ''
       if (!this.enabled || userid === '') {

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -1,6 +1,20 @@
 <template>
-  <oc-application-menu name="coreMenu" v-model="visible" :inert="!visible" ref="sidebar" @close="close">
-    <oc-sidebar-nav-item v-for="(n, nid) in entries" :active="isActive(n)" :key="nid" :icon="n.iconMaterial" :target="n.route ? n.route.path : null" @click="openItem(n.url)">{{ translateMenu(n) }}</oc-sidebar-nav-item>
+  <oc-application-menu
+    ref="sidebar"
+    v-model="visible"
+    name="coreMenu"
+    :inert="!visible"
+    @close="close"
+  >
+    <oc-sidebar-nav-item
+      v-for="(n, nid) in entries"
+      :key="nid"
+      :active="isActive(n)"
+      :icon="n.iconMaterial"
+      :target="n.route ? n.route.path : null"
+      @click="openItem(n.url)"
+      >{{ translateMenu(n) }}</oc-sidebar-nav-item
+    >
   </oc-application-menu>
 </template>
 
@@ -18,12 +32,11 @@ export default {
       default: () => []
     }
   },
-  data () {
-    return {
-    }
+  data() {
+    return {}
   },
   watch: {
-    visible (val) {
+    visible(val) {
       this.isOpen = val
       if (val) {
         this.focusFirstLink()
@@ -31,31 +44,31 @@ export default {
     }
   },
   methods: {
-    close () {
+    close() {
       this.$emit('closed')
     },
-    navigateTo (route) {
+    navigateTo(route) {
       this.$router.push(route)
     },
-    translateMenu (navItem) {
+    translateMenu(navItem) {
       return this.$gettext(navItem.name)
     },
-    openItem (url) {
+    openItem(url) {
       if (url) {
         const win = window.open(url, '_blank')
         win.focus()
       }
       this.close()
     },
-    isActive (navItem) {
+    isActive(navItem) {
       return navItem.route.name === this.$route.name
     },
-    focusFirstLink () {
+    focusFirstLink() {
       /*
-      * Delay for two reasons:
-      * - for screen readers Virtual buffer
-      * - to outsmart uikit's focus management
-      */
+       * Delay for two reasons:
+       * - for screen readers Virtual buffer
+       * - to outsmart uikit's focus management
+       */
       setTimeout(() => {
         this.$refs.sidebar.$el.querySelector('a:first-of-type').focus()
       }, 500)
@@ -65,8 +78,8 @@ export default {
 </script>
 
 <style scoped>
-  /* Workaround until we decide what to do with the sidebar navigation */
-  #coreMenu {
-    top: 60px;
-  }
+/* Workaround until we decide what to do with the sidebar navigation */
+#coreMenu {
+  top: 60px;
+}
 </style>

--- a/src/components/MessageBar.vue
+++ b/src/components/MessageBar.vue
@@ -2,14 +2,14 @@
   <oc-notifications>
     <transition-group name="oc-alerts-transition" tag="div">
       <oc-notification-message
-            v-for="item in $_ocMessages_limited"
-            :key="item.id"
-            :title="item.title"
-            :message="item.desc"
-            :status="item.status"
-            @close="deleteMessage(item)"
-            class="uk-width-large"
-    />
+        v-for="item in $_ocMessages_limited"
+        :key="item.id"
+        :title="item.title"
+        :message="item.desc"
+        :status="item.status"
+        class="uk-width-large"
+        @close="deleteMessage(item)"
+      />
     </transition-group>
   </oc-notifications>
 </template>
@@ -24,12 +24,12 @@ export default {
     }
   },
   computed: {
-    $_ocMessages_limited () {
+    $_ocMessages_limited() {
       return this.activeMessages ? this.activeMessages.slice(0, 5) : []
     }
   },
   methods: {
-    deleteMessage (item) {
+    deleteMessage(item) {
       this.$emit('deleteMessage', item)
     }
   }

--- a/src/components/Notifications.vue
+++ b/src/components/Notifications.vue
@@ -13,32 +13,32 @@
       position="bottom-right"
       class="uk-overflow-auto uk-height-large uk-width-3-4 uk-width-large@s"
     >
-      <div
-        v-for="(el, index) in activeNotifications"
-        :key="index"
-        class="uk-width-1-1"
-      >
+      <div v-for="(el, index) in activeNotifications" :key="index" class="uk-width-1-1">
         <h5 class="uk-h4">{{ el.subject }}</h5>
         <p v-if="el.message" class="uk-text-small">{{ el.message }}</p>
         <p>
-          <a v-if="el.link" :href="el.link" class="uk-link" target="_blank">{{el.link}}</a>
+          <a v-if="el.link" :href="el.link" class="uk-link" target="_blank">{{ el.link }}</a>
         </p>
         <div class="uk-button-group uk-width-1-1 uk-flex-right">
           <template v-if="el.actions.length !== 0">
             <oc-button
-              v-for="(action, index) in el.actions"
-              :key="index"
+              v-for="(action, actionIndex) in el.actions"
+              :key="index + '-' + actionIndex"
               size="small"
               :variation="action.primary ? 'primary' : 'default'"
               @click.prevent="executeRequest(el.app, action.link, action.type, el.notification_id)"
-            >{{ action.label }}</oc-button>
+              >{{ action.label }}</oc-button
+            >
           </template>
           <oc-button
             v-else
             id="resolve-notification-button"
             size="small"
-            @click.prevent.once="deleteNotification({ client: $client, notification: el.notification_id })"
-          >Mark as read</oc-button>
+            @click.prevent.once="
+              deleteNotification({ client: $client, notification: el.notification_id })
+            "
+            >Mark as read</oc-button
+          >
         </div>
         <hr v-if="index + 1 !== activeNotifications.length" />
       </div>
@@ -56,32 +56,34 @@ export default {
     ...mapActions(['deleteNotification', 'showMessage']),
     ...mapActions('Files', ['loadFolder']),
 
-    executeRequest (app, link, type, notificationId) {
-      this.$client.requests.ocs({
-        service: 'apps/' + app,
-        action: link.substr(link.lastIndexOf('api')),
-        method: type
-      }).then(res => {
-        this.deleteNotification({
-          client: this.$client,
-          notification: notificationId
+    executeRequest(app, link, type, notificationId) {
+      this.$client.requests
+        .ocs({
+          service: 'apps/' + app,
+          action: link.substr(link.lastIndexOf('api')),
+          method: type
         })
-        res.json().then(json => {
-          json.ocs.data.map(item => {
-            const path = item.path.substr(0, item.path.lastIndexOf('/') + 1)
-            const absolutePath = this.$route.params.item ? this.$route.params.item : '/'
-            if (path === absolutePath) this.reloadFilesList(path)
+        .then(res => {
+          this.deleteNotification({
+            client: this.$client,
+            notification: notificationId
+          })
+          res.json().then(json => {
+            json.ocs.data.map(item => {
+              const path = item.path.substr(0, item.path.lastIndexOf('/') + 1)
+              const absolutePath = this.$route.params.item ? this.$route.params.item : '/'
+              if (path === absolutePath) this.reloadFilesList(path)
+            })
           })
         })
-      })
     },
-    reloadFilesList (path) {
+    reloadFilesList(path) {
       this.loadFolder({
         client: this.$client,
         absolutePath: path,
         $gettext: this.$gettext,
         routeName: this.$route.name
-      }).catch((error) => {
+      }).catch(error => {
         this.showMessage({
           title: this.$gettext('Loading folder failed…'),
           desc: error.message,

--- a/src/components/OcAppContent.vue
+++ b/src/components/OcAppContent.vue
@@ -1,17 +1,15 @@
 <template>
   <div class="oc-app-content">
-      <slot name="content"></slot>
+    <slot name="content"></slot>
   </div>
 </template>
 <script>
 export default {
-  data: () => ({
-
-  })
+  data: () => ({})
 }
 </script>
 <style scoped>
-  .oc-app-content {
-    overflow-y: scroll;
-  }
+.oc-app-content {
+  overflow-y: scroll;
+}
 </style>

--- a/src/components/SkipTo.vue
+++ b/src/components/SkipTo.vue
@@ -6,20 +6,20 @@
 export default {
   props: {
     /*
-    * The element to focus and to skip to
-    */
+     * The element to focus and to skip to
+     */
     target: {
       type: String,
       required: true
     }
   },
   computed: {
-    targetElement () {
+    targetElement() {
       return document.getElementById(this.target)
     }
   },
   methods: {
-    skipToTarget () {
+    skipToTarget() {
       // Make targetElement programmatically focusable
       this.targetElement.setAttribute('tabindex', '-1')
 
@@ -41,7 +41,7 @@ export default {
   border: none;
   background-color: #ffffff;
   font: inherit;
-  padding: .25em .5em;
+  padding: 0.25em 0.5em;
 }
 
 .skip-button:focus {

--- a/src/components/Top-Bar.vue
+++ b/src/components/Top-Bar.vue
@@ -4,23 +4,28 @@
       <oc-button
         v-if="hasAppNavigation"
         key="extension-navigation-button"
+        ref="menubutton"
         icon="menu"
         variation="primary"
         class="oc-topbar-menu-burger uk-height-1-1"
         :aria-label="$gettext('Menu')"
         @click="toggleAppNavigationVisibility"
-        ref="menubutton"
       >
-        <span class="oc-topbar-menu-burger-label" v-translate>Menu</span>
+        <span v-translate class="oc-topbar-menu-burger-label">Menu</span>
       </oc-button>
-      <span v-else key="extension-title" class="topbar-current-extension-title uk-margin-left" v-text="currentExtensionName" />
+      <span
+        v-else
+        key="extension-title"
+        class="topbar-current-extension-title uk-margin-left"
+        v-text="currentExtensionName"
+      />
     </oc-navbar-item>
     <oc-navbar-item position="center">
       <router-link to="/" class="oc-topbar-icon">ownCloud X</router-link>
     </oc-navbar-item>
-    <oc-navbar-item position="right" v-if="!isPublicPage">
+    <oc-navbar-item v-if="!isPublicPage" position="right">
       <notifications v-if="activeNotifications.length" />
-      <applications-menu :applicationsList="applicationsList"/>
+      <applications-menu :applications-list="applicationsList" />
       <user-menu :user-id="userId" :user-display-name="userDisplayName" />
     </oc-navbar-item>
   </oc-navbar>
@@ -39,9 +44,7 @@ export default {
     ApplicationsMenu,
     UserMenu
   },
-  mixins: [
-    pluginHelper
-  ],
+  mixins: [pluginHelper],
   props: {
     userId: {
       type: String,
@@ -72,16 +75,16 @@ export default {
   computed: {
     ...mapGetters(['apps']),
 
-    isPublicPage () {
+    isPublicPage() {
       return !this.userId
     },
 
-    currentExtensionName () {
+    currentExtensionName() {
       return this.$gettext(this.apps[this.currentExtension].name)
     }
   },
   methods: {
-    toggleAppNavigationVisibility () {
+    toggleAppNavigationVisibility() {
       this.$emit('toggleAppNavigationVisibility')
     }
   }
@@ -91,6 +94,6 @@ export default {
 TODO: Move to ODS and enable theming
 <style scoped>
 .topbar-current-extension-title {
-  color: white
+  color: white;
 }
 </style>

--- a/src/components/UserMenu.vue
+++ b/src/components/UserMenu.vue
@@ -1,26 +1,47 @@
 <template>
   <div>
-    <oc-button id="_userMenuButton" class="oc-topbar-personal uk-height-1-1" variation="primary" :aria-label="$gettext('User Menu')" ref="menuButton">
+    <oc-button
+      id="_userMenuButton"
+      ref="menuButton"
+      class="oc-topbar-personal uk-height-1-1"
+      variation="primary"
+      :aria-label="$gettext('User Menu')"
+    >
       <oc-grid gutter="small">
-        <avatar-image class="oc-topbar-personal-avatar" :width="32" :userid="userId" :userName="userDisplayName"/>
+        <avatar-image
+          class="oc-topbar-personal-avatar"
+          :width="32"
+          :userid="userId"
+          :user-name="userDisplayName"
+        />
         <div class="oc-topbar-personal-label">{{ userDisplayName }}</div>
       </oc-grid>
     </oc-button>
-    <oc-drop toggle="#_userMenuButton" mode="click" :options="{pos:'bottom-right'}" class="uk-width-large" ref="menu">
-      <div class="uk-card-body uk-flex uk-flex-middle uk-flex-column" id="account-info-container">
-        <avatar-image
-          :userid="userId"
-          :userName="userDisplayName"
-          :width="128"
-        />
+    <oc-drop
+      ref="menu"
+      toggle="#_userMenuButton"
+      mode="click"
+      :options="{ pos: 'bottom-right' }"
+      class="uk-width-large"
+    >
+      <div id="account-info-container" class="uk-card-body uk-flex uk-flex-middle uk-flex-column">
+        <avatar-image :userid="userId" :user-name="userDisplayName" :width="128" />
         <h3 class="uk-card-title">{{ userDisplayName }}</h3>
         <span v-if="userEmail">{{ userEmail }}</span>
-        <router-link to="/account" target="_blank"><translate>Manage your account</translate></router-link>
-        <br/>
-        <oc-button id="logoutMenuItem" type="a" @click="logout()"><translate>Log out</translate></oc-button>
+        <router-link to="/account" target="_blank"
+          ><translate>Manage your account</translate></router-link
+        >
+        <br />
+        <oc-button id="logoutMenuItem" type="a" @click="logout()"
+          ><translate>Log out</translate></oc-button
+        >
       </div>
       <div class="uk-card-footer uk-flex uk-flex-middle uk-flex-column">
-        <span>Version: {{appVersion.version}}-{{appVersion.hash}} ({{appVersion.buildDate}})</span>
+        <span
+          >Version: {{ appVersion.version }}-{{ appVersion.hash }} ({{
+            appVersion.buildDate
+          }})</span
+        >
       </div>
     </oc-drop>
   </div>
@@ -45,13 +66,13 @@ export default {
       default: null
     }
   },
-  data () {
+  data() {
     return {
       appVersion: appVersionJson
     }
   },
   watch: {
-    visible (val) {
+    visible(val) {
       if (val) {
         this.focusFirstLink()
       } else {
@@ -60,11 +81,11 @@ export default {
     }
   },
   methods: {
-    logout () {
+    logout() {
       this.visible = false
       this.$store.dispatch('logout')
     },
-    openItem (url) {
+    openItem(url) {
       if (url) {
         const win = window.open(url, '_blank')
         if (win) {
@@ -72,12 +93,12 @@ export default {
         }
       }
     },
-    focusFirstLink () {
+    focusFirstLink() {
       /*
-      * Delay for two reasons:
-      * - for screen readers Virtual buffer
-      * - to outsmart uikit's focus management
-      */
+       * Delay for two reasons:
+       * - for screen readers Virtual buffer
+       * - to outsmart uikit's focus management
+       */
       setTimeout(() => {
         this.$refs.menuButton.$el.querySelector('a:first-of-type').focus()
       }, 500)

--- a/src/mixins/pluginHelper.js
+++ b/src/mixins/pluginHelper.js
@@ -1,6 +1,5 @@
 export default {
   methods: {
-
     /**
      * Path to application file
      *
@@ -8,16 +7,16 @@ export default {
      * @param plugin Plugin
      */
 
-    getPlugin (ext) {
-      return this.$root.plugins.find((n) => {
+    getPlugin(ext) {
+      return this.$root.plugins.find(n => {
         if (n.extend === ext) {
           return n
         }
       })
     },
 
-    getPlugins (ext) {
-      return this.$root.plugins.filter((n) => {
+    getPlugins(ext) {
+      return this.$root.plugins.filter(n => {
         if (n.extend === ext) {
           return n
         }

--- a/src/pages/accessDenied.vue
+++ b/src/pages/accessDenied.vue
@@ -1,31 +1,33 @@
 <template>
   <div class="oc-login" uk-height-viewport>
-      <div class="oc-login-card uk-position-center">
-          <h1 class="oc-login-logo" v-translate>
-              ownCloud
-          </h1>
-          <div class="oc-login-card-body uk-width-large">
-              <h3 class="oc-login-card-title">
-                  <span v-translate>Login Error</span>
-              </h3>
-              <h4 v-translate class="uk-margin-remove">
-                You are not allowed to use this application.
-              </h4>
-              <br>
-              <div v-translate class="uk-margin-remove" @click="performLogout">
-                If you like to login with a different user please proceed to <a id='exitAnchor'>exit</a>.
-              </div>
-              <br>
-              <div v-translate class="uk-margin-remove">
-                <strong>Attention:</strong> this will log you out from all applications you are running in this browser with your current user.</div>
-          </div>
-          <div class="oc-login-card-footer uk-width-large">
-              <p>
-                {{ helpDeskText }}
-                <a v-if="helpDeskLink" :href="helpDeskLink" v-text="helpDeskLinkText" />
-              </p>
-          </div>
+    <div class="oc-login-card uk-position-center">
+      <h1 v-translate class="oc-login-logo">
+        ownCloud
+      </h1>
+      <div class="oc-login-card-body uk-width-large">
+        <h3 class="oc-login-card-title">
+          <span v-translate>Login Error</span>
+        </h3>
+        <h4 v-translate class="uk-margin-remove">
+          You are not allowed to use this application.
+        </h4>
+        <br />
+        <div v-translate class="uk-margin-remove" @click="performLogout">
+          If you like to login with a different user please proceed to <a id="exitAnchor">exit</a>.
+        </div>
+        <br />
+        <div v-translate class="uk-margin-remove">
+          <strong>Attention:</strong> this will log you out from all applications you are running in
+          this browser with your current user.
+        </div>
       </div>
+      <div class="oc-login-card-footer uk-width-large">
+        <p>
+          {{ helpDeskText }}
+          <a v-if="helpDeskLink" :href="helpDeskLink" v-text="helpDeskLinkText" />
+        </p>
+      </div>
+    </div>
   </div>
 </template>
 <script>
@@ -34,23 +36,28 @@ export default {
   name: 'AccessDeniedPage',
   computed: {
     ...mapGetters(['configuration']),
-    helpDeskText () {
-      if (this.configuration.theme.general.helpDeskText && this.configuration.theme.general.helpDeskText.en) {
+    helpDeskText() {
+      if (
+        this.configuration.theme.general.helpDeskText &&
+        this.configuration.theme.general.helpDeskText.en
+      ) {
         const lang = this.$language.current
         if (this.configuration.theme.general.helpDeskText[lang]) {
           return this.configuration.theme.general.helpDeskText[lang]
         }
         return this.configuration.theme.general.helpDeskText.en
       }
-      return this.$gettext('Please contact your administrator if you think this message shows up in error.')
+      return this.$gettext(
+        'Please contact your administrator if you think this message shows up in error.'
+      )
     },
-    helpDeskLink () {
+    helpDeskLink() {
       if (this.configuration.theme.general.helpDeskLink) {
         return this.configuration.theme.general.helpDeskLink
       }
       return ''
     },
-    helpDeskLinkText () {
+    helpDeskLinkText() {
       if (this.configuration.theme.general.helpDeskLinkText) {
         return this.configuration.theme.general.helpDeskLinkText
       }
@@ -59,7 +66,7 @@ export default {
   },
   methods: {
     ...mapActions(['logout']),
-    performLogout (event) {
+    performLogout(event) {
       if (event.target.id === 'exitAnchor') {
         this.logout()
       }

--- a/src/pages/account.vue
+++ b/src/pages/account.vue
@@ -3,8 +3,13 @@
     <oc-loader v-if="loading" />
     <div v-if="!loading" class="uk-width-3-4@m uk-container uk-padding">
       <div class="uk-flex uk-flex-between uk-flex-middle">
-        <h1 id="account-page-title" class="oc-page-title" v-translate>Account</h1>
-        <oc-button class="account-logout-button" icon="exit_to_app" @click="$_oc_settingsAccount_logout"><translate>Log out</translate></oc-button>
+        <h1 id="account-page-title" v-translate class="oc-page-title">Account</h1>
+        <oc-button
+          class="account-logout-button"
+          icon="exit_to_app"
+          @click="$_oc_settingsAccount_logout"
+          ><translate>Log out</translate></oc-button
+        >
       </div>
       <hr />
       <div class="uk-text-bold uk-margin-bottom"><translate>Account Information</translate></div>
@@ -26,7 +31,10 @@
           <div class="uk-text-meta"><translate>Groups membership:</translate></div>
           <template v-if="groups.length > 0">
             <span v-for="(group, index) in groups" :key="index">
-              {{ group }}<template v-if="index + 1  < groups.length">, </template>
+              {{ group
+              }}<template v-if="index + 1 < groups.length"
+                >,
+              </template>
             </span>
           </template>
           <span v-else v-translate>You are not part of any group</span>
@@ -40,7 +48,7 @@
 import { mapGetters, mapActions } from 'vuex'
 export default {
   name: 'Personal',
-  data () {
+  data() {
     return {
       loading: true,
       groups: []
@@ -49,19 +57,18 @@ export default {
   computed: {
     ...mapGetters(['user'])
   },
-  mounted () {
+  mounted() {
     this.$_oc_settingsAccount_getGroup()
   },
   methods: {
     ...mapActions(['logout']),
-    $_oc_settingsAccount_getGroup () {
-      this.$client.users.getUserGroups(this.user.id)
-        .then(groups => {
-          this.groups = groups
-          this.loading = false
-        })
+    $_oc_settingsAccount_getGroup() {
+      this.$client.users.getUserGroups(this.user.id).then(groups => {
+        this.groups = groups
+        this.loading = false
+      })
     },
-    $_oc_settingsAccount_logout () {
+    $_oc_settingsAccount_logout() {
       this.logout()
     }
   }

--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -1,34 +1,42 @@
 <template>
-    <div class="oc-login" uk-height-viewport>
-        <div class="oc-login-card uk-position-center">
-            <h1 class="oc-login-logo" v-translate>
-                ownCloud
-            </h1>
-            <div class="oc-login-card-body">
-                <h3 class="oc-login-card-title">
-                  <translate :translate-params="{productName: $_productName}">Welcome to %{productName}</translate>
-                </h3>
-                <p v-translate>
-                    Please click the button below to authenticate and get access to your data.
-                </p>
-                <oc-button size="large" variation="primary" class="oc-login-authorize-button" id="authenticate" @click.native="login()">
-                  <translate>Login</translate>
-                </oc-button>
-            </div>
-            <div class="oc-login-card-footer">
-                <p>
-                    {{ configuration.theme.general.slogan }}
-                </p>
-            </div>
-        </div>
+  <div class="oc-login" uk-height-viewport>
+    <div class="oc-login-card uk-position-center">
+      <h1 v-translate class="oc-login-logo">
+        ownCloud
+      </h1>
+      <div class="oc-login-card-body">
+        <h3 class="oc-login-card-title">
+          <translate :translate-params="{ productName: $_productName }"
+            >Welcome to %{productName}</translate
+          >
+        </h3>
+        <p v-translate>
+          Please click the button below to authenticate and get access to your data.
+        </p>
+        <oc-button
+          id="authenticate"
+          size="large"
+          variation="primary"
+          class="oc-login-authorize-button"
+          @click.native="login()"
+        >
+          <translate>Login</translate>
+        </oc-button>
+      </div>
+      <div class="oc-login-card-footer">
+        <p>
+          {{ configuration.theme.general.slogan }}
+        </p>
+      </div>
     </div>
+  </div>
 </template>
 
 <script>
 import { mapGetters, mapActions } from 'vuex'
 export default {
   name: 'LoginPage',
-  data () {
+  data() {
     return {
       loading: false
     }
@@ -36,7 +44,7 @@ export default {
   computed: {
     ...mapGetters(['configuration']),
 
-    $_productName () {
+    $_productName() {
       return this.configuration.theme.general.name
     }
   },

--- a/src/pages/missingConfig.vue
+++ b/src/pages/missingConfig.vue
@@ -1,31 +1,34 @@
 <template>
   <div id="Phoenix" class="uk-height-1-1">
     <div class="oc-login" uk-height-viewport>
-        <div class="oc-login-card uk-position-center">
-            <h1 class="oc-login-logo" v-translate>
-                ownCloud
-            </h1>
-            <div class="oc-login-card-body">
-                <h3 class="oc-login-card-title">
-                    <span v-translate>Missing config</span>
-                </h3>
-                <p v-translate>
-                    Please check if file config.json exists.
-                </p>
-            </div>
-            <div class="oc-login-card-footer">
-                <p>
-                    <!-- Until we have documentation for Phoenix let's point this link to Phoenix repo -->
-                    <translate>For help visit our</translate> <translate tag="a" href="https://github.com/owncloud/phoenix" target="_blank">documentation</translate>.
-                </p>
-            </div>
+      <div class="oc-login-card uk-position-center">
+        <h1 v-translate class="oc-login-logo">
+          ownCloud
+        </h1>
+        <div class="oc-login-card-body">
+          <h3 class="oc-login-card-title">
+            <span v-translate>Missing config</span>
+          </h3>
+          <p v-translate>
+            Please check if file config.json exists.
+          </p>
         </div>
+        <div class="oc-login-card-footer">
+          <p>
+            <!-- Until we have documentation for Phoenix let's point this link to Phoenix repo -->
+            <translate>For help visit our</translate>
+            <translate tag="a" href="https://github.com/owncloud/phoenix" target="_blank"
+              >documentation</translate
+            >.
+          </p>
+        </div>
+      </div>
     </div>
   </div>
 </template>
 
 <script>
 export default {
-  name: 'missingConfigPage'
+  name: 'MissingConfigPage'
 }
 </script>

--- a/src/pages/oidcCallback.vue
+++ b/src/pages/oidcCallback.vue
@@ -1,39 +1,39 @@
 <template>
-    <div class="oc-login" uk-height-viewport>
-        <div class="oc-login-card uk-position-center">
-            <h1 class="oc-login-logo" v-translate>
-                ownCloud
-            </h1>
-          <div v-show="error" class="oc-login-card-body">
-            <h3 class="oc-login-card-title">
-              <translate>Authentication failed</translate>
-            </h3>
-            <p v-translate>
-              Please contact the administrator if this error persists.
-            </p>
-          </div>
-          <div v-show="!error" class="oc-login-card-body">
-            <h3 class="oc-login-card-title">
-              <translate>Redirecting</translate>
-            </h3>
-            <p v-translate>
-              Please wait a while. You are being redirected.
-            </p>
-          </div>
-            <div class="oc-login-card-footer">
-                <p>
-                    {{ configuration.theme.general.slogan }}
-                </p>
-            </div>
-        </div>
+  <div class="oc-login" uk-height-viewport>
+    <div class="oc-login-card uk-position-center">
+      <h1 v-translate class="oc-login-logo">
+        ownCloud
+      </h1>
+      <div v-show="error" class="oc-login-card-body">
+        <h3 class="oc-login-card-title">
+          <translate>Authentication failed</translate>
+        </h3>
+        <p v-translate>
+          Please contact the administrator if this error persists.
+        </p>
+      </div>
+      <div v-show="!error" class="oc-login-card-body">
+        <h3 class="oc-login-card-title">
+          <translate>Redirecting</translate>
+        </h3>
+        <p v-translate>
+          Please wait a while. You are being redirected.
+        </p>
+      </div>
+      <div class="oc-login-card-footer">
+        <p>
+          {{ configuration.theme.general.slogan }}
+        </p>
+      </div>
     </div>
+  </div>
 </template>
 
 <script>
 import { mapGetters, mapActions } from 'vuex'
 export default {
   name: 'OidcCallbackPage',
-  data () {
+  data() {
     return {
       error: false
     }
@@ -41,11 +41,13 @@ export default {
   computed: {
     ...mapGetters(['configuration'])
   },
-  mounted () {
+  mounted() {
     this.$nextTick(() => {
       if (this.$route.query.error) {
         this.error = true
-        console.warn('OAuth error: ' + this.$route.query.error + ' - ' + this.$route.query.error_description)
+        console.warn(
+          'OAuth error: ' + this.$route.query.error + ' - ' + this.$route.query.error_description
+        )
         return
       }
       if (this.$route.path === '/oidc-silent-redirect') {

--- a/src/plugins/mediaSource.js
+++ b/src/plugins/mediaSource.js
@@ -2,8 +2,8 @@ import store from '../store'
 const { default: PQueue } = require('p-queue')
 
 export default {
-  install (Vue) {
-    function _mediaSource (source, returnAs = 'url', headers = null) {
+  install(Vue) {
+    function _mediaSource(source, returnAs = 'url', headers = null) {
       return new Promise((resolve, reject) => {
         if (headers === null) {
           headers = new Headers()
@@ -11,51 +11,58 @@ export default {
         }
         headers.append('X-Requested-With', 'XMLHttpRequest')
 
-        fetch(source, { headers }).then(response => {
-          if (!response.ok) {
-            reject(response)
-            return
-          }
-          response.blob().then(blob => {
-            if (returnAs === 'base64') {
-              const reader = new FileReader()
-              reader.readAsDataURL(blob)
-              reader.onloadend = function () {
-                resolve(reader)
-              }
-            } else if (returnAs === 'url') {
-              const source = window.URL.createObjectURL(blob)
-              resolve(source)
+        fetch(source, { headers })
+          .then(response => {
+            if (!response.ok) {
+              reject(response)
+              return
             }
+            response.blob().then(blob => {
+              if (returnAs === 'base64') {
+                const reader = new FileReader()
+                reader.readAsDataURL(blob)
+                reader.onloadend = function() {
+                  resolve(reader)
+                }
+              } else if (returnAs === 'url') {
+                const source = window.URL.createObjectURL(blob)
+                resolve(source)
+              }
+            })
           })
-        }).catch(e => {
-          console.warn('media-source', e)
-          reject(e)
-        })
+          .catch(e => {
+            console.warn('media-source', e)
+            reject(e)
+          })
       })
     }
     // For use with <img> tags
     Vue.directive('image-source', {
-      bind (el, binding) {
+      bind(el, binding) {
         // Set an empty image while resolving
-        el.setAttribute('src', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=')
+        el.setAttribute(
+          'src',
+          'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+        )
 
-        _mediaSource(binding.value).then(dataImage => {
-          el.setAttribute('src', dataImage)
-        }).catch(e => {
-          console.warn('image-source', e)
-        })
+        _mediaSource(binding.value)
+          .then(dataImage => {
+            el.setAttribute('src', dataImage)
+          })
+          .catch(e => {
+            console.warn('image-source', e)
+          })
       }
     })
 
     Vue.mixin({
-      data: function () {
+      data: function() {
         return {
           mediaSourceQueue: new PQueue({ concurrency: 2 })
         }
       },
       methods: {
-        mediaSource (source, returnAs = 'url', headers = null) {
+        mediaSource(source, returnAs = 'url', headers = null) {
           return this.mediaSourceQueue.add(() => _mediaSource(source, returnAs, headers))
         }
       }

--- a/src/plugins/phoenix.js
+++ b/src/plugins/phoenix.js
@@ -1,13 +1,13 @@
 import { mapGetters, mapActions } from 'vuex'
 
 export default {
-  install (Vue) {
+  install(Vue) {
     Vue.mixin({
       computed: {
         ...mapGetters(['getToken', 'isAuthenticated']),
         ...mapGetters('Files', ['publicLinkPassword']),
 
-        currentExtension () {
+        currentExtension() {
           return this.$route.path.split('/')[1]
         }
       },
@@ -15,13 +15,13 @@ export default {
         ...mapActions('Files', ['addActionToProgress', 'removeActionFromProgress']),
         ...mapActions(['showMessage']),
 
-        publicPage () {
+        publicPage() {
           // public page is either when not authenticated
           // but also when accessing pages that require no auth even when authenticated
           return !this.isAuthenticated || this.$route.meta.auth === false
         },
         // FIXME: optional publicContext parameter is a mess
-        downloadFile (file, publicContext = null) {
+        downloadFile(file, publicContext = null) {
           this.addActionToProgress(file)
           const publicPage = publicContext !== null ? publicContext : this.publicPage()
           let headers = {}
@@ -29,7 +29,9 @@ export default {
             const url = this.$client.publicFiles.getFileUrl(file.path)
             const password = this.publicLinkPassword
             if (password) {
-              headers = { Authorization: 'Basic ' + Buffer.from('public:' + password).toString('base64') }
+              headers = {
+                Authorization: 'Basic ' + Buffer.from('public:' + password).toString('base64')
+              }
             }
 
             return this.downloadFileFromUrl(url, headers, file)
@@ -39,7 +41,7 @@ export default {
 
           return this.downloadFileFromUrl(url, headers, file)
         },
-        downloadFileFromUrl (url, headers, file) {
+        downloadFileFromUrl(url, headers, file) {
           const request = new XMLHttpRequest()
           request.open('GET', url)
           request.responseType = 'blob'
@@ -57,9 +59,11 @@ export default {
               this.removeActionFromProgress(file)
             } else if (request.readyState === 4 && request.status === 200) {
               // Download has finished
-              if (window.navigator && window.navigator.msSaveOrOpenBlob) { // for IE
+              if (window.navigator && window.navigator.msSaveOrOpenBlob) {
+                // for IE
                 window.navigator.msSaveOrOpenBlob(request.response, file.name)
-              } else { // for Non-IE (chrome, firefox etc.)
+              } else {
+                // for Non-IE (chrome, firefox etc.)
                 const objectUrl = window.URL.createObjectURL(request.response)
 
                 const anchor = document.createElement('a')
@@ -100,7 +104,7 @@ export default {
          * Checks whether the browser is Internet Explorer 11
          * @return {boolean} true if the browser is Internet Expoler 11
          */
-        isIE11 () {
+        isIE11() {
           return !!window.MSInputMethodContext && !!document.documentMode
         },
         /**
@@ -109,7 +113,7 @@ export default {
          * @param path path
          * @return encoded path
          */
-        encodePath: function (path) {
+        encodePath: function(path) {
           if (!path) {
             return path
           }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -10,7 +10,7 @@ import store from '../store'
 Vue.use(Router)
 
 const router = new Router({
-//  mode: 'history',
+  //  mode: 'history',
   routes: [
     {
       path: '/login',
@@ -64,7 +64,7 @@ const router = new Router({
   ]
 })
 
-router.beforeEach(function (to, from, next) {
+router.beforeEach(function(to, from, next) {
   const isAuthenticated = store.getters.isAuthenticated
   let authRequired = true
   if (to.meta.auth === false) {

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -1,6 +1,6 @@
 import { Log, User, UserManager, WebStorageStateStore } from 'oidc-client'
 
-export function initVueAuthenticate (config) {
+export function initVueAuthenticate(config) {
   if (config) {
     const store = new WebStorageStateStore({
       prefix: 'oc_oAuth',
@@ -61,15 +61,15 @@ export function initVueAuthenticate (config) {
     Log.logger = console
     Log.level = openIdConfig.logLevel
 
-    mgr.events.addUserSignedOut(function () {
+    mgr.events.addUserSignedOut(function() {
       console.log('UserSignedOut：', arguments)
     })
 
     return {
-      authenticate () {
+      authenticate() {
         return mgr.signinRedirect()
       },
-      getToken () {
+      getToken() {
         const storageString = sessionStorage.getItem('oc_oAuth' + mgr._userStoreKey)
         if (storageString) {
           const user = User.fromStorageString(storageString)
@@ -80,7 +80,7 @@ export function initVueAuthenticate (config) {
         }
         return null
       },
-      getStoredUserObject () {
+      getStoredUserObject() {
         const storageString = sessionStorage.getItem('oc_oAuth' + mgr._userStoreKey)
         if (storageString) {
           const user = User.fromStorageString(storageString)
@@ -91,17 +91,17 @@ export function initVueAuthenticate (config) {
         }
         return null
       },
-      isAuthenticated () {
+      isAuthenticated() {
         return this.getToken() !== null
       },
-      logout () {
+      logout() {
         return mgr.signoutRedirect()
       },
-      clearLoginState () {
+      clearLoginState() {
         return mgr.removeUser()
       },
       mgr: mgr,
-      events () {
+      events() {
         return mgr.events
       }
     }

--- a/src/store/app.js
+++ b/src/store/app.js
@@ -8,44 +8,45 @@ const state = {
 }
 
 const actions = {
-  toggleSidebar (context, visible) {
+  toggleSidebar(context, visible) {
     context.commit('TOGGLE_SIDEBAR', visible)
   },
-  showMessage (context, message) {
+  showMessage(context, message) {
     context.commit('ENQUEUE_MESSAGE', message)
   },
-  deleteMessage (context, mId) {
+  deleteMessage(context, mId) {
     context.commit('REMOVE_MESSAGE', mId)
   },
-  fetchNotifications (context, client) {
+  fetchNotifications(context, client) {
     context.commit('LOADING_NOTIFICATIONS', true)
 
-    return client.requests.ocs({
-      service: 'apps/notifications',
-      action: 'api/v1/notifications'
-    })
-      .then(response => {
-        response.json()
-          .then(json => {
-            if (response.ok) {
-              context.commit('UPDATE_NOTIFICATIONS', json.ocs.data)
-            } else {
-              context.commit('ERROR_NOTIFICATIONS', json.ocs.meta.message)
-            }
-            context.commit('LOADING_NOTIFICATIONS', false)
-          })
+    return client.requests
+      .ocs({
+        service: 'apps/notifications',
+        action: 'api/v1/notifications'
       })
-      .catch((error) => {
+      .then(response => {
+        response.json().then(json => {
+          if (response.ok) {
+            context.commit('UPDATE_NOTIFICATIONS', json.ocs.data)
+          } else {
+            context.commit('ERROR_NOTIFICATIONS', json.ocs.meta.message)
+          }
+          context.commit('LOADING_NOTIFICATIONS', false)
+        })
+      })
+      .catch(error => {
         context.commit('ERROR_NOTIFICATIONS', error)
         context.commit('LOADING_NOTIFICATIONS', false)
       })
   },
-  deleteNotification (context, { client, notification }) {
-    client.requests.ocs({
-      service: 'apps/notifications',
-      action: 'api/v1/notifications/' + notification,
-      method: 'DELETE'
-    })
+  deleteNotification(context, { client, notification }) {
+    client.requests
+      .ocs({
+        service: 'apps/notifications',
+        action: 'api/v1/notifications/' + notification,
+        method: 'DELETE'
+      })
       .then(response => {
         if (response.ok) {
           context.commit('DELETE_NOTIFICATION', notification)
@@ -53,32 +54,35 @@ const actions = {
           context.commit('ERROR_NOTIFICATIONS', response.ocs.meta.status)
         }
       })
-      .catch((error) => {
+      .catch(error => {
         context.commit('ERROR_NOTIFICATIONS', error)
       })
   }
 }
 
 const mutations = {
-  ENQUEUE_MESSAGE (state, message) {
+  ENQUEUE_MESSAGE(state, message) {
     // set random id to improve iteration in v-for & lodash
-    if (!message.id) message.id = Math.random().toString(36).slice(2, -1)
+    if (!message.id)
+      message.id = Math.random()
+        .toString(36)
+        .slice(2, -1)
     state.messages.push(message)
   },
-  REMOVE_MESSAGE (state, item) {
+  REMOVE_MESSAGE(state, item) {
     state.messages.splice(state.messages.indexOf(item), 1)
   },
-  LOADING_NOTIFICATIONS (state, loading) {
+  LOADING_NOTIFICATIONS(state, loading) {
     state.notifications.loading = loading
   },
-  ERROR_NOTIFICATIONS (state, failed) {
+  ERROR_NOTIFICATIONS(state, failed) {
     state.notifications.failed = failed
   },
-  UPDATE_NOTIFICATIONS (state, notifications) {
+  UPDATE_NOTIFICATIONS(state, notifications) {
     state.notifications.data = notifications
   },
-  DELETE_NOTIFICATION (state, notification) {
-    const data = state.notifications.data.filter((n) => {
+  DELETE_NOTIFICATION(state, notification) {
+    const data = state.notifications.data.filter(n => {
       return n.notification_id !== notification
     })
     state.notifications.data = data
@@ -90,7 +94,9 @@ const getters = {
     return state.messages
   },
   activeNotifications: state => {
-    return (state.notifications.data.length && !state.notifications.failed) ? state.notifications.data : false
+    return state.notifications.data.length && !state.notifications.failed
+      ? state.notifications.data
+      : false
   }
 }
 

--- a/src/store/apps.js
+++ b/src/store/apps.js
@@ -18,7 +18,7 @@ const actions = {
    * Open a file via webdav
    * @param {object} payload - filePath & client reference
    */
-  openFile (context, payload) {
+  openFile(context, payload) {
     return new Promise((resolve, reject) => {
       // TODO fix js-owncloud-client & change payload to filePath
       const filePath = payload.filePath
@@ -26,7 +26,10 @@ const actions = {
       // TODO fix js-owncloud-client & use global client
       const client = payload.client || false
       if (client) {
-        client.files.getFileContents(filePath).then(resolve).catch(reject)
+        client.files
+          .getFileContents(filePath)
+          .then(resolve)
+          .catch(reject)
       } else {
         // if no client is given, implicit resolve without fetching the file...
         // useful for images
@@ -34,10 +37,10 @@ const actions = {
       }
     })
   },
-  registerApp ({ commit }, app) {
+  registerApp({ commit }, app) {
     commit('REGISTER_APP', app)
   },
-  addFileAction ({ commit }, action) {
+  addFileAction({ commit }, action) {
     commit('ADD_FILE_ACTION', action)
   },
 
@@ -46,7 +49,7 @@ const actions = {
    * @param {Object} app      AppInfo containing information about app and local config
    * @param {Object} config   Config from config.json which can overwrite local config from AppInfo
    */
-  loadExternalAppConfig ({ dispatch }, { app, config }) {
+  loadExternalAppConfig({ dispatch }, { app, config }) {
     config.external_apps.map(extension => {
       // Check if app is loaded from external server
       // Extension id = id from external apps array
@@ -71,7 +74,7 @@ const actions = {
 }
 
 const mutations = {
-  REGISTER_APP (state, appInfo) {
+  REGISTER_APP(state, appInfo) {
     if (appInfo.fileActions) {
       appInfo.fileActions.forEach(a => {
         a.extensions.forEach(e => {
@@ -90,7 +93,7 @@ const mutations = {
       })
     }
     if (appInfo.extensions) {
-      appInfo.extensions.forEach((e) => {
+      appInfo.extensions.forEach(e => {
         const link = {
           app: appInfo.id,
           icon: e.icon,
@@ -114,7 +117,7 @@ const mutations = {
       // Merge in file side bars into global list
       // Reassign object in whole so that it updates the state properly
       const list = state.fileSideBars
-      appInfo.fileSideBars.forEach((sideBar) => {
+      appInfo.fileSideBars.forEach(sideBar => {
         list.push(sideBar)
       })
       state.fileSideBars = list
@@ -138,7 +141,7 @@ const mutations = {
     }
     state.meta[app.id] = app
   },
-  FETCH_FILE (state, filePath) {
+  FETCH_FILE(state, filePath) {
     state.file.path = filePath
   }
 }
@@ -159,7 +162,7 @@ const getters = {
       if (!ext) {
         return []
       }
-      ext.map((e) => {
+      ext.map(e => {
         if (e.version === 3) {
           return e
         }

--- a/src/store/config.js
+++ b/src/store/config.js
@@ -31,16 +31,16 @@ const state = {
 }
 
 const actions = {
-  loadConfig (context, config) {
+  loadConfig(context, config) {
     context.commit('LOAD_CONFIG', config)
   },
-  loadTheme (context, theme) {
+  loadTheme(context, theme) {
     context.commit('LOAD_THEME', theme)
   }
 }
 
 const mutations = {
-  LOAD_CONFIG (state, config) {
+  LOAD_CONFIG(state, config) {
     state.server = config.server
     state.auth = config.auth
     state.openIdConnect = config.openIdConnect
@@ -49,7 +49,7 @@ const mutations = {
     state.applications = config.applications === undefined ? [] : config.applications
     if (config.corrupted) state.corrupted = config.corrupted
   },
-  LOAD_THEME (state, theme) {
+  LOAD_THEME(state, theme) {
     state.theme = theme
   }
 }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -3,7 +3,7 @@ import Vuex from 'vuex'
 import VuexPersistence from 'vuex-persist'
 
 /* STORE MODULES
-*/
+ */
 import app from './app'
 import apps from './apps'
 import config from './config'
@@ -16,12 +16,9 @@ const vuexPersistInSession = new VuexPersistence({
   key: 'phoenixStateInSessionStorage',
   // Browser tab independent storage which gets deleted after the tab is closed
   storage: window.sessionStorage,
-  filter: (mutation) => ([
-    'SAVE_URL_BEFORE_LOGIN',
-    'SET_USER',
-    'SET_TOKEN',
-    'SET_CAPABILITIES'
-  ].indexOf(mutation.type) > -1),
+  filter: mutation =>
+    ['SAVE_URL_BEFORE_LOGIN', 'SET_USER', 'SET_TOKEN', 'SET_CAPABILITIES'].indexOf(mutation.type) >
+    -1,
   modules: ['router', 'user']
 })
 

--- a/src/store/router.js
+++ b/src/store/router.js
@@ -3,13 +3,13 @@ const state = {
 }
 
 const actions = {
-  saveUrlBeforeLogin ({ commit }, url) {
+  saveUrlBeforeLogin({ commit }, url) {
     commit('SAVE_URL_BEFORE_LOGIN', url)
   }
 }
 
 const mutations = {
-  SAVE_URL_BEFORE_LOGIN (state, url) {
+  SAVE_URL_BEFORE_LOGIN(state, url) {
     state.urlBeforeLogin = url
   }
 }

--- a/src/store/user.js
+++ b/src/store/user.js
@@ -15,7 +15,7 @@ const state = {
 }
 
 const actions = {
-  cleanUpLoginState (context) {
+  cleanUpLoginState(context) {
     if (context.state.id === '') {
       return
     }
@@ -26,7 +26,7 @@ const actions = {
     // clear oidc client state
     vueAuthInstance.clearLoginState()
   },
-  logout (context) {
+  logout(context) {
     const logoutFinalizer = () => {
       context.dispatch('cleanUpLoginState')
       // force redirect to login page after logout
@@ -35,7 +35,8 @@ const actions = {
     // TODO: only call logout if we still have the id token
     const u = vueAuthInstance.getStoredUserObject()
     if (u && u.id_token) {
-      vueAuthInstance.logout()
+      vueAuthInstance
+        .logout()
         .then(logoutFinalizer)
         .catch(error => {
           console.error(error)
@@ -45,8 +46,8 @@ const actions = {
       logoutFinalizer()
     }
   },
-  initAuth (context, payload = { autoRedirect: false }) {
-    function init (client, token, doLogin = true) {
+  initAuth(context, payload = { autoRedirect: false }) {
+    function init(client, token, doLogin = true) {
       const instance = context.rootState.config.server || window.location.origin
       const options = {
         baseUrl: instance,
@@ -67,9 +68,10 @@ const actions = {
 
       client.init(options)
       if (doLogin) {
-        return client.login().then(res => {
-          return client.getCapabilities()
-            .then(cap => {
+        return client
+          .login()
+          .then(res => {
+            return client.getCapabilities().then(cap => {
               client.users.getUserGroups(res.id).then(groups => {
                 context.commit('SET_CAPABILITIES', cap)
                 context.commit('SET_USER', {
@@ -86,11 +88,12 @@ const actions = {
                 }
               })
             })
-        }).catch((e) => {
-          console.warn('Seems that your token is invalid. Error:', e)
-          context.dispatch('cleanUpLoginState')
-          router.push({ name: 'accessDenied' })
-        })
+          })
+          .catch(e => {
+            console.warn('Seems that your token is invalid. Error:', e)
+            context.dispatch('cleanUpLoginState')
+            router.push({ name: 'accessDenied' })
+          })
       } else {
         context.commit('UPDATE_TOKEN', token)
       }
@@ -100,14 +103,18 @@ const actions = {
     if (!vueAuthInstance) {
       vueAuthInstance = initVueAuthenticate(context.rootState.config)
       const client = this._vm.$client
-      vueAuthInstance.events().addAccessTokenExpired(function () {
+      vueAuthInstance.events().addAccessTokenExpired(function() {
         console.log('AccessToken Expired：', arguments)
       })
-      vueAuthInstance.mgr.events.addAccessTokenExpiring(function () {
+      vueAuthInstance.mgr.events.addAccessTokenExpiring(function() {
         console.log('AccessToken Expiring：', arguments)
       })
       vueAuthInstance.events().addUserLoaded(user => {
-        console.log(`New User Loaded. access_token： ${user.access_token}, refresh_token: ${user.refresh_token}`)
+        console.log(
+          `New User Loaded. access_token： ${user.access_token}, refresh_token: ${
+            user.refresh_token
+          }`
+        )
         init(client, user.access_token, false)
       })
       vueAuthInstance.events().addUserUnloaded(() => {
@@ -126,7 +133,7 @@ const actions = {
       init(this._vm.$client, token)
     }
   },
-  login (context, payload = { provider: 'oauth2' }) {
+  login(context, payload = { provider: 'oauth2' }) {
     // reset vue-authenticate
     vueAuthInstance = initVueAuthenticate(context.rootState.config)
     vueAuthInstance.authenticate(payload.provider, {}, {}).then(() => {
@@ -135,18 +142,21 @@ const actions = {
       }
     })
   },
-  callback (context) {
+  callback(context) {
     if (!vueAuthInstance) vueAuthInstance = initVueAuthenticate(context.rootState.config)
-    vueAuthInstance.mgr.signinRedirectCallback().then(() => {
-      const autoRedirect = true
-      context.dispatch('initAuth', { autoRedirect })
-    }).catch((e) => {
-      console.warn('error in OpenIdConnect:', e)
-      context.dispatch('cleanUpLoginState')
-      router.push({ name: 'accessDenied' })
-    })
+    vueAuthInstance.mgr
+      .signinRedirectCallback()
+      .then(() => {
+        const autoRedirect = true
+        context.dispatch('initAuth', { autoRedirect })
+      })
+      .catch(e => {
+        console.warn('error in OpenIdConnect:', e)
+        context.dispatch('cleanUpLoginState')
+        router.push({ name: 'accessDenied' })
+      })
   },
-  signinSilentCallback (context) {
+  signinSilentCallback(context) {
     if (!vueAuthInstance) vueAuthInstance = initVueAuthenticate(context.rootState.config)
     vueAuthInstance.mgr.signinSilentCallback().then(() => {
       context.dispatch('initAuth')
@@ -155,7 +165,7 @@ const actions = {
 }
 
 const mutations = {
-  SET_USER (state, user) {
+  SET_USER(state, user) {
     state.displayname = user.displayname
     state.id = user.id
     state.email = user.email
@@ -163,26 +173,26 @@ const mutations = {
     state.token = user.token
     state.groups = user.groups
   },
-  SET_CAPABILITIES (state, data) {
+  SET_CAPABILITIES(state, data) {
     state.capabilities = data.capabilities
     state.version = data.version
   },
-  UPDATE_TOKEN (state, token) {
+  UPDATE_TOKEN(state, token) {
     state.token = token
   }
 }
 
 const getters = {
-  isAuthenticated: (state) => {
+  isAuthenticated: state => {
     return state.isAuthenticated
   },
-  getToken: (state) => {
+  getToken: state => {
     return state.token
   },
-  user: (state) => {
+  user: state => {
     return state
   },
-  capabilities: (state) => {
+  capabilities: state => {
     return state.capabilities
   }
 }

--- a/tests/acceptance/customCommands/angryClick.js
+++ b/tests/acceptance/customCommands/angryClick.js
@@ -4,9 +4,9 @@
 // If click fails, it might be because something is in the way.
 // Try dismissing lightboxes/overlays by clicking on the body tag,
 // then click again.
-exports.command = function angryClick (selector, callback) {
+exports.command = function angryClick(selector, callback) {
   var self = this
-  return this.click(selector, function (result) {
+  return this.click(selector, function(result) {
     if (result.status === 0) {
       // click succeeded, handle callback
       if (typeof callback === 'function') {
@@ -15,14 +15,14 @@ exports.command = function angryClick (selector, callback) {
     } else {
       // click failed
       console.log('element not clickable; will try again')
-      this.execute(function () {
+      this.execute(function() {
         // Bypass Selenium element selection and access the body directly.
         // TA body click handler will dismiss it.
         if (typeof document.body.click !== 'undefined') {
           document.body.click()
         }
       })
-      // try clicking again
+        // try clicking again
         .click(selector, callback)
     }
   })

--- a/tests/acceptance/customCommands/clearValueWithEvent.js
+++ b/tests/acceptance/customCommands/clearValueWithEvent.js
@@ -8,7 +8,7 @@
  * @param {string} selector
  * @returns
  */
-exports.command = function clearValueWithEvent (selector) {
+exports.command = function clearValueWithEvent(selector) {
   const { END, BACK_SPACE } = this.Keys
   return this.getValue(selector, result => {
     const chars = result.value.split('')

--- a/tests/acceptance/customCommands/clickElementAt.js
+++ b/tests/acceptance/customCommands/clickElementAt.js
@@ -1,4 +1,3 @@
-exports.command = function clickElementAt (selector, x, y, mouseButton = 0) {
-  return this.moveToElement(selector, x, y)
-    .mouseButtonClick(mouseButton)
+exports.command = function clickElementAt(selector, x, y, mouseButton = 0) {
+  return this.moveToElement(selector, x, y).mouseButtonClick(mouseButton)
 }

--- a/tests/acceptance/customCommands/getClipBoardContent.js
+++ b/tests/acceptance/customCommands/getClipBoardContent.js
@@ -1,23 +1,29 @@
-exports.command = function (callback) {
+exports.command = function(callback) {
   const helperElementId = 'helperClipboardInput'
-  this.execute(function (elementId) {
-    const myInput = document.createElement('INPUT')
-    const inputId = document.createAttribute('id')
-    inputId.value = elementId
-    myInput.setAttributeNode(inputId)
-    myInput.setAttribute('style', 'position: absolute; left:0; top:0;') // make sure its visible
-    document.body.appendChild(myInput)
-  }, [helperElementId])
+  this.execute(
+    function(elementId) {
+      const myInput = document.createElement('INPUT')
+      const inputId = document.createAttribute('id')
+      inputId.value = elementId
+      myInput.setAttributeNode(inputId)
+      myInput.setAttribute('style', 'position: absolute; left:0; top:0;') // make sure its visible
+      document.body.appendChild(myInput)
+    },
+    [helperElementId]
+  )
     .useCss()
     .setValue(`#${helperElementId}`, '') // just to focus the element
     .keys([this.Keys.CONTROL, 'v']) // copy the content of the clipboard into that field
-    .getValue(`#${helperElementId}`, function (clipboard) {
+    .getValue(`#${helperElementId}`, function(clipboard) {
       callback(clipboard.value)
     })
-    .execute(function (elementId) {
-      const el = document.getElementById(elementId)
-      el.parentNode.removeChild(el)
-    }, [helperElementId])
+    .execute(
+      function(elementId) {
+        const el = document.getElementById(elementId)
+        el.parentNode.removeChild(el)
+      },
+      [helperElementId]
+    )
 
   return this
 }

--- a/tests/acceptance/customCommands/initAjaxCounters.js
+++ b/tests/acceptance/customCommands/initAjaxCounters.js
@@ -1,38 +1,38 @@
-exports.command = function () {
-  this.execute(function () {
+exports.command = function() {
+  this.execute(function() {
     window.sumStartedAjaxRequests = 0
     window.activeAjaxCount = 0
 
-    function isAllXhrComplete () {
+    function isAllXhrComplete() {
       window.activeAjaxCount--
     }
 
-    (function (open) {
-      XMLHttpRequest.prototype.open = function () {
+    ;(function(open) {
+      XMLHttpRequest.prototype.open = function() {
         this.addEventListener('loadend', isAllXhrComplete)
         return open.apply(this, arguments)
       }
     })(XMLHttpRequest.prototype.open)
   })
-  this.execute(function () {
-    (function (send) {
-      XMLHttpRequest.prototype.send = function () {
+  this.execute(function() {
+    ;(function(send) {
+      XMLHttpRequest.prototype.send = function() {
         window.activeAjaxCount++
         window.sumStartedAjaxRequests++
         return send.apply(this, arguments)
       }
     })(XMLHttpRequest.prototype.send)
   })
-  this.execute(function () {
-    (function (wrappedFetch) {
-      window.fetch = function () {
+  this.execute(function() {
+    ;(function(wrappedFetch) {
+      window.fetch = function() {
         window.activeAjaxCount++
         window.sumStartedAjaxRequests++
         const fetchResult = wrappedFetch.apply(this, arguments)
-        fetchResult.then(function () {
+        fetchResult.then(function() {
           window.activeAjaxCount--
         })
-        fetchResult.catch(function () {
+        fetchResult.catch(function() {
           window.activeAjaxCount--
         })
         return fetchResult

--- a/tests/acceptance/customCommands/setValueBySingleKeys.js
+++ b/tests/acceptance/customCommands/setValueBySingleKeys.js
@@ -8,7 +8,7 @@
  * @param {string} inputValue
  * @returns
  */
-exports.command = function setValueBySingleKeys (selector, inputValue) {
+exports.command = function setValueBySingleKeys(selector, inputValue) {
   if (inputValue) {
     const chars = inputValue.split('').slice(0, -2)
     const charsEnd = inputValue.split('').slice(-2)
@@ -16,7 +16,7 @@ exports.command = function setValueBySingleKeys (selector, inputValue) {
 
     // Sometimes the autocomplete list is not displayed when the characters are entered very fast
     // So we add a small pause for entering the last two characters
-    const charEndPromise = charsEnd.map((char) => this.setValue(selector, char).pause(100)) || []
+    const charEndPromise = charsEnd.map(char => this.setValue(selector, char).pause(100)) || []
 
     return Promise.all([charPromise, ...charEndPromise])
   }

--- a/tests/acceptance/customCommands/toggleCheckbox.js
+++ b/tests/acceptance/customCommands/toggleCheckbox.js
@@ -4,12 +4,14 @@
  * @param {string} selector
  * @param {string} strategy which selection strategy to use 'css selector' or 'xpath'
  */
-exports.command = function (enableOrDisable, selector, strategy = 'css selector') {
-  this.element(strategy, selector, (response) => {
-    this.elementIdSelected(response.value.ELEMENT, (result) => {
+exports.command = function(enableOrDisable, selector, strategy = 'css selector') {
+  this.element(strategy, selector, response => {
+    this.elementIdSelected(response.value.ELEMENT, result => {
       const checked = result.value === true
-      if ((enableOrDisable === 'disable' && checked) ||
-        (enableOrDisable === 'enable' && !checked)) {
+      if (
+        (enableOrDisable === 'disable' && checked) ||
+        (enableOrDisable === 'enable' && !checked)
+      ) {
         // if the checkbox needs to be unchecked but it is checked
         // Or the checkbox needs to be checked but it is unchecked
         if (strategy === 'xpath') {
@@ -17,8 +19,7 @@ exports.command = function (enableOrDisable, selector, strategy = 'css selector'
             .click(selector)
             .useCss()
         } else {
-          this
-            .click(selector)
+          this.click(selector)
         }
       } else if (enableOrDisable !== 'enable' && enableOrDisable !== 'disable') {
         throw new Error(`Expected 'enable' or 'disable', ${enableOrDisable} given`)

--- a/tests/acceptance/customCommands/uploadRemote.js
+++ b/tests/acceptance/customCommands/uploadRemote.js
@@ -11,7 +11,7 @@ class UploadRemote extends events.EventEmitter {
    * @param {string} filePath Local path to the file used for uploading
    * @param {function (string): void} [callback] - called when file gets uploaded with path to uploaded file
    */
-  command (filePath, callback) {
+  command(filePath, callback) {
     const buffers = []
     const zip = archiver('zip')
     /*
@@ -21,8 +21,12 @@ class UploadRemote extends events.EventEmitter {
     was uploaded) which we can retrieve from the callback
      */
     zip
-      .on('data', data => { buffers.push(data) })
-      .on('error', err => { throw err })
+      .on('data', data => {
+        buffers.push(data)
+      })
+      .on('error', err => {
+        throw err
+      })
       .on('warning', console.log)
       .on('finish', () => {
         const file = Buffer.concat(buffers).toString('base64')

--- a/tests/acceptance/customCommands/useStrategy.js
+++ b/tests/acceptance/customCommands/useStrategy.js
@@ -12,7 +12,7 @@ class UseStrategy extends events.EventEmitter {
    * useSelector(selector).assert.elementNotPresent.useCss() // selector is string
    * useSelector({locateStrategy: selector})
    */
-  command (strategy = this.client.locateStrategy) {
+  command(strategy = this.client.locateStrategy) {
     if (typeof strategy === 'object' && strategy.locateStrategy) {
       strategy = strategy.locateStrategy
     }

--- a/tests/acceptance/customCommands/waitForAjaxCallsToStartAndFinish.js
+++ b/tests/acceptance/customCommands/waitForAjaxCallsToStartAndFinish.js
@@ -1,7 +1,7 @@
 var numAjaxRequestsStart = 0
 var start = 0
 var end = 0
-const sleepWhenNoNewAjaxCallsStarted = function (result) {
+const sleepWhenNoNewAjaxCallsStarted = function(result) {
   var currentTime = Date.now()
   if (result.value <= numAjaxRequestsStart && currentTime < end) {
     this.pause(this.globals.waitForConditionPollInterval)
@@ -12,18 +12,20 @@ const sleepWhenNoNewAjaxCallsStarted = function (result) {
   }
 }
 
-const checkSumStartedAjaxRequests = function (api) {
+const checkSumStartedAjaxRequests = function(api) {
   api.execute('return window.sumStartedAjaxRequests', [], sleepWhenNoNewAjaxCallsStarted)
 }
-exports.command = function () {
+exports.command = function() {
   // init the ajax counters if they haven't been initialized yet
-  this.execute('return (typeof window.sumStartedAjaxRequests === "undefined")', [], function (result) {
+  this.execute('return (typeof window.sumStartedAjaxRequests === "undefined")', [], function(
+    result
+  ) {
     if (result.value === true) {
       this.initAjaxCounters()
     }
   })
 
-  this.execute('return window.sumStartedAjaxRequests', [], function (result) {
+  this.execute('return window.sumStartedAjaxRequests', [], function(result) {
     numAjaxRequestsStart = result.value
   })
   start = Date.now()

--- a/tests/acceptance/customCommands/waitForAnimationToFinish.js
+++ b/tests/acceptance/customCommands/waitForAnimationToFinish.js
@@ -2,7 +2,7 @@
  * try to use waitForElementEnabled() instead of this
  * @returns {exports}
  */
-exports.command = function () {
+exports.command = function() {
   // till we have a better idea how to detect that an animation is finished
   console.log('waiting for 500ms ...')
   this.pause(500)

--- a/tests/acceptance/customCommands/waitForCSSPropertyEquals.js
+++ b/tests/acceptance/customCommands/waitForCSSPropertyEquals.js
@@ -8,9 +8,13 @@
  * @returns {exports}
  */
 
-module.exports.command = function (
-  { selector, locateStrategy = 'css selector', property, value, timeout = this.globals.waitForConditionTimeout }
-) {
+module.exports.command = function({
+  selector,
+  locateStrategy = 'css selector',
+  property,
+  value,
+  timeout = this.globals.waitForConditionTimeout
+}) {
   if (locateStrategy === 'xpath') {
     this.useXpath()
   } else if (locateStrategy === 'css selector') {
@@ -18,6 +22,10 @@ module.exports.command = function (
   } else {
     this.assert.fail('invalid locateStrategy')
   }
-  this.expect.element(selector).to.have.css(property).which.equals(value).before(timeout)
+  this.expect
+    .element(selector)
+    .to.have.css(property)
+    .which.equals(value)
+    .before(timeout)
   return this
 }

--- a/tests/acceptance/customCommands/waitForElementEnabled.js
+++ b/tests/acceptance/customCommands/waitForElementEnabled.js
@@ -14,8 +14,10 @@
  * @param timeout defaults to this.globals.waitForConditionTimeout
  * @returns {exports}
  */
-module.exports.command = function (
-  selector, locateStrategy = 'css selector', timeout = this.globals.waitForConditionTimeout
+module.exports.command = function(
+  selector,
+  locateStrategy = 'css selector',
+  timeout = this.globals.waitForConditionTimeout
 ) {
   let self = this
   if (locateStrategy === 'xpath') {

--- a/tests/acceptance/customCommands/waitForOutstandingAjaxCalls.js
+++ b/tests/acceptance/customCommands/waitForOutstandingAjaxCalls.js
@@ -1,4 +1,4 @@
-const sleepWhenOutstandingAjaxCalls = function (result, retryWithZero) {
+const sleepWhenOutstandingAjaxCalls = function(result, retryWithZero) {
   // sleep in all cases, because even with zero calls we don't know if there isn't
   // one that might start in the next tick, so to be sure sleep again
   this.pause(this.globals.waitForConditionPollInterval)
@@ -10,16 +10,18 @@ const sleepWhenOutstandingAjaxCalls = function (result, retryWithZero) {
   }
 }
 
-exports.command = function (retryWithZero = true) {
+exports.command = function(retryWithZero = true) {
   // init the ajax counter if it hasn't been initialized yet
-  this.execute('return (typeof window.activeAjaxCount === "undefined")', [], function (result) {
+  this.execute('return (typeof window.activeAjaxCount === "undefined")', [], function(result) {
     if (result.value === true) {
-      throw Error('checking outstanding Ajax calls will not work without calling initAjaxCounter() first')
+      throw Error(
+        'checking outstanding Ajax calls will not work without calling initAjaxCounter() first'
+      )
     }
   })
 
-  this.execute(
-    'return window.activeAjaxCount', [], (result) => sleepWhenOutstandingAjaxCalls.call(this, result, retryWithZero)
+  this.execute('return window.activeAjaxCount', [], result =>
+    sleepWhenOutstandingAjaxCalls.call(this, result, retryWithZero)
   )
   return this
 }

--- a/tests/acceptance/helpers/backendHelper.js
+++ b/tests/acceptance/helpers/backendHelper.js
@@ -4,15 +4,15 @@ const { client } = require('nightwatch-api')
  * @enum {string}
  * @readonly
  */
-const BACKENDS = exports.BACKENDS = Object.freeze({
+const BACKENDS = (exports.BACKENDS = Object.freeze({
   local: 'LOCAL',
   remote: 'REMOTE'
-})
+}))
 
 /**
  * Give the backend URL for currently default backend
  */
-exports.getCurrentBackendUrl = function () {
+exports.getCurrentBackendUrl = function() {
   // eslint-disable-next-line camelcase
   const { backend_url, remote_backend_url, default_backend } = client.globals
   // eslint-disable-next-line camelcase
@@ -33,7 +33,7 @@ exports.getCurrentBackendUrl = function () {
  * runOnRemoteBackend(doSomething, arg1, arg2); // if you don't want unnecessary closures
  * runOnRemoteBackend(() => doSomething(arg1, arg2)); // use closure to get better completion
  */
-exports.runOnRemoteBackend = async function (fn, ...args) {
+exports.runOnRemoteBackend = async function(fn, ...args) {
   if (typeof fn !== 'function') {
     throw new Error('expected function, received: ' + typeof fn)
   }

--- a/tests/acceptance/helpers/browserConsole.js
+++ b/tests/acceptance/helpers/browserConsole.js
@@ -1,18 +1,20 @@
 import { client } from 'nightwatch-api'
 
-function cleanupLogMessage (message) {
-  return message
-    .replace(/\\u003C/gi, '')
-    .replace(/\\n/g, '\n') // revive newlines
+function cleanupLogMessage(message) {
+  return message.replace(/\\u003C/gi, '').replace(/\\n/g, '\n') // revive newlines
 }
 
-function formatLog (log) {
-  return new Date(log.timestamp).toLocaleTimeString() + ' - ' +
-    log.level + ' - ' +
+function formatLog(log) {
+  return (
+    new Date(log.timestamp).toLocaleTimeString() +
+    ' - ' +
+    log.level +
+    ' - ' +
     cleanupLogMessage(log.message)
+  )
 }
 
-async function getAllLogs () {
+async function getAllLogs() {
   let logs = []
   await client.getLog('browser', entries => {
     logs = entries
@@ -20,13 +22,11 @@ async function getAllLogs () {
   return logs
 }
 
-export async function getAllLogsWithDateTime (level = null) {
+export async function getAllLogsWithDateTime(level = null) {
   let logs = await getAllLogs()
   if (level) {
     logs = logs.filter(entry => entry.level === level)
   }
 
-  return logs
-    .filter(e => !e.message.includes('favicon.ico'))
-    .map(formatLog)
+  return logs.filter(e => !e.message.includes('favicon.ico')).map(formatLog)
 }

--- a/tests/acceptance/helpers/codify.js
+++ b/tests/acceptance/helpers/codify.js
@@ -9,7 +9,7 @@ const { passwords } = require('./userSettings')
  * @param {string} input
  * @returns {string}
  */
-exports.replaceInlineCode = function (input) {
+exports.replaceInlineCode = function(input) {
   const codes = {
     ...passwords,
     remote_backend_url: client.globals.remote_backend_url,
@@ -21,7 +21,7 @@ exports.replaceInlineCode = function (input) {
   return compiled(codes)
 }
 
-exports.replaceInlineTable = function (dataTable) {
+exports.replaceInlineTable = function(dataTable) {
   dataTable.raw().forEach(row => {
     row.forEach((cell, index, arr) => {
       arr[index] = exports.replaceInlineCode(cell)

--- a/tests/acceptance/helpers/config.js
+++ b/tests/acceptance/helpers/config.js
@@ -9,20 +9,17 @@ const limit = pLimit(10)
 
 const config = {}
 
-async function setSkeletonDirectory (server, admin) {
+async function setSkeletonDirectory(server, admin) {
   const data = JSON.stringify({ directory: 'webUISkeleton' })
   const apiUrl = 'apps/testing/api/v1/testingskeletondirectory'
-  const resp = await httpHelper.postOCS(
-    apiUrl,
-    'admin',
-    data,
-    { 'Content-Type': 'application/json' }
-  )
+  const resp = await httpHelper.postOCS(apiUrl, 'admin', data, {
+    'Content-Type': 'application/json'
+  })
 
   httpHelper.checkStatus(resp, 'Could not set skeletondirectory.')
 }
 
-function rollbackSystemConfigs (oldSysConfig, newSysConfig) {
+function rollbackSystemConfigs(oldSysConfig, newSysConfig) {
   const configToChange = difference(newSysConfig, oldSysConfig)
   const _rollbacks = []
 
@@ -34,22 +31,14 @@ function rollbackSystemConfigs (oldSysConfig, newSysConfig) {
     if (value === undefined) {
       _rollbacks.push(limit(occHelper.runOcc, ['config:system:delete', key]))
     } else {
-      _rollbacks.push(
-        limit(
-          occHelper.runOcc, [
-            'config:system:set',
-            key,
-          `--value=${value}`
-          ]
-        )
-      )
+      _rollbacks.push(limit(occHelper.runOcc, ['config:system:set', key, `--value=${value}`]))
     }
   }
 
   return Promise.all(_rollbacks)
 }
 
-function rollbackAppConfigs (oldAppConfig, newAppConfig) {
+function rollbackAppConfigs(oldAppConfig, newAppConfig) {
   const configToChange = difference(newAppConfig, oldAppConfig)
 
   const _rollbacks = []
@@ -60,15 +49,7 @@ function rollbackAppConfigs (oldAppConfig, newAppConfig) {
       if (value === undefined) {
         _rollbacks.push(limit(occHelper.runOcc, ['config:app:delete', app, key]))
       } else {
-        _rollbacks.push(
-          limit(
-            occHelper.runOcc,
-            [
-              'config:app:set', app, key,
-              `--value=${value}`
-            ]
-          )
-        )
+        _rollbacks.push(limit(occHelper.runOcc, ['config:app:set', app, key, `--value=${value}`]))
       }
     }
   }
@@ -76,10 +57,8 @@ function rollbackAppConfigs (oldAppConfig, newAppConfig) {
   return Promise.all(_rollbacks)
 }
 
-export async function getConfigs () {
-  const resp = await occHelper.runOcc([
-    'config:list'
-  ])
+export async function getConfigs() {
+  const resp = await occHelper.runOcc(['config:list'])
   let stdOut = _.get(resp, 'ocs.data.stdOut')
   if (stdOut === undefined) {
     throw new Error('stdOut notFound, Found:', resp)
@@ -88,16 +67,16 @@ export async function getConfigs () {
   return stdOut
 }
 
-export async function cacheConfigs (server) {
+export async function cacheConfigs(server) {
   config[server] = await getConfigs()
   return config
 }
 
-export async function setConfigs (server, admin = 'admin') {
+export async function setConfigs(server, admin = 'admin') {
   await setSkeletonDirectory(server, admin)
 }
 
-export async function rollbackConfigs (server) {
+export async function rollbackConfigs(server) {
   const newConfig = await getConfigs()
 
   const appConfig = _.get(newConfig, 'apps')

--- a/tests/acceptance/helpers/httpHelper.js
+++ b/tests/acceptance/helpers/httpHelper.js
@@ -10,11 +10,10 @@ const backendHelper = require('../helpers/backendHelper')
  *
  * @returns {{Authorization: string}}
  */
-const createAuthHeader = function (userId) {
+const createAuthHeader = function(userId) {
   const password = userSettings.getPasswordForUser(userId)
   return {
-    Authorization: 'Basic ' +
-      Buffer.from(userId + ':' + password).toString('base64')
+    Authorization: 'Basic ' + Buffer.from(userId + ':' + password).toString('base64')
   }
 }
 /**
@@ -23,7 +22,7 @@ const createAuthHeader = function (userId) {
  *
  * @returns {{<header>: string}}
  */
-const createOCSRequestHeaders = function (userId) {
+const createOCSRequestHeaders = function(userId) {
   return {
     ...createAuthHeader(userId),
     'OCS-APIREQUEST': true
@@ -37,8 +36,9 @@ const createOCSRequestHeaders = function (userId) {
  * @throws Error
  * @returns {node-fetch.Response}
  */
-const checkStatus = function (response, message) {
-  if (response.ok) { // response.status >= 200 && response.status < 300
+const checkStatus = function(response, message) {
+  if (response.ok) {
+    // response.status >= 200 && response.status < 300
     return response
   } else {
     throw Error(message + ' Status:' + response.status + ' ' + response.statusText)
@@ -53,7 +53,7 @@ const checkStatus = function (response, message) {
  * @throws Error
  * @returns {node-fetch.Response}
  */
-const checkOCSStatus = function (response, message) {
+const checkOCSStatus = function(response, message) {
   const statusCode = _.get(response, 'ocs.meta.statuscode')
   if (statusCode === 200) {
     return response
@@ -80,7 +80,7 @@ const fetcher = (url, options) => fetch(url, options)
  *
  * @returns {node-fetch}
  */
-const requestEndpoint = function (path, params, userId = 'admin', header = {}) {
+const requestEndpoint = function(path, params, userId = 'admin', header = {}) {
   const headers = { ...createAuthHeader(userId), ...header }
   const options = { ...params, headers }
   const url = join(backendHelper.getCurrentBackendUrl(), 'remote.php/dav', path)
@@ -96,11 +96,15 @@ const requestEndpoint = function (path, params, userId = 'admin', header = {}) {
  *
  * @returns {node-fetch}
  */
-const requestOCSEndpoint = function (path, params, userId = 'admin', header = {}) {
+const requestOCSEndpoint = function(path, params, userId = 'admin', header = {}) {
   const headers = { ...createOCSRequestHeaders(userId), ...header }
   const options = { ...params, headers }
   const separator = path.includes('?') ? '&' : '?'
-  const url = join(backendHelper.getCurrentBackendUrl(), 'ocs/v2.php', path + separator + 'format=json')
+  const url = join(
+    backendHelper.getCurrentBackendUrl(),
+    'ocs/v2.php',
+    path + separator + 'format=json'
+  )
   return fetcher(url, options)
 }
 
@@ -112,17 +116,27 @@ module.exports = {
   requestEndpoint,
   requestOCSEndpoint,
   // ocs request methods
-  getOCS: (url, userId, body, header) => requestOCSEndpoint(url, { body, method: 'GET' }, userId, header),
-  putOCS: (url, userId, body, header) => requestOCSEndpoint(url, { body, method: 'PUT' }, userId, header),
-  postOCS: (url, userId, body, header) => requestOCSEndpoint(url, { body, method: 'POST' }, userId, header),
-  deleteOCS: (url, userId, body, header) => requestOCSEndpoint(url, { body, method: 'DELETE' }, userId, header),
+  getOCS: (url, userId, body, header) =>
+    requestOCSEndpoint(url, { body, method: 'GET' }, userId, header),
+  putOCS: (url, userId, body, header) =>
+    requestOCSEndpoint(url, { body, method: 'PUT' }, userId, header),
+  postOCS: (url, userId, body, header) =>
+    requestOCSEndpoint(url, { body, method: 'POST' }, userId, header),
+  deleteOCS: (url, userId, body, header) =>
+    requestOCSEndpoint(url, { body, method: 'DELETE' }, userId, header),
   // dav request methods
   get: (url, userId, body, header) => requestEndpoint(url, { body, method: 'GET' }, userId, header),
   put: (url, userId, body, header) => requestEndpoint(url, { body, method: 'PUT' }, userId, header),
-  delete: (url, userId, body, header) => requestEndpoint(url, { body, method: 'DELETE' }, userId, header),
-  move: (url, userId, body, header) => requestEndpoint(url, { body, method: 'MOVE' }, userId, header),
-  mkcol: (url, userId, body, header) => requestEndpoint(url, { body, method: 'MKCOL' }, userId, header),
-  propfind: (url, userId, body, header) => requestEndpoint(url, { body, method: 'PROPFIND' }, userId, header),
-  report: (url, userId, body, header) => requestEndpoint(url, { body, method: 'REPORT' }, userId, header),
-  proppatch: (url, userId, body, header) => requestEndpoint(url, { body, method: 'PROPPATCH' }, userId, header)
+  delete: (url, userId, body, header) =>
+    requestEndpoint(url, { body, method: 'DELETE' }, userId, header),
+  move: (url, userId, body, header) =>
+    requestEndpoint(url, { body, method: 'MOVE' }, userId, header),
+  mkcol: (url, userId, body, header) =>
+    requestEndpoint(url, { body, method: 'MKCOL' }, userId, header),
+  propfind: (url, userId, body, header) =>
+    requestEndpoint(url, { body, method: 'PROPFIND' }, userId, header),
+  report: (url, userId, body, header) =>
+    requestEndpoint(url, { body, method: 'REPORT' }, userId, header),
+  proppatch: (url, userId, body, header) =>
+    requestEndpoint(url, { body, method: 'PROPPATCH' }, userId, header)
 }

--- a/tests/acceptance/helpers/ldapHelper.js
+++ b/tests/acceptance/helpers/ldapHelper.js
@@ -8,7 +8,7 @@ const userHelper = require('./userSettings')
 const USERS_OU = 'ou=TestUsers,dc=owncloud,dc=com'
 const GROUPS_OU = 'ou=TestGroups,dc=owncloud,dc=com'
 
-exports.createClient = function (url) {
+exports.createClient = function(url) {
   return new Promise((resolve, reject) => {
     const ldapClient = ldap.createClient({
       url: url || client.globals.ldap_url
@@ -20,29 +20,37 @@ exports.createClient = function (url) {
       }
     })
 
-    ldapClient.add(USERS_OU, {
-      objectclass: ['top', 'organizationalUnit'],
-      ou: 'TestUsers'
-    }, (err) => {
-      if (err) {
-        console.log('Users OU already exists.')
-      }
-      ldapClient.add(GROUPS_OU, {
+    ldapClient.add(
+      USERS_OU,
+      {
         objectclass: ['top', 'organizationalUnit'],
-        ou: 'TestGroups'
-      }, (err) => {
+        ou: 'TestUsers'
+      },
+      err => {
         if (err) {
-          console.log('Groups OU already exists.')
+          console.log('Users OU already exists.')
         }
-        resolve(ldapClient)
-      })
-    })
+        ldapClient.add(
+          GROUPS_OU,
+          {
+            objectclass: ['top', 'organizationalUnit'],
+            ou: 'TestGroups'
+          },
+          err => {
+            if (err) {
+              console.log('Groups OU already exists.')
+            }
+            resolve(ldapClient)
+          }
+        )
+      }
+    )
   })
 }
 
-exports.createEntry = function (client, dn, entry) {
+exports.createEntry = function(client, dn, entry) {
   return new Promise((resolve, reject) => {
-    client.add(dn, entry, function (err) {
+    client.add(dn, entry, function(err) {
       if (err) {
         reject(err)
       }
@@ -52,16 +60,16 @@ exports.createEntry = function (client, dn, entry) {
   })
 }
 
-exports.cleanup = function (client) {
+exports.cleanup = function(client) {
   return new Promise((resolve, reject) => {
-    client.del(GROUPS_OU, function (err) {
+    client.del(GROUPS_OU, function(err) {
       if (err) {
         reject(err)
       }
       resolve()
     })
   }).then(() => {
-    client.del(USERS_OU, function (err) {
+    client.del(USERS_OU, function(err) {
       if (err) {
         Promise.reject(err)
       }
@@ -70,69 +78,74 @@ exports.cleanup = function (client) {
   })
 }
 
-exports.getNewUID = function (ldapClient) {
+exports.getNewUID = function(ldapClient) {
   const userCn = USERS_OU
   let uid = 1
   return new Promise((resolve, reject) => {
-    ldapClient.search(
-      userCn,
-      { scope: 'sub', attributes: ['uidNumber'] },
-      (err, res) => {
-        if (err) reject(err)
-        res.on('searchEntry', function (entry) {
-          const entryId = parseInt(entry.object.uidNumber)
-          if (entryId >= uid) {
-            uid = entryId + 1
-          }
-        })
-        res.on('error', function (err) {
-          reject(err)
-        })
-        res.on('end', function (result) {
-          resolve(uid)
-        })
+    ldapClient.search(userCn, { scope: 'sub', attributes: ['uidNumber'] }, (err, res) => {
+      if (err) reject(err)
+      res.on('searchEntry', function(entry) {
+        const entryId = parseInt(entry.object.uidNumber)
+        if (entryId >= uid) {
+          uid = entryId + 1
+        }
       })
+      res.on('error', function(err) {
+        reject(err)
+      })
+      res.on('end', function(result) {
+        resolve(uid)
+      })
+    })
   })
 }
 
-exports.createUser = async function (ldapClient, user, password = null, displayName = null, email = null) {
+exports.createUser = async function(
+  ldapClient,
+  user,
+  password = null,
+  displayName = null,
+  email = null
+) {
   password = password || userHelper.getPasswordForUser(user)
   displayName = displayName || userHelper.getDisplayNameForUser(user)
   email = email || userHelper.getEmailAddressForUser(user)
   const uid = await exports.getNewUID(ldapClient)
-  return exports.createEntry(ldapClient, `uid=${user},${USERS_OU}`, {
-    cn: user,
-    sn: user,
-    objectclass: ['posixAccount', 'inetOrgPerson'],
-    homeDirectory: `/home/openldap/${user}`,
-    userPassword: password,
-    displayName: displayName,
-    mail: email,
-    gidNumber: 5000,
-    uidNumber: uid,
-    gecos: user,
-    loginshell: '/bin/bash',
-    uid: user,
-    givenname: user
-  }).then(err => {
-    if (!err) {
-      userHelper.addUserToCreatedUsersList(user, password, displayName, email)
-      const skelDir = client.globals.ocis_skeleton_dir
-      if (skelDir) {
-        const dataDir = join(client.globals.ocis_data_dir, 'data', user)
-        if (!fs.existsSync(dataDir)) {
-          fs.removeSync(dataDir)
-          fs.mkdirpSync(dataDir)
+  return exports
+    .createEntry(ldapClient, `uid=${user},${USERS_OU}`, {
+      cn: user,
+      sn: user,
+      objectclass: ['posixAccount', 'inetOrgPerson'],
+      homeDirectory: `/home/openldap/${user}`,
+      userPassword: password,
+      displayName: displayName,
+      mail: email,
+      gidNumber: 5000,
+      uidNumber: uid,
+      gecos: user,
+      loginshell: '/bin/bash',
+      uid: user,
+      givenname: user
+    })
+    .then(err => {
+      if (!err) {
+        userHelper.addUserToCreatedUsersList(user, password, displayName, email)
+        const skelDir = client.globals.ocis_skeleton_dir
+        if (skelDir) {
+          const dataDir = join(client.globals.ocis_data_dir, 'data', user)
+          if (!fs.existsSync(dataDir)) {
+            fs.removeSync(dataDir)
+            fs.mkdirpSync(dataDir)
+          }
+          return fs.copy(skelDir, join(dataDir, 'files'))
         }
-        return fs.copy(skelDir, join(dataDir, 'files'))
+        return
       }
-      return
-    }
-    return Promise.reject(new Error('Could not create user on LDAP backend!'))
-  })
+      return Promise.reject(new Error('Could not create user on LDAP backend!'))
+    })
 }
 
-exports.createGroup = function (client, group, members = []) {
+exports.createGroup = function(client, group, members = []) {
   const entry = {
     cn: group,
     objectclass: ['posixGroup', 'top'],
@@ -144,9 +157,9 @@ exports.createGroup = function (client, group, members = []) {
   return exports.createEntry(client, `cn=${group},${GROUPS_OU}`, entry)
 }
 
-exports.deleteGroup = function (client, group) {
+exports.deleteGroup = function(client, group) {
   return new Promise((resolve, reject) => {
-    client.del(`cn=${group},${GROUPS_OU}`, function (err) {
+    client.del(`cn=${group},${GROUPS_OU}`, function(err) {
       if (err) {
         reject(err)
       }
@@ -155,9 +168,9 @@ exports.deleteGroup = function (client, group) {
   })
 }
 
-exports.deleteUser = function (client, user) {
+exports.deleteUser = function(client, user) {
   return new Promise((resolve, reject) => {
-    client.del(`uid=${user},${USERS_OU}`, function (err) {
+    client.del(`uid=${user},${USERS_OU}`, function(err) {
       if (err) {
         reject(err)
       }
@@ -166,8 +179,8 @@ exports.deleteUser = function (client, user) {
   })
 }
 
-exports.terminate = function (ldapClient) {
-  return new Promise((resolve) => {
+exports.terminate = function(ldapClient) {
+  return new Promise(resolve => {
     if (!ldapClient) {
       resolve()
     }
@@ -181,47 +194,43 @@ exports.terminate = function (ldapClient) {
   })
 }
 
-exports.addUserToGroup = function (client, user, group) {
+exports.addUserToGroup = function(client, user, group) {
   return new Promise((resolve, reject) => {
     const groupCn = `cn=${group},${GROUPS_OU}`
-    client.search(
-      groupCn,
-      { attributes: [] },
-      (err, res) => {
-        if (err) reject(err)
-        res.on('searchEntry', function (entry) {
-          var memberUid
-          if (entry.object.memberUid) {
-            if (
-              entry.object.memberUid === user ||
-              (Array.isArray(entry.object.memberUid) &&
-                entry.object.memberuid.includes(user))
-            ) {
-              resolve()
-            } else if (Array.isArray(entry.object.memberUid)) {
-              memberUid = entry.object.memberUid.concat(user)
-            } else {
-              memberUid = [user, entry.object.memberUid]
-            }
+    client.search(groupCn, { attributes: [] }, (err, res) => {
+      if (err) reject(err)
+      res.on('searchEntry', function(entry) {
+        var memberUid
+        if (entry.object.memberUid) {
+          if (
+            entry.object.memberUid === user ||
+            (Array.isArray(entry.object.memberUid) && entry.object.memberuid.includes(user))
+          ) {
+            resolve()
+          } else if (Array.isArray(entry.object.memberUid)) {
+            memberUid = entry.object.memberUid.concat(user)
           } else {
-            memberUid = user
+            memberUid = [user, entry.object.memberUid]
           }
-          const change = new ldap.Change({
-            operation: 'replace',
-            modification: {
-              memberUid
-            }
-          })
-          client.modify(groupCn, change, function (err) {
-            if (err) reject(err)
-          })
+        } else {
+          memberUid = user
+        }
+        const change = new ldap.Change({
+          operation: 'replace',
+          modification: {
+            memberUid
+          }
         })
-        res.on('error', function (err) {
-          reject(err)
-        })
-        res.on('end', function (result) {
-          resolve()
+        client.modify(groupCn, change, function(err) {
+          if (err) reject(err)
         })
       })
+      res.on('error', function(err) {
+        reject(err)
+      })
+      res.on('end', function(result) {
+        resolve()
+      })
+    })
   })
 }

--- a/tests/acceptance/helpers/loginHelper.js
+++ b/tests/acceptance/helpers/loginHelper.js
@@ -1,4 +1,10 @@
-const { client, createSession, closeSession, startWebDriver, stopWebDriver } = require('nightwatch-api')
+const {
+  client,
+  createSession,
+  closeSession,
+  startWebDriver,
+  stopWebDriver
+} = require('nightwatch-api')
 const userSettings = require('./userSettings')
 
 module.exports = {
@@ -7,8 +13,11 @@ module.exports = {
    * @param {userId} userId
    * @param {password} [password=null] - If not passed, default password for given `userId` will be used
    */
-  loginAsUser: async function (userId, password = null) {
-    await client.page.loginPage().navigate().authenticate()
+  loginAsUser: async function(userId, password = null) {
+    await client.page
+      .loginPage()
+      .navigate()
+      .authenticate()
 
     password = password || userSettings.getPasswordForUser(userId)
     if (client.globals.openid_login) {
@@ -18,8 +27,8 @@ module.exports = {
       await client.page.ownCloudLoginPage().login(userId, password)
       await client.page.ownCloudAuthorizePage().authorize()
     }
-    await client
-      .page.phoenixPage()
+    await client.page
+      .phoenixPage()
       .waitForElementVisible('@appContainer')
       .then(() => {
         client.globals.currentUser = userId
@@ -31,7 +40,7 @@ module.exports = {
    *
    * @param {string} userId
    */
-  reLoginAsUser: async function (userId) {
+  reLoginAsUser: async function(userId) {
     let env = 'local'
     if (process.env.DRONE) {
       env = 'drone'
@@ -43,7 +52,7 @@ module.exports = {
     return this.loginAsUser(userId)
   },
 
-  logout: function (userId) {
+  logout: function(userId) {
     const phoenixPage = client.page.phoenixPage()
     return phoenixPage
       .navigate()

--- a/tests/acceptance/helpers/navigationHelper.js
+++ b/tests/acceptance/helpers/navigationHelper.js
@@ -1,12 +1,11 @@
 const { client } = require('nightwatch-api')
 
 module.exports = {
-
   /**
    * @param {string} url
    * @param {object} loadingIndicatorSelector - object that can have properties {selector [,locateStrategy]}
    */
-  navigateAndWaitTillLoaded: function (url, loadingIndicatorSelector) {
+  navigateAndWaitTillLoaded: function(url, loadingIndicatorSelector) {
     client.url(url)
     client.refresh() // IE11 needs an extra refresh because of the hash in the url
     const locator = {}

--- a/tests/acceptance/helpers/objects.js
+++ b/tests/acceptance/helpers/objects.js
@@ -7,11 +7,11 @@ const _ = require('lodash')
  * @param  {Object} base   Object to compare with
  * @return {Object}        Return a new object who represent the diff
  */
-exports.difference = function (object, base) {
-  function changes (object, base) {
-    return _.transform(object, function (result, value, key) {
+exports.difference = function(object, base) {
+  function changes(object, base) {
+    return _.transform(object, function(result, value, key) {
       if (!_.isEqual(value, base[key])) {
-        result[key] = (_.isObject(value) && _.isObject(base[key])) ? changes(value, base[key]) : value
+        result[key] = _.isObject(value) && _.isObject(base[key]) ? changes(value, base[key]) : value
       }
     })
   }

--- a/tests/acceptance/helpers/occHelper.js
+++ b/tests/acceptance/helpers/occHelper.js
@@ -5,15 +5,17 @@ const httpHelper = require('../helpers/httpHelper')
  *
  * @param {Array} args
  */
-exports.runOcc = function (args) {
+exports.runOcc = function(args) {
   const params = new URLSearchParams()
   params.append('command', args.join(' '))
   const apiURL = 'apps/testing/api/v1/occ'
-  return httpHelper.postOCS(apiURL, 'admin', params)
+  return httpHelper
+    .postOCS(apiURL, 'admin', params)
     .then(res => {
       httpHelper.checkStatus(res, 'Failed while executing occ command')
       return res.json()
-    }).then(res => {
+    })
+    .then(res => {
       httpHelper.checkOCSStatus(res, 'Failed while executing occ command')
       return res
     })

--- a/tests/acceptance/helpers/path.js
+++ b/tests/acceptance/helpers/path.js
@@ -3,21 +3,26 @@ const fs = require('fs')
 const _ = require('lodash/fp')
 const assert = require('assert')
 const normalize = _.replace(/^\/+|$/g, '')
-const parts = _.pipe(normalize, _.split('/'))
-const relativeTo = function (basePath, childPath) {
+const parts = _.pipe(
+  normalize,
+  _.split('/')
+)
+const relativeTo = function(basePath, childPath) {
   basePath = normalize(basePath)
   childPath = normalize(childPath)
   assert.ok(childPath.startsWith(basePath), `${childPath} doesnot contain ${basePath}`)
   const basePathLength = basePath.length
   return childPath.slice(basePathLength)
 }
-const deleteFolderRecursive = function (path) {
+const deleteFolderRecursive = function(path) {
   if (fs.existsSync(path)) {
     fs.readdirSync(path).forEach((file, index) => {
       const curPath = join(path, file)
-      if (fs.lstatSync(curPath).isDirectory()) { // recurse
+      if (fs.lstatSync(curPath).isDirectory()) {
+        // recurse
         deleteFolderRecursive(curPath)
-      } else { // delete file
+      } else {
+        // delete file
         fs.unlinkSync(curPath)
       }
     })
@@ -31,6 +36,10 @@ module.exports = {
   join,
   parts,
   relativeTo,
-  filename: _.pipe(parts, _.remove(n => n === ''), _.last),
+  filename: _.pipe(
+    parts,
+    _.remove(n => n === ''),
+    _.last
+  ),
   deleteFolderRecursive
 }

--- a/tests/acceptance/helpers/sharingHelper.js
+++ b/tests/acceptance/helpers/sharingHelper.js
@@ -29,10 +29,10 @@ module.exports = {
    * @param permissionsString string of permissions separated by comma. For valid permissions see this.PERMISSION_TYPES
    * @returns {number} a number the OCS sharing API understands see https://doc.owncloud.com/server/developer_manual/core/apis/ocs-share-api.html
    */
-  humanReadablePermissionsToBitmask: function (permissionsString) {
+  humanReadablePermissionsToBitmask: function(permissionsString) {
     let permissionBitMask = 0
     let humanReadablePermissions = permissionsString.split(',')
-    humanReadablePermissions = humanReadablePermissions.map(function (s) {
+    humanReadablePermissions = humanReadablePermissions.map(function(s) {
       return String.prototype.trim.apply(s)
     })
     for (var i = 0; i < humanReadablePermissions.length; i++) {
@@ -49,7 +49,7 @@ module.exports = {
    * @param {string} shareTypeString
    * @returns {number}
    */
-  humanReadableShareTypeToNumber: function (shareTypeString) {
+  humanReadableShareTypeToNumber: function(shareTypeString) {
     shareTypeString = shareTypeString.trim()
     if (!(shareTypeString in this.SHARE_TYPES)) {
       throw Error('Invalid share type: ' + shareTypeString)
@@ -61,13 +61,16 @@ module.exports = {
    * @param {string} dateString
    * @returns {string}
    */
-  calculateDate: function (dateString) {
+  calculateDate: function(dateString) {
     if (dateString.startsWith('+') || dateString.startsWith('-')) {
       dateString = parseInt(dateString)
       const date = new Date()
       date.setDate(date.getDate() + dateString)
-      dateString = date.getFullYear() + '-' +
-        String((date.getMonth() + 1)).padStart(2, '0') + '-' +
+      dateString =
+        date.getFullYear() +
+        '-' +
+        String(date.getMonth() + 1).padStart(2, '0') +
+        '-' +
         String(date.getDate()).padStart(2, '0') +
         ' 00:00:00'
     }
@@ -81,30 +84,41 @@ module.exports = {
    *
    * @returns {Promise<unknown>}
    */
-  assertUserHasShareWithDetails: function (user, expectedDetailsTable, filters = {}) {
+  assertUserHasShareWithDetails: function(user, expectedDetailsTable, filters = {}) {
     codify.replaceInlineTable(expectedDetailsTable)
     const sharingHelper = this
     const apiURL = 'apps/files_sharing/api/v1/shares?'
     const search = new URLSearchParams(filters).toString()
 
-    return httpHelper.getOCS(apiURL + search, user)
+    return httpHelper
+      .getOCS(apiURL + search, user)
       .then(res => res.json())
-      .then(function (sharesResult) {
-        httpHelper.checkOCSStatus(sharesResult, 'Could not get shares. Message: ' + sharesResult.ocs.meta.message)
+      .then(function(sharesResult) {
+        httpHelper.checkOCSStatus(
+          sharesResult,
+          'Could not get shares. Message: ' + sharesResult.ocs.meta.message
+        )
         const shares = sharesResult.ocs.data
         let found
         for (const share of shares) {
           found = true
           for (const expectedDetail of expectedDetailsTable.hashes()) {
             if (expectedDetail.field === 'permissions') {
-              expectedDetail.value = sharingHelper.humanReadablePermissionsToBitmask(expectedDetail.value).toString()
+              expectedDetail.value = sharingHelper
+                .humanReadablePermissionsToBitmask(expectedDetail.value)
+                .toString()
             } else if (expectedDetail.field === 'share_type') {
-              expectedDetail.value = sharingHelper.humanReadableShareTypeToNumber(expectedDetail.value).toString()
+              expectedDetail.value = sharingHelper
+                .humanReadableShareTypeToNumber(expectedDetail.value)
+                .toString()
             } else if (expectedDetail.field === 'expiration') {
               expectedDetail.value = sharingHelper.calculateDate(expectedDetail.value)
             }
 
-            if (!(expectedDetail.field in share) || share[expectedDetail.field].toString() !== expectedDetail.value) {
+            if (
+              !(expectedDetail.field in share) ||
+              share[expectedDetail.field].toString() !== expectedDetail.value
+            ) {
               found = false
               break
             }
@@ -114,7 +128,9 @@ module.exports = {
           }
         }
         assert.strictEqual(
-          found, true, 'could not find expected share in "' + JSON.stringify(sharesResult, null, 2) + '"'
+          found,
+          true,
+          'could not find expected share in "' + JSON.stringify(sharesResult, null, 2) + '"'
         )
         return this
       })
@@ -126,15 +142,19 @@ module.exports = {
    * @param {string} linkCreator link creator
    * @return {Promise<Object>} last share token
    */
-  fetchLastPublicLinkShare: async function (linkCreator) {
+  fetchLastPublicLinkShare: async function(linkCreator) {
     const self = this
     const apiURL = 'apps/files_sharing/api/v1/shares'
     let lastShareToken
     let lastShare
-    await httpHelper.getOCS(apiURL, linkCreator)
+    await httpHelper
+      .getOCS(apiURL, linkCreator)
       .then(res => res.json())
-      .then(function (sharesResult) {
-        httpHelper.checkOCSStatus(sharesResult, 'Could not get shares. Message: ' + sharesResult.ocs.meta.message)
+      .then(function(sharesResult) {
+        httpHelper.checkOCSStatus(
+          sharesResult,
+          'Could not get shares. Message: ' + sharesResult.ocs.meta.message
+        )
         const shares = sharesResult.ocs.data
         let lastFoundShareId = 0
         for (const share of shares) {
@@ -145,7 +165,9 @@ module.exports = {
           }
         }
         if (lastShareToken === null) {
-          throw Error('Could not find public shares. All shares: ' + JSON.stringify(shares, null, 2))
+          throw Error(
+            'Could not find public shares. All shares: ' + JSON.stringify(shares, null, 2)
+          )
         }
       })
     return lastShare
@@ -156,12 +178,15 @@ module.exports = {
    * @param sharer user whose all public links are to be fetched
    * @returns {Object<[]>}
    */
-  getAllPublicLinkShares: async function (sharer) {
+  getAllPublicLinkShares: async function(sharer) {
     const data = []
     const apiURL = 'apps/files_sharing/api/v1/shares'
     const response = await httpHelper.getOCS(apiURL, sharer)
     const jsonResponse = await response.json()
-    httpHelper.checkOCSStatus(jsonResponse, 'Could not get shares. Message: ' + jsonResponse.ocs.meta.message)
+    httpHelper.checkOCSStatus(
+      jsonResponse,
+      'Could not get shares. Message: ' + jsonResponse.ocs.meta.message
+    )
     for (const share of jsonResponse.ocs.data) {
       if (share.share_type === this.SHARE_TYPES.public_link) {
         data.push(share)
@@ -175,7 +200,7 @@ module.exports = {
    * @param {boolean} sharedWithUser
    * @returns {Promise<[*]>}
    */
-  getAllShares: function (user, sharedWithUser = false) {
+  getAllShares: function(user, sharedWithUser = false) {
     const params = new URLSearchParams()
     if (sharedWithUser === true) {
       params.set('shared_with_me', 'true')
@@ -183,7 +208,8 @@ module.exports = {
     params.set('format', 'json')
     params.set('state', 'all')
     const apiURL = `apps/files_sharing/api/v1/shares?${params.toString()}`
-    return httpHelper.getOCS(apiURL, user)
+    return httpHelper
+      .getOCS(apiURL, user)
       .then(res => {
         httpHelper.checkStatus(res, 'The response status is not the expected value')
         return res.json()
@@ -192,10 +218,10 @@ module.exports = {
         return res.ocs.data
       })
   },
-  getAllSharesSharedWithUser: function (user) {
+  getAllSharesSharedWithUser: function(user) {
     return this.getAllShares(user, true)
   },
-  getAllSharesSharedByUser: function (user) {
+  getAllSharesSharedByUser: function(user) {
     return this.getAllShares(user)
   },
 
@@ -207,12 +233,14 @@ module.exports = {
    * @param {string} user
    * @param {string} sharer
    */
-  declineShare: async function (filename, user, sharer) {
+  declineShare: async function(filename, user, sharer) {
     const allShares = await this.getAllSharesSharedWithUser(user)
-    const elementsToDecline = allShares.filter((element) => {
-      return element.state === this.SHARE_STATE.pending &&
+    const elementsToDecline = allShares.filter(element => {
+      return (
+        element.state === this.SHARE_STATE.pending &&
         normalize(element.path) === filename &&
         element.uid_owner === sharer
+      )
     })
     if (elementsToDecline.length < 1) {
       throw new Error('Could not find the share to be declined')
@@ -220,11 +248,13 @@ module.exports = {
     for (const element of elementsToDecline) {
       const shareID = element.id
       const apiURL = `apps/files_sharing/api/v1/shares/pending/${shareID}`
-      return httpHelper.deleteOCS(apiURL, user)
+      return httpHelper
+        .deleteOCS(apiURL, user)
         .then(res => {
           res = httpHelper.checkStatus(res, 'The response status is not the expected value')
           return res.json()
-        }).then(res => {
+        })
+        .then(res => {
           httpHelper.checkOCSStatus(res, 'Could not perform the decline action')
         })
     }
@@ -238,12 +268,14 @@ module.exports = {
    * @param {string} user
    * @param {string} sharer
    */
-  acceptShare: async function (filename, user, sharer) {
+  acceptShare: async function(filename, user, sharer) {
     const allShares = await this.getAllSharesSharedWithUser(user)
-    const elementsToAccept = allShares.filter((element) => {
-      return element.state === this.SHARE_STATE.pending &&
+    const elementsToAccept = allShares.filter(element => {
+      return (
+        element.state === this.SHARE_STATE.pending &&
         element.path.slice(1) === filename &&
         element.uid_owner === sharer
+      )
     })
     if (elementsToAccept.length < 1) {
       throw new Error('Could not find the share to be accepted')
@@ -251,11 +283,13 @@ module.exports = {
     for (const element of elementsToAccept) {
       const shareID = element.id
       const apiURL = `apps/files_sharing/api/v1/shares/pending/${shareID}`
-      return httpHelper.postOCS(apiURL, user)
+      return httpHelper
+        .postOCS(apiURL, user)
         .then(res => {
           res = httpHelper.checkStatus(res, 'The response status is not the expected value')
           return res.json()
-        }).then(res => {
+        })
+        .then(res => {
           httpHelper.checkOCSStatus(res, 'Could not perform the accept action')
         })
     }
@@ -269,18 +303,18 @@ module.exports = {
    * @param {string} expectedDetails.expireDate - expire date for public link share in format 'YYYY-MM-DD'
    * @returns {Promise<void>}
    */
-  assertUserLastPublicShareDetails: async function (linkCreator, expectedDetails) {
+  assertUserLastPublicShareDetails: async function(linkCreator, expectedDetails) {
     const lastShare = await this.fetchLastPublicLinkShare(linkCreator)
     if (lastShare.share_type === this.SHARE_TYPES.public_link) {
       const regDate = lastShare.expiration.split(' ')[0]
       if (expectedDetails.token) {
-        assert.strictEqual(
-          lastShare.token, expectedDetails.token, 'Token Missmatch' + lastShare
-        )
+        assert.strictEqual(lastShare.token, expectedDetails.token, 'Token Missmatch' + lastShare)
       }
       if (expectedDetails.expireDate) {
         assert.strictEqual(
-          regDate, expectedDetails.expireDate, 'Expiry Date Missmatch: ' + lastShare
+          regDate,
+          expectedDetails.expireDate,
+          'Expiry Date Missmatch: ' + lastShare
         )
       }
     } else {

--- a/tests/acceptance/helpers/userSettings.js
+++ b/tests/acceptance/helpers/userSettings.js
@@ -78,7 +78,7 @@ module.exports = {
    * @param {string} displayname
    * @param {string} email
    */
-  addUserToCreatedUsersList: function (userId, password, displayname = null, email = null) {
+  addUserToCreatedUsersList: function(userId, password, displayname = null, email = null) {
     if (client.globals.default_backend === BACKENDS.remote) {
       this.createdRemoteUsers[userId] = {
         password,
@@ -97,21 +97,21 @@ module.exports = {
    *
    * @param {string} userId
    */
-  deleteUserFromCreatedUsersList: function (userId) {
+  deleteUserFromCreatedUsersList: function(userId) {
     delete this.createdUsers[userId]
   },
   /**
    *
    * @param {string} groupId
    */
-  addGroupToCreatedGroupsList: function (groupId) {
+  addGroupToCreatedGroupsList: function(groupId) {
     this.createdGroups.push(groupId)
   },
   /**
    *
    * @param {string} userId
    */
-  deleteGroupFromCreatedGroupsList: function (groupId) {
+  deleteGroupFromCreatedGroupsList: function(groupId) {
     this.createdGroups = this.createdGroups.filter(item => item !== groupId)
   },
   /**
@@ -122,7 +122,7 @@ module.exports = {
    * @param {string} userId
    * @returns {string}
    */
-  getPasswordForUser: function (userId) {
+  getPasswordForUser: function(userId) {
     if (userId in this.createdUsers) {
       return this.createdUsers[userId].password
     } else if (userId in this.defaultUsers) {
@@ -140,7 +140,7 @@ module.exports = {
    * @param {string} userId
    * @returns {string}
    */
-  getDisplayNameForUser: function (userId) {
+  getDisplayNameForUser: function(userId) {
     let user = {}
     if (userId in this.createdUsers) {
       user = this.createdUsers[userId]
@@ -162,7 +162,7 @@ module.exports = {
    * @param {string} userId
    * @returns {null|string}
    */
-  getDisplayNameOfDefaultUser: function (userId) {
+  getDisplayNameOfDefaultUser: function(userId) {
     if (userId in this.defaultUsers) {
       return this.defaultUsers[userId].displayname
     } else {
@@ -177,7 +177,7 @@ module.exports = {
    * @param {string} userId
    * @returns {null|string}
    */
-  getEmailAddressForUser: function (userId) {
+  getEmailAddressForUser: function(userId) {
     let user = {}
     if (userId in this.createdUsers) {
       user = this.createdUsers[userId]
@@ -199,7 +199,7 @@ module.exports = {
    * @param {string} userId
    * @returns {null|string}
    */
-  getEmailAddressOfDefaultUser: function (userId) {
+  getEmailAddressOfDefaultUser: function(userId) {
     if (userId in this.defaultUsers) {
       return this.defaultUsers[userId].email
     } else {
@@ -210,7 +210,7 @@ module.exports = {
    *
    * @returns {module.exports.createdUsers|{}}
    */
-  getCreatedUsers: function (server = BACKENDS.local) {
+  getCreatedUsers: function(server = BACKENDS.local) {
     switch (server) {
       case BACKENDS.local:
         return this.createdUsers
@@ -224,15 +224,15 @@ module.exports = {
    *
    * @returns {Array}
    */
-  getCreatedGroups: function () {
+  getCreatedGroups: function() {
     return this.createdGroups
   },
 
-  resetCreatedUsers: function () {
+  resetCreatedUsers: function() {
     this.createdUsers = {}
   },
 
-  resetCreatedGroups: function () {
+  resetCreatedGroups: function() {
     this.createdGroups = []
   }
 }

--- a/tests/acceptance/helpers/webdavHelper.js
+++ b/tests/acceptance/helpers/webdavHelper.js
@@ -11,7 +11,7 @@ const occHelper = require('../helpers/occHelper')
  * @param {string} element
  * @param {string} server - (REMOTE/LOCAL) server to use for dav path
  */
-exports.createDavPath = function (userId, element) {
+exports.createDavPath = function(userId, element) {
   const replaceEncoded = encodeURIComponent(element).replace(/%2F/g, '/')
   return `files/${userId}/${replaceEncoded}`
 }
@@ -21,12 +21,10 @@ exports.createDavPath = function (userId, element) {
  * @param {string} userId
  * @param {string} file
  */
-exports.download = function (userId, file) {
+exports.download = function(userId, file) {
   const davPath = exports.createDavPath(userId, file)
-  return httpHelper.get(
-    davPath,
-    userId
-  )
+  return httpHelper
+    .get(davPath, userId)
     .then(res => httpHelper.checkStatus(res, 'Could not download file.'))
     .then(res => res.text())
 }
@@ -36,12 +34,10 @@ exports.download = function (userId, file) {
  * @param {string} userId
  * @param {string} file
  */
-exports.delete = function (userId, file) {
+exports.delete = function(userId, file) {
   const davPath = exports.createDavPath(userId, file)
-  return httpHelper.delete(
-    davPath,
-    userId
-  )
+  return httpHelper
+    .delete(davPath, userId)
     .then(res => httpHelper.checkStatus(res, 'Could not delete file ' + file))
     .then(res => res.text())
 }
@@ -53,18 +49,17 @@ exports.delete = function (userId, file) {
  * @param {string} fromName
  * @param {string} toName
  */
-exports.move = function (userId, fromName, toName) {
+exports.move = function(userId, fromName, toName) {
   const davPath = exports.createDavPath(userId, fromName)
   let body
-  return httpHelper.move(
-    davPath,
-    userId,
-    body,
-    {
-      Destination:
-        join(backendHelper.getCurrentBackendUrl(), '/remote.php/dav/', exports.createDavPath(userId, toName))
-    }
-  )
+  return httpHelper
+    .move(davPath, userId, body, {
+      Destination: join(
+        backendHelper.getCurrentBackendUrl(),
+        '/remote.php/dav/',
+        exports.createDavPath(userId, toName)
+      )
+    })
     .then(res => httpHelper.checkStatus(res, 'Could not move file.'))
     .then(res => res.text())
 }
@@ -76,7 +71,7 @@ exports.move = function (userId, fromName, toName) {
  * @param {array} properties
  * @param {number} folderDepth
  */
-exports.propfind = function (path, userId, properties, folderDepth = 1) {
+exports.propfind = function(path, userId, properties, folderDepth = 1) {
   const davPath = path
   let propertyBody = ''
   properties.map(prop => {
@@ -89,13 +84,7 @@ exports.propfind = function (path, userId, properties, folderDepth = 1) {
                 xmlns:ocs="http://open-collaboration-services.org/ns">
                 <d:prop>${propertyBody}</d:prop>
                 </d:propfind>`
-  return httpHelper.propfind(
-    davPath,
-    userId,
-    body,
-    { Depth: folderDepth }
-  )
-    .then(res => res.text())
+  return httpHelper.propfind(davPath, userId, body, { Depth: folderDepth }).then(res => res.text())
 }
 
 /**
@@ -111,15 +100,20 @@ exports.propfind = function (path, userId, properties, folderDepth = 1) {
  *
  * @param {string} user
  */
-exports.getTrashBinElements = function (user, depth = 2) {
-  return new Promise((resolve) => {
-    exports.propfind(`/trash-bin/${user}`, user,
-      [
-        'oc:trashbin-original-filename',
-        'oc:trashbin-original-location',
-        'oc:trashbin-delete-timestamp',
-        'd:getlastmodified'
-      ], depth)
+exports.getTrashBinElements = function(user, depth = 2) {
+  return new Promise(resolve => {
+    exports
+      .propfind(
+        `/trash-bin/${user}`,
+        user,
+        [
+          'oc:trashbin-original-filename',
+          'oc:trashbin-original-location',
+          'oc:trashbin-delete-timestamp',
+          'd:getlastmodified'
+        ],
+        depth
+      )
       .then(str => {
         const trashData = convert.xml2js(str, { compact: true })['d:multistatus']['d:response']
         const trashItems = []
@@ -142,10 +136,13 @@ exports.getTrashBinElements = function (user, depth = 2) {
  * @param {string} user
  * @param {string} folderName
  */
-exports.createFolder = function (user, folderName) {
+exports.createFolder = function(user, folderName) {
   const davPath = exports.createDavPath(user, folderName)
-  return httpHelper.mkcol(davPath, user)
-    .then(res => httpHelper.checkStatus(res, `Could not create the folder "${folderName}" for user "${user}".`))
+  return httpHelper
+    .mkcol(davPath, user)
+    .then(res =>
+      httpHelper.checkStatus(res, `Could not create the folder "${folderName}" for user "${user}".`)
+    )
     .then(res => res.text())
 }
 /**
@@ -155,10 +152,13 @@ exports.createFolder = function (user, folderName) {
  * @param {string} fileName
  * @param {string} contents
  */
-exports.createFile = function (user, fileName, contents = '') {
+exports.createFile = function(user, fileName, contents = '') {
   const davPath = exports.createDavPath(user, fileName)
-  return httpHelper.put(davPath, user, contents)
-    .then(res => httpHelper.checkStatus(res, `Could not create the file "${fileName}" for user "${user}".`))
+  return httpHelper
+    .put(davPath, user, contents)
+    .then(res =>
+      httpHelper.checkStatus(res, `Could not create the file "${fileName}" for user "${user}".`)
+    )
     .then(res => res.text())
 }
 
@@ -168,34 +168,33 @@ exports.createFile = function (user, fileName, contents = '') {
  * @param {string} path
  * @param {string} userId
  * @param {array} requestedProps
-*/
-exports.getProperties = function (path, userId, requestedProps) {
+ */
+exports.getProperties = function(path, userId, requestedProps) {
   return new Promise((resolve, reject) => {
     const trimmedPath = normalize(path) // remove a leading slash
     const relativePath = `/files/${userId}/${trimmedPath}`
-    exports.propfind(relativePath, userId, requestedProps,
-      0)
-      .then(str => {
-        const response = JSON.parse(convert.xml2json(str, { compact: true }))
-        const receivedProps = _.get(
-          response,
-          "['d:multistatus']['d:response']['d:propstat']['d:prop']"
-        )
-        if (receivedProps === undefined) {
-          const errMsg = "Could not find 'd:prop' inside response. Received:\n"
-          return reject(new Error(errMsg + JSON.stringify(str)))
-        }
-        const properties = {}
-        requestedProps.map(propertyName => {
-          properties[propertyName] = receivedProps[propertyName]._text
-        })
-        return resolve(properties)
+    exports.propfind(relativePath, userId, requestedProps, 0).then(str => {
+      const response = JSON.parse(convert.xml2json(str, { compact: true }))
+      const receivedProps = _.get(
+        response,
+        "['d:multistatus']['d:response']['d:propstat']['d:prop']"
+      )
+      if (receivedProps === undefined) {
+        const errMsg = "Could not find 'd:prop' inside response. Received:\n"
+        return reject(new Error(errMsg + JSON.stringify(str)))
+      }
+      const properties = {}
+      requestedProps.map(propertyName => {
+        properties[propertyName] = receivedProps[propertyName]._text
       })
+      return resolve(properties)
+    })
   })
 }
 
-exports.getSkeletonFile = function (filename) {
-  return occHelper.runOcc(['config:system:get', 'skeletondirectory'])
+exports.getSkeletonFile = function(filename) {
+  return occHelper
+    .runOcc(['config:system:get', 'skeletondirectory'])
     .then(resp => resp.ocs.data.stdOut)
     .then(dir => {
       const element = join(dir.trim(), filename)
@@ -208,27 +207,24 @@ exports.getSkeletonFile = function (filename) {
     })
 }
 
-exports.uploadFileWithContent = function (user, content, filename) {
+exports.uploadFileWithContent = function(user, content, filename) {
   const apiURL = `files/${user}/${filename}`
-  return httpHelper.put(apiURL,
-    user,
-    content,
-    { 'Content-Type': 'text/plain' }
-  )
-    .then(res => httpHelper.checkStatus(res, 'Could not upload file' + filename + 'with content' + content))
+  return httpHelper
+    .put(apiURL, user, content, { 'Content-Type': 'text/plain' })
+    .then(res =>
+      httpHelper.checkStatus(res, 'Could not upload file' + filename + 'with content' + content)
+    )
 }
 
-exports.getFavouritedResources = function (user) {
+exports.getFavouritedResources = function(user) {
   const body = `<oc:filter-files  xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
                  <d:prop><d:resourcetype /></d:prop>
                  <oc:filter-rules>
                      <oc:favorite>1</oc:favorite>
                  </oc:filter-rules>
                 </oc:filter-files>`
-  return httpHelper.report(`files/${user}`,
-    user,
-    body
-  )
+  return httpHelper
+    .report(`files/${user}`, user, body)
     .then(res => res.text())
     .then(res => {
       const favData = convert.xml2js(res, { compact: true })['d:multistatus']['d:response']

--- a/tests/acceptance/helpers/xpath.js
+++ b/tests/acceptance/helpers/xpath.js
@@ -13,7 +13,7 @@ module.exports = {
    * @param {string} value
    * @returns {string}
    */
-  buildXpathLiteral: function (value) {
+  buildXpathLiteral: function(value) {
     if (!value.includes("'")) {
       // if we don't have any single quotes, then wrap them with single quotes
       return "'" + value + "'"

--- a/tests/acceptance/pageObjects/FilesPageElement/SharingDialog/collaboratorsDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/SharingDialog/collaboratorsDialog.js
@@ -6,14 +6,13 @@ module.exports = {
      * @param {string} collaborator
      * @returns {Promise.<string[]>} Array of autocomplete webElementIds
      */
-    deleteShareWithUserGroup: function (collaborator) {
+    deleteShareWithUserGroup: function(collaborator) {
       const informationSelector = util.format(
         this.elements.collaboratorInformationByCollaboratorName.selector,
         collaborator
       )
       const deleteSelector = informationSelector + this.elements.deleteShareButton.selector
-      return this
-        .useXpath()
+      return this.useXpath()
         .waitForElementVisible(deleteSelector)
         .waitForAnimationToFinish()
         .click(deleteSelector)
@@ -22,9 +21,8 @@ module.exports = {
     /**
      * Clicks the button to add a new collaborator
      */
-    clickCreateShare: function () {
-      return this
-        .initAjaxCounters()
+    clickCreateShare: function() {
+      return this.initAjaxCounters()
         .useXpath()
         .waitForElementVisible('@createShareButton')
         .click('@createShareButton')
@@ -37,14 +35,13 @@ module.exports = {
      *
      * @param {string} collaborator
      */
-    clickEditShare: function (collaborator) {
+    clickEditShare: function(collaborator) {
       const informationSelector = util.format(
         this.elements.collaboratorInformationByCollaboratorName.selector,
         collaborator
       )
       const editSelector = informationSelector + this.elements.editShareButton.selector
-      return this
-        .useXpath()
+      return this.useXpath()
         .waitForElementVisible(editSelector)
         .click(editSelector)
         .waitForElementVisible('@editShareDialog')
@@ -56,7 +53,7 @@ module.exports = {
      * inside the collaborator element, defaults to all when null
      * @returns {Promise.<string[]>} Array of users/groups in share list
      */
-    getCollaboratorsList: async function (subSelectors = null, filterDisplayName = null) {
+    getCollaboratorsList: async function(subSelectors = null, filterDisplayName = null) {
       let results = []
       let informationSelector = {
         selector: '@collaboratorsInformation',
@@ -64,7 +61,10 @@ module.exports = {
       }
       if (filterDisplayName !== null) {
         informationSelector = {
-          selector: util.format(this.elements.collaboratorInformationByCollaboratorName.selector, filterDisplayName),
+          selector: util.format(
+            this.elements.collaboratorInformationByCollaboratorName.selector,
+            filterDisplayName
+          ),
           locateStrategy: this.elements.collaboratorInformationByCollaboratorName.locateStrategy,
           abortOnFailure: false
         }
@@ -90,7 +90,7 @@ module.exports = {
           collaboratorsElementIds = result.value.map(item => item[Object.keys(item)[0]])
         })
 
-      results = collaboratorsElementIds.map(async (collaboratorElementId) => {
+      results = collaboratorsElementIds.map(async collaboratorElementId => {
         const collaboratorResult = {}
         for (const attrName in subSelectors) {
           let attrElementId = null
@@ -98,7 +98,7 @@ module.exports = {
             collaboratorElementId,
             'css selector',
             subSelectors[attrName],
-            (result) => {
+            result => {
               if (result.status !== -1) {
                 attrElementId = result.value.ELEMENT
               }
@@ -108,11 +108,11 @@ module.exports = {
           if (attrElementId) {
             // Get collaborator type via aria-label of indicator
             if (attrName === 'shareType') {
-              await this.api.elementIdAttribute(attrElementId, 'aria-label', (label) => {
+              await this.api.elementIdAttribute(attrElementId, 'aria-label', label => {
                 collaboratorResult[attrName] = label.value
               })
             } else {
-              await this.api.elementIdText(attrElementId, (text) => {
+              await this.api.elementIdText(attrElementId, text => {
                 collaboratorResult[attrName] = text.value
               })
             }
@@ -131,7 +131,7 @@ module.exports = {
      *
      * @returns {Promise.<string[]>} Array of user/group display names in share list
      */
-    getCollaboratorsListNames: async function () {
+    getCollaboratorsListNames: async function() {
       const list = await this.getCollaboratorsList({
         name: this.elements.collaboratorInformationSubName
       })
@@ -141,16 +141,19 @@ module.exports = {
      * check if the expiration date is present in the collaborator share and then get the expiration information
      * @return {Promise.<string>}
      */
-    getCollaboratorExpirationInfo: async function (user) {
+    getCollaboratorExpirationInfo: async function(user) {
       let elementId
       let text
-      const formattedWithUserName = util.format(this.elements.collaboratorExpirationInfo.selector, user)
+      const formattedWithUserName = util.format(
+        this.elements.collaboratorExpirationInfo.selector,
+        user
+      )
       const formattedCollaboratorInfoByCollaboratorName = util.format(
-        this.elements.collaboratorInformationByCollaboratorName.selector, user)
-      await this
-        .useXpath()
-        .waitForElementVisible(formattedCollaboratorInfoByCollaboratorName)
-      await this.api.element('xpath', formattedWithUserName, function (result) {
+        this.elements.collaboratorInformationByCollaboratorName.selector,
+        user
+      )
+      await this.useXpath().waitForElementVisible(formattedCollaboratorInfoByCollaboratorName)
+      await this.api.element('xpath', formattedWithUserName, function(result) {
         elementId = result.value.ELEMENT
       })
       if (elementId === undefined) {
@@ -165,7 +168,8 @@ module.exports = {
   },
   elements: {
     collaboratorInformationByCollaboratorName: {
-      selector: '//*[contains(@class, "files-collaborators-collaborator-name") and .="%s"]/ancestor::*[contains(concat(" ", @class, " "), " files-collaborators-collaborator ")]',
+      selector:
+        '//*[contains(@class, "files-collaborators-collaborator-name") and .="%s"]/ancestor::*[contains(concat(" ", @class, " "), " files-collaborators-collaborator ")]',
       locateStrategy: 'xpath'
     },
     deleteShareButton: {
@@ -218,7 +222,8 @@ module.exports = {
       selector: '.files-collaborators-collaborator-indicator'
     },
     collaboratorExpirationInfo: {
-      selector: '//div/span[.="%s"]/parent::div/following-sibling::span/span[contains(text(), "Expires")]',
+      selector:
+        '//div/span[.="%s"]/parent::div/following-sibling::span/span[contains(text(), "Expires")]',
       locateStrategy: 'xpath'
     }
   }

--- a/tests/acceptance/pageObjects/FilesPageElement/appSideBar.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/appSideBar.js
@@ -1,19 +1,17 @@
 module.exports = {
   commands: {
-    isThumbnailVisible: function () {
-      return this
-        .waitForElementVisible(this.elements.sideBar)
-        .waitForElementVisible(this.elements.sidebarThumbnail)
+    isThumbnailVisible: function() {
+      return this.waitForElementVisible(this.elements.sideBar).waitForElementVisible(
+        this.elements.sidebarThumbnail
+      )
     },
     /**
      * @returns {*}
      */
-    openVersionsTab: function () {
-      return this
-        .waitForElementVisible('@sidebarVersionsTab')
-        .click('@sidebarVersionsTab')
+    openVersionsTab: function() {
+      return this.waitForElementVisible('@sidebarVersionsTab').click('@sidebarVersionsTab')
     },
-    closeSidebar: function (timeout = null) {
+    closeSidebar: function(timeout = null) {
       if (timeout === null) {
         timeout = this.api.globals.waitForConditionTimeout
       } else {
@@ -35,35 +33,27 @@ module.exports = {
      * @param {string} tabSelectorXpath
      * @returns {Promise<boolean>}
      */
-    isTabPresentOnCurrentSidebar: async function (tabSelectorXpath) {
+    isTabPresentOnCurrentSidebar: async function(tabSelectorXpath) {
       let isPresent = true
-      await this
-        .useXpath()
+      await this.useXpath()
         .waitForElementVisible('@sideBar') // sidebar is expected to be opened and visible
-        .api.elements(
-          'xpath',
-          tabSelectorXpath,
-          (result) => {
-            isPresent = result.value.length > 0
-          })
+        .api.elements('xpath', tabSelectorXpath, result => {
+          isPresent = result.value.length > 0
+        })
         .useCss()
       return isPresent
     },
     /**
      * @returns {Promise<boolean>}
      */
-    isLinksTabPresentOnCurrentSidebar: function () {
-      return this.isTabPresentOnCurrentSidebar(
-        this.elements.sidebarLinksTab.selector
-      )
+    isLinksTabPresentOnCurrentSidebar: function() {
+      return this.isTabPresentOnCurrentSidebar(this.elements.sidebarLinksTab.selector)
     },
     /**
      * @returns {Promise<boolean>}
      */
-    isCollaboratorsTabPresentOnCurrentSidebar: function () {
-      return this.isTabPresentOnCurrentSidebar(
-        this.elements.sidebarCollaboratorsTab.selector
-      )
+    isCollaboratorsTabPresentOnCurrentSidebar: function() {
+      return this.isTabPresentOnCurrentSidebar(this.elements.sidebarCollaboratorsTab.selector)
     }
   },
   elements: {

--- a/tests/acceptance/pageObjects/FilesPageElement/expirationDatePicker.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/expirationDatePicker.js
@@ -8,7 +8,7 @@ module.exports = {
      * @param year
      * @returns {{locateStrategy: string, selector: *}}
      */
-    setExpiryDateYearSelectorXpath: function (year) {
+    setExpiryDateYearSelectorXpath: function(year) {
       const yearSelectorXpath = util.format(this.elements.dateTimeYearPicker.selector, year)
       return {
         selector: yearSelectorXpath,
@@ -21,7 +21,7 @@ module.exports = {
      * @param {string} month month name
      * @returns {{locateStrategy: string, selector: *}}
      */
-    setExpiryDateMonthSelectorXpath: function (month) {
+    setExpiryDateMonthSelectorXpath: function(month) {
       const monthSelectorXpath = util.format(this.elements.dateTimeMonthPicker.selector, month)
       return {
         selector: monthSelectorXpath,
@@ -34,7 +34,7 @@ module.exports = {
      * @param day
      * @returns {{locateStrategy: string, selector: *}}
      */
-    setExpiryDateDaySelectorXpath: function (day) {
+    setExpiryDateDaySelectorXpath: function(day) {
       const daySelectorXpath = util.format(this.elements.dateTimeDayPicker.selector, day)
       return {
         selector: daySelectorXpath,
@@ -47,14 +47,11 @@ module.exports = {
      * @param {string} year
      * @returns {Promise<void>}
      */
-    setExpiryDateYear: function (year) {
+    setExpiryDateYear: function(year) {
       const yearSelector = this.setExpiryDateYearSelectorXpath(year)
-      return this
-        .waitForElementVisible('@dateTimePopupYear')
+      return this.waitForElementVisible('@dateTimePopupYear')
         .waitForAnimationToFinish()
-        .waitForElementEnabled(
-          this.elements.dateTimePopupYear.selector
-        )
+        .waitForElementEnabled(this.elements.dateTimePopupYear.selector)
         .click('@dateTimePopupYear')
         .waitForElementVisible(yearSelector)
         .click(yearSelector)
@@ -67,10 +64,9 @@ module.exports = {
      * @param {number} month
      * @returns {Promise<void>}
      */
-    setExpiryDateMonth: function (month) {
+    setExpiryDateMonth: function(month) {
       const monthSelector = this.setExpiryDateMonthSelectorXpath(month)
-      return this
-        .waitForElementVisible('@dateTimePopupDate')
+      return this.waitForElementVisible('@dateTimePopupDate')
         .click('@dateTimePopupDate')
         .waitForElementVisible(monthSelector)
         .click(monthSelector)
@@ -83,10 +79,9 @@ module.exports = {
      * @param {string} day
      * @returns {Promise<void>}
      */
-    setExpiryDateDay: function (day) {
+    setExpiryDateDay: function(day) {
       const daySelector = this.setExpiryDateDaySelectorXpath(day)
-      return this
-        .waitForElementVisible(daySelector)
+      return this.waitForElementVisible(daySelector)
         .click(daySelector)
         .click('@dateTimeOkButton')
         .waitForElementNotPresent(daySelector)
@@ -98,44 +93,43 @@ module.exports = {
      *
      * @returns {Promise<boolean>}
      */
-    isExpiryDateDisabled: async function (pastDate) {
+    isExpiryDateDisabled: async function(pastDate) {
       let disabled = false
       const yearSelector = this.setExpiryDateYearSelectorXpath(pastDate.getFullYear())
       const monthSelector = this.setExpiryDateMonthSelectorXpath(
         pastDate.toLocaleString('en-GB', { month: 'long' })
       )
       const daySelector = this.setExpiryDateDaySelectorXpath(pastDate.getDate())
-      await this
-        .waitForElementVisible('@dateTimePopupYear')
+      await this.waitForElementVisible('@dateTimePopupYear')
         .waitForAnimationToFinish()
-        .waitForElementEnabled(
-          this.elements.dateTimePopupYear.selector
-        )
+        .waitForElementEnabled(this.elements.dateTimePopupYear.selector)
         .angryClick('@dateTimePopupYear')
         .waitForElementVisible(yearSelector)
-        .getAttribute(yearSelector, 'class', (result) => {
+        .getAttribute(yearSelector, 'class', result => {
           if (result.value.includes('--disabled') === true) {
             disabled = true
           }
         })
-      if (disabled) { return disabled }
-      await this
-        .click(yearSelector)
+      if (disabled) {
+        return disabled
+      }
+      await this.click(yearSelector)
         .click('@dateTimeOkButton')
         .waitForElementVisible('@dateTimePopupDate')
         .click('@dateTimePopupDate')
         .waitForElementVisible(monthSelector)
-        .getAttribute(monthSelector, 'class', (result) => {
+        .getAttribute(monthSelector, 'class', result => {
           if (result.value.includes('--disabled') === true) {
             disabled = true
           }
         })
-      if (disabled) { return disabled }
-      await this
-        .click(monthSelector)
+      if (disabled) {
+        return disabled
+      }
+      await this.click(monthSelector)
         .click('@dateTimeOkButton')
         .waitForElementVisible(daySelector)
-        .getAttribute(daySelector, 'class', (result) => {
+        .getAttribute(daySelector, 'class', result => {
           if (result.value.includes('--disabled') === true) {
             disabled = true
           }
@@ -149,7 +143,7 @@ module.exports = {
      * @param {string} shareType link|collaborator
      * @returns {Promise<boolean>} returns true if succeeds to set provided expiration date
      */
-    setExpirationDate: async function (value, shareType = 'collaborator') {
+    setExpirationDate: async function(value, shareType = 'collaborator') {
       if (value === '') {
         return this.click('@publicLinkDeleteExpirationDateButton')
       }
@@ -158,17 +152,14 @@ module.exports = {
         const disabled = await this.isExpiryDateDisabled(dateToSet)
         if (disabled) {
           console.log('WARNING: Cannot change expiration date to disabled value!')
-          await this
-            .waitForElementVisible('@dateTimeCancelButton')
-            .click('@dateTimeCancelButton')
+          await this.waitForElementVisible('@dateTimeCancelButton').click('@dateTimeCancelButton')
           return false
         }
       }
       const year = dateToSet.getFullYear()
       const month = dateToSet.toLocaleString('en-GB', { month: 'long' })
       const day = dateToSet.getDate()
-      await this
-        .setExpiryDateYear(year)
+      await this.setExpiryDateYear(year)
         .setExpiryDateMonth(month)
         .setExpiryDateDay(day)
       return true

--- a/tests/acceptance/pageObjects/FilesPageElement/fileActionsMenu.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/fileActionsMenu.js
@@ -19,7 +19,7 @@ module.exports = {
      * @param {string} action
      * @returns {string}
      */
-    getActionSelector: function (action) {
+    getActionSelector: function(action) {
       const actionsDropdownSelector = this.elements.itemActionsDropdown.selector
       const actionSelector = this.elements[action + 'ButtonInFileRow'].selector
 
@@ -33,10 +33,9 @@ module.exports = {
      * @throws Error
      * @returns {*}
      */
-    performFileAction: function (action) {
+    performFileAction: function(action) {
       const fileActionBtnSelectorXpath = this.getActionSelector(action)
-      return this
-        .useXpath()
+      return this.useXpath()
         .waitForElementVisible(fileActionBtnSelectorXpath)
         .click(fileActionBtnSelectorXpath)
         .useCss()
@@ -47,14 +46,13 @@ module.exports = {
      * @param {string} action
      * @returns {Promise<boolean>}
      */
-    getActionDisabledAttr: async function (action) {
+    getActionDisabledAttr: async function(action) {
       let disabledState
       const btnSelector = this.getActionSelector(action)
-      await this
-        .api.element('xpath', btnSelector, result => {
-          // action is disabled when not visible in dropdown menu
-          disabledState = result.status === -1
-        })
+      await this.api.element('xpath', btnSelector, result => {
+        // action is disabled when not visible in dropdown menu
+        disabledState = result.status === -1
+      })
 
       return disabledState
     },
@@ -62,7 +60,7 @@ module.exports = {
      * deletes resource using fileActions 'delete' button
      * @returns {Promise<*>}
      */
-    delete: async function () {
+    delete: async function() {
       this.performFileAction(this.FileAction.delete)
       await this.api.page.FilesPageElement.filesList().confirmDeletion()
       return this
@@ -72,7 +70,7 @@ module.exports = {
      * @param {boolean} expectToSucceed
      * @return {*}
      */
-    rename: async function (toName, expectToSucceed = true) {
+    rename: async function(toName, expectToSucceed = true) {
       await this.initAjaxCounters()
         .useXpath()
         .performFileAction(this.FileAction.rename)
@@ -95,11 +93,10 @@ module.exports = {
      * assumes filesAction menu for the resource to be opened
      * @return {*}
      */
-    openCollaboratorsDialog: function () {
+    openCollaboratorsDialog: function() {
       const api = this.api.page.FilesPageElement
       api.appSideBar().closeSidebar(500)
-      this
-        .useXpath()
+      this.useXpath()
         .performFileAction(this.FileAction.share)
         .waitForElementVisible('@sharingSideBar')
         .useCss()
@@ -110,26 +107,24 @@ module.exports = {
      *
      * @returns {Promise<boolean>}
      */
-    isSharingBtnPresent: async function () {
+    isSharingBtnPresent: async function() {
       const shareButtonXpath = this.elements.shareButtonInFileRow.selector
       let isPresent = true
-      await this
-        .api.page.FilesPageElement.appSideBar().closeSidebar(100)
-      await this
-        .api.elements(
-          this.elements.shareButtonInFileRow.locateStrategy,
-          shareButtonXpath,
-          (result) => {
-            isPresent = result.value.length > 0
-          })
+      await this.api.page.FilesPageElement.appSideBar().closeSidebar(100)
+      await this.api.elements(
+        this.elements.shareButtonInFileRow.locateStrategy,
+        shareButtonXpath,
+        result => {
+          isPresent = result.value.length > 0
+        }
+      )
       return isPresent
     },
     /**
      * @return {Promise<module.exports.commands>}
      */
-    restore: async function () {
-      await this
-        .initAjaxCounters()
+    restore: async function() {
+      await this.initAjaxCounters()
         .useXpath()
         .performFileAction(this.FileAction.restore)
         .waitForOutstandingAjaxCalls()
@@ -139,9 +134,8 @@ module.exports = {
     /**
      * @return {Promise<module.exports.commands>}
      */
-    download: async function () {
-      await this
-        .initAjaxCounters()
+    download: async function() {
+      await this.initAjaxCounters()
         .performFileAction(this.FileAction.download)
         .waitForOutstandingAjaxCalls()
       return this
@@ -149,7 +143,7 @@ module.exports = {
     /**
      * @return {Promise<module.exports.commands>}
      */
-    deleteResourceImmediately: async function () {
+    deleteResourceImmediately: async function() {
       this.performFileAction(this.FileAction.deleteImmediately)
       await this.api.page.FilesPageElement.filesList().confirmDeletion()
 

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -11,10 +11,9 @@ module.exports = {
      * @param {string} fileName
      * @return {Promise<*>}
      */
-    openSharingDialog: async function (fileName) {
+    openSharingDialog: async function(fileName) {
       await this.waitForFileVisible(fileName)
-      return filesRow.openFileActionsMenu(fileName)
-        .openCollaboratorsDialog()
+      return filesRow.openFileActionsMenu(fileName).openCollaboratorsDialog()
     },
     /**
      * opens links dialog for given resource
@@ -22,10 +21,11 @@ module.exports = {
      *
      * @return {*}
      */
-    openLinksDialog: function () {
+    openLinksDialog: function() {
       const api = this.api.page.FilesPageElement
       const sidebarLinksTabXpath = api.appSideBar().elements.sidebarLinksTab.selector
-      api.fileActionsMenu()
+      api
+        .fileActionsMenu()
         .openCollaboratorsDialog()
         .useXpath()
         .waitForElementVisible(sidebarLinksTabXpath)
@@ -37,7 +37,7 @@ module.exports = {
      * @param {string} fileName
      * @return {Promise<*>}
      */
-    openPublicLinkDialog: async function (fileName) {
+    openPublicLinkDialog: async function(fileName) {
       await this.waitForFileVisible(fileName)
       await filesRow.openFileActionsMenu(fileName)
       return this.openLinksDialog()
@@ -46,11 +46,9 @@ module.exports = {
      * @param {string} resource
      * @return {Promise<module.exports.commands>}
      */
-    deleteFile: async function (resource) {
+    deleteFile: async function(resource) {
       await this.waitForFileVisible(resource)
-      await filesRow
-        .openFileActionsMenu(resource)
-        .delete()
+      await filesRow.openFileActionsMenu(resource).delete()
       return this
     },
     /**
@@ -59,11 +57,9 @@ module.exports = {
      * @param {boolean} expectToSucceed
      * @return {Promise<module.exports.commands>}
      */
-    renameFile: async function (fromName, toName, expectToSucceed = true) {
+    renameFile: async function(fromName, toName, expectToSucceed = true) {
       await this.waitForFileVisible(fromName)
-      await filesRow
-        .openFileActionsMenu(fromName)
-        .rename(toName, expectToSucceed)
+      await filesRow.openFileActionsMenu(fromName).rename(toName, expectToSucceed)
       return this
     },
     /**
@@ -71,22 +67,18 @@ module.exports = {
      * @param {string} elementType
      * @return {Promise<module.exports.commands>}
      */
-    restoreFile: async function (element, elementType) {
+    restoreFile: async function(element, elementType) {
       await this.waitForFileWithPathVisible(element, elementType)
-      await filesRow
-        .openFileActionsMenu(element, elementType)
-        .restore()
+      await filesRow.openFileActionsMenu(element, elementType).restore()
       return this
     },
     /**
      * @param {string} resource
      * @return {Promise<module.exports.commands>}
      */
-    deleteImmediately: async function (resource) {
+    deleteImmediately: async function(resource) {
       await this.waitForFileVisible(resource)
-      await filesRow
-        .openFileActionsMenu(resource)
-        .deleteResourceImmediately(resource)
+      await filesRow.openFileActionsMenu(resource).deleteResourceImmediately(resource)
       return this
     },
     /**
@@ -94,39 +86,33 @@ module.exports = {
      * @param {string} resource
      * @return {Promise<boolean>}
      */
-    isActionAttributeDisabled: async function (action, resource) {
+    isActionAttributeDisabled: async function(action, resource) {
       await this.waitForFileVisible(resource)
-      return filesRow
-        .openFileActionsMenu(resource)
-        .getActionDisabledAttr('delete')
+      return filesRow.openFileActionsMenu(resource).getActionDisabledAttr('delete')
     },
     /**
      * @param {string} resource
      * @return {Promise<module.exports.commands>}
      */
-    downloadFile: async function (resource) {
+    downloadFile: async function(resource) {
       await this.waitForFileVisible(resource)
-      await filesRow
-        .openFileActionsMenu(resource)
-        .download()
+      await filesRow.openFileActionsMenu(resource).download()
       return this
     },
     /**
      * @param {string} resource
      * @return {Promise<module.exports.commands>}
      */
-    isSharingButtonPresent: async function (resource) {
+    isSharingButtonPresent: async function(resource) {
       await this.waitForFileVisible(resource)
-      await filesRow
-        .openFileActionsMenu(resource)
-        .isSharingBtnPresent()
+      await filesRow.openFileActionsMenu(resource).isSharingBtnPresent()
       return this
     },
     /**
      * @return {Promise<*>}
      */
-    confirmDeletion: async function () {
-      const clickAction = function () {
+    confirmDeletion: async function() {
+      const clickAction = function() {
         return this.initAjaxCounters()
           .waitForElementEnabled('@deleteFileConfirmationBtn')
           .click('@deleteFileConfirmationBtn')
@@ -136,7 +122,7 @@ module.exports = {
             this.api.globals.waitForConditionTimeout,
             this.api.globals.waitForConditionPollInterval,
             false,
-            function () {
+            function() {
               console.log('waited for popup to disappear.')
             }
           )
@@ -166,28 +152,27 @@ module.exports = {
           locateStrategy: this.elements.deleteFileConfirmationDialog.locateStrategy,
           suppressNotFoundErrors: true
         },
-        ({ value }) => { isPopupVisible = value }
+        ({ value }) => {
+          isPopupVisible = value
+        }
       )
       if (isPopupVisible === true) {
         console.log('Retrying again. Popup did not disappear.')
         await clickAction()
       }
 
-      return this.waitForCSSPropertyEquals(
-        {
-          selector: this.elements.deleteFileConfirmationDialog.selector,
-          locateStrategy: this.elements.deleteFileConfirmationBtn.locateStrategy,
-          property: 'display',
-          value: 'none'
-        }
-      )
-        .useCss()
+      return this.waitForCSSPropertyEquals({
+        selector: this.elements.deleteFileConfirmationDialog.selector,
+        locateStrategy: this.elements.deleteFileConfirmationBtn.locateStrategy,
+        property: 'display',
+        value: 'none'
+      }).useCss()
     },
     /**
      *
      * @param {string} folder
      */
-    navigateToFolder: async function (folder) {
+    navigateToFolder: async function(folder) {
       await this.waitForFileVisible(folder)
       await this.initAjaxCounters()
 
@@ -209,14 +194,14 @@ module.exports = {
      * @param {string} resource
      * @returns {*}
      */
-    openSideBar: async function (resource) {
+    openSideBar: async function(resource) {
       await this.clickRow(resource)
       return this.api.page.FilesPageElement.appSideBar()
     },
     /**
      *
      */
-    checkAllFiles: function () {
+    checkAllFiles: function() {
       return this.initAjaxCounters()
         .waitForElementVisible('@filesTable')
         .waitForElementVisible('@checkBoxAllFiles')
@@ -226,7 +211,7 @@ module.exports = {
      * Restores all the selected files/folders
      *
      */
-    restoreSelected: function () {
+    restoreSelected: function() {
       return this.initAjaxCounters()
         .waitForElementVisible('@restoreSelectedButton')
         .useXpath()
@@ -236,7 +221,7 @@ module.exports = {
     /**
      * @param {string} item the file/folder to click
      */
-    clickRow: async function (item) {
+    clickRow: async function(item) {
       await this.waitForFileVisible(item)
       await this.initAjaxCounters()
         .useXpath()
@@ -255,11 +240,11 @@ module.exports = {
      * @param {string} enableOrDisable
      * @param {string} path
      */
-    toggleFileOrFolderCheckbox: async function (enableOrDisable, path) {
+    toggleFileOrFolderCheckbox: async function(enableOrDisable, path) {
       await this.waitForFileVisible(path)
 
-      const fileCheckbox = this.getFileRowSelectorByFileName(path) +
-        this.elements.checkboxInFileRow.selector
+      const fileCheckbox =
+        this.getFileRowSelectorByFileName(path) + this.elements.checkboxInFileRow.selector
 
       await this.toggleCheckbox(enableOrDisable, fileCheckbox, 'xpath')
 
@@ -271,22 +256,25 @@ module.exports = {
      * @param {string} fileName
      * @param {string} elementType
      */
-    waitForFileVisible: async function (fileName, elementType = 'file') {
+    waitForFileVisible: async function(fileName, elementType = 'file') {
       const linkSelector = this.getFileLinkSelectorByFileName(fileName, elementType)
 
       await this.waitForElementPresent('@filesTableContainer')
       await this.filesListScrollToTop()
       // Find the item in files list if it's not in the view
       await this.findItemInFilesList(fileName)
-      await this
-        .useXpath()
-        .getAttribute(linkSelector, 'filename', function (result) {
+      await this.useXpath()
+        .getAttribute(linkSelector, 'filename', function(result) {
           if (result.value.error) {
             this.assert.fail(result.value.error)
           }
           // using basename because some file lists display the full path while the
           // file name attribute only contains the basename
-          this.assert.strictEqual(result.value, path.basename(fileName), 'displayed file name not as expected')
+          this.assert.strictEqual(
+            result.value,
+            path.basename(fileName),
+            'displayed file name not as expected'
+          )
         })
         .useCss()
       // Wait for preview to be loaded
@@ -296,23 +284,29 @@ module.exports = {
     /**
      * Wait for all visible thumbnails to finish loading
      */
-    waitForAllThumbnailsLoaded: function () {
+    waitForAllThumbnailsLoaded: function() {
       return this.waitForElementNotPresent('@allFilePreviewsLoading')
     },
-    waitForThumbnailLoaded: async function (resourceName, elementType) {
+    waitForThumbnailLoaded: async function(resourceName, elementType) {
       if (elementType !== 'file') {
         // no thumbnails for folders
         return this
       }
-      const fileRowPreviewLoadedSelector = this.getFileRowSelectorByFileName(resourceName, elementType) + this.elements.filePreviewLoadedInFileRow.selector
+      const fileRowPreviewLoadedSelector =
+        this.getFileRowSelectorByFileName(resourceName, elementType) +
+        this.elements.filePreviewLoadedInFileRow.selector
       await this.useXpath()
         .waitForElementVisible(fileRowPreviewLoadedSelector)
         .useCss()
       return this
     },
-    getResourceThumbnail: async function (resourceName, elementType) {
-      const fileRowPreviewSelector = this.getFileRowSelectorByFileName(resourceName, elementType) + this.elements.filePreviewInFileRow.selector
-      const fileRowIconSelector = this.getFileRowSelectorByFileName(resourceName, elementType) + this.elements.fileIconInFileRow.selector
+    getResourceThumbnail: async function(resourceName, elementType) {
+      const fileRowPreviewSelector =
+        this.getFileRowSelectorByFileName(resourceName, elementType) +
+        this.elements.filePreviewInFileRow.selector
+      const fileRowIconSelector =
+        this.getFileRowSelectorByFileName(resourceName, elementType) +
+        this.elements.fileIconInFileRow.selector
       let iconUrl = null
       // this implicitly waits for preview to be loaded
       await this.waitForFileVisible(resourceName)
@@ -323,7 +317,7 @@ module.exports = {
             selector: fileRowPreviewSelector
           },
           'src',
-          (result) => {
+          result => {
             // somehow when element was not found the result.value is an empty array...
             if (result.status !== -1 && typeof result.value === 'string') {
               iconUrl = result.value
@@ -347,13 +341,12 @@ module.exports = {
      * @param {string} path
      * @param {string} elementType
      */
-    waitForFileWithPathVisible: function (path, elementType = 'file') {
+    waitForFileWithPathVisible: function(path, elementType = 'file') {
       const linkSelector = this.getFileLinkSelectorByFileName(path, elementType)
       const rowSelector = this.getFileRowSelectorByFileName(path, elementType)
-      return this
-        .useXpath()
+      return this.useXpath()
         .waitForElementVisible(rowSelector)
-        .getAttribute(linkSelector, 'innerText', function (result) {
+        .getAttribute(linkSelector, 'innerText', function(result) {
           this.assert.strictEqual(result.value.trim(), path, 'displayed file name not as expected')
         })
         .useCss()
@@ -365,7 +358,7 @@ module.exports = {
      *
      * @returns {string}
      */
-    getFileRowSelectorByFileName: function (fileName, elementType = 'file') {
+    getFileRowSelectorByFileName: function(fileName, elementType = 'file') {
       if (elementType === 'file') {
         const parts = path.parse(fileName)
         // If our file has a extension that starts with space (for eg. "newfile. txt")
@@ -391,9 +384,11 @@ module.exports = {
      * @param {string} elementType
      * @returns {string}
      */
-    getFileLinkSelectorByFileName: function (fileName, elementType) {
-      return this.getFileRowSelectorByFileName(fileName, elementType) +
+    getFileLinkSelectorByFileName: function(fileName, elementType) {
+      return (
+        this.getFileRowSelectorByFileName(fileName, elementType) +
         this.elements.fileLinkInFileRow.selector
+      )
     },
     /**
      * checks whether the element is listed or not on the filesList
@@ -402,29 +397,24 @@ module.exports = {
      * @param {string} elementType
      * @returns {boolean}
      */
-    isElementListed: async function (element, elementType = 'file') {
+    isElementListed: async function(element, elementType = 'file') {
       let isListed = true
-      await this
-        .waitForElementVisible('@filesTable')
+      await this.waitForElementVisible('@filesTable')
         .useXpath()
         .waitForElementNotPresent('@loadingIndicator')
-        .api.elements(
-          'xpath',
-          this.getFileRowSelectorByFileName(element, elementType),
-          (result) => {
-            isListed = result.value.length > 0
-          })
+        .api.elements('xpath', this.getFileRowSelectorByFileName(element, elementType), result => {
+          isListed = result.value.length > 0
+        })
         .useCss()
       return isListed
     },
     /**
      * @returns {Array} array of files/folders element
      */
-    allFileRows: async function () {
+    allFileRows: async function() {
       let returnResult = null
-      await this
-        .waitForElementNotPresent('@filesListProgressBar')
-      await this.api.elements('css selector', this.elements.fileRows, function (result) {
+      await this.waitForElementNotPresent('@filesListProgressBar')
+      await this.api.elements('css selector', this.elements.fileRows, function(result) {
         returnResult = result
       })
       return returnResult
@@ -434,7 +424,7 @@ module.exports = {
      *
      * @return {Boolean} true if the message is visible, false otherwise
      */
-    isNoContentMessageVisible: async function () {
+    isNoContentMessageVisible: async function() {
       let visible = false
       let elementId = null
       await this.waitForElementNotPresent('@filesListProgressBar')
@@ -453,19 +443,17 @@ module.exports = {
       }
       return visible
     },
-    countFilesAndFolders: async function () {
+    countFilesAndFolders: async function() {
       let filesCount = 0
       let foldersCount = 0
 
-      await this.waitForElementVisible('@filesCount')
-        .getText('@filesCount', result => {
-          filesCount = parseInt(result.value, 10)
-        })
+      await this.waitForElementVisible('@filesCount').getText('@filesCount', result => {
+        filesCount = parseInt(result.value, 10)
+      })
 
-      await this.waitForElementVisible('@foldersCount')
-        .getText('@foldersCount', result => {
-          foldersCount = parseInt(result.value, 10)
-        })
+      await this.waitForElementVisible('@foldersCount').getText('@foldersCount', result => {
+        foldersCount = parseInt(result.value, 10)
+      })
 
       return filesCount + foldersCount
     },
@@ -473,7 +461,7 @@ module.exports = {
     /**
      * Find an item in the files list. Scrolls down in case the item is not visible in viewport
      */
-    findItemInFilesList: async function (itemName) {
+    findItemInFilesList: async function(itemName) {
       // Escape double quotes inside of selector
       if (itemName.indexOf('"') > -1) {
         itemName = this.replaceChar(itemName, '"', '\\"')
@@ -482,19 +470,14 @@ module.exports = {
       await this.initAjaxCounters()
       await this.waitForElementVisible('@virtualScrollWrapper')
       await this.api.executeAsync(
-        function (
-          {
-            itemName,
-            scrollWrapperSelector,
-            listHeaderSelector
-          },
-          done
-        ) {
+        function({ itemName, scrollWrapperSelector, listHeaderSelector }, done) {
           const virtualScrollWrapper = document.querySelector(scrollWrapperSelector)
-          const tableHeaderPosition = document.querySelector(listHeaderSelector).getBoundingClientRect().top
+          const tableHeaderPosition = document
+            .querySelector(listHeaderSelector)
+            .getBoundingClientRect().top
           let scrollDistance = virtualScrollWrapper.scrollTop
 
-          function scrollUntilElementVisible () {
+          function scrollUntilElementVisible() {
             const item = document.querySelector(`[filename="${itemName}"]`)
 
             if (item) {
@@ -516,17 +499,21 @@ module.exports = {
 
             scrollDistance += virtualScrollWrapper.clientHeight
             virtualScrollWrapper.scrollTop = scrollDistance
-            setTimeout(function () {
+            setTimeout(function() {
               scrollUntilElementVisible()
             }, 500)
           }
 
           scrollUntilElementVisible()
-        }, [{
-          itemName: itemName,
-          scrollWrapperSelector: this.elements.virtualScrollWrapper.selector,
-          listHeaderSelector: this.elements.filesTableHeader.selector
-        }])
+        },
+        [
+          {
+            itemName: itemName,
+            scrollWrapperSelector: this.elements.virtualScrollWrapper.selector,
+            listHeaderSelector: this.elements.filesTableHeader.selector
+          }
+        ]
+      )
 
       // wait for previews to be loaded after scrolling to resources that were
       // not rendered before
@@ -538,64 +525,70 @@ module.exports = {
     /**
      * Scroll the files list to the beginning
      */
-    filesListScrollToTop: async function () {
+    filesListScrollToTop: async function() {
       await this.waitForElementVisible('@virtualScrollWrapper')
-      await this.api.executeAsync(function (scrollerContainerSelector, done) {
-        const filesListScroll = document.querySelector(scrollerContainerSelector)
-        if (filesListScroll.scrollTop > 0) {
-          filesListScroll.scrollTop = 0
-        }
+      await this.api.executeAsync(
+        function(scrollerContainerSelector, done) {
+          const filesListScroll = document.querySelector(scrollerContainerSelector)
+          if (filesListScroll.scrollTop > 0) {
+            filesListScroll.scrollTop = 0
+          }
 
-        done()
-      }, [this.elements.virtualScrollWrapper.selector])
+          done()
+        },
+        [this.elements.virtualScrollWrapper.selector]
+      )
 
       return this
     },
 
-    getShareIndicatorsForResource: async function (fileName) {
+    getShareIndicatorsForResource: async function(fileName) {
       const resourceRowXpath = this.getFileRowSelectorByFileName(fileName)
-      const shareIndicatorsXpath = resourceRowXpath + this.elements.shareIndicatorsInFileRow.selector
+      const shareIndicatorsXpath =
+        resourceRowXpath + this.elements.shareIndicatorsInFileRow.selector
       const indicators = []
 
       await this.waitForFileVisible(fileName)
 
-      await this
-        .api.elements(
-          this.elements.shareIndicatorsInFileRow.locateStrategy,
-          shareIndicatorsXpath,
-          (result) => {
-            result.value.forEach(element => {
-              this.api.elementIdAttribute(element.ELEMENT, 'class', (attr) => {
-                if (attr.value.indexOf('uk-invisible') >= 0) {
-                  return
+      await this.api.elements(
+        this.elements.shareIndicatorsInFileRow.locateStrategy,
+        shareIndicatorsXpath,
+        result => {
+          result.value.forEach(element => {
+            this.api.elementIdAttribute(element.ELEMENT, 'class', attr => {
+              if (attr.value.indexOf('uk-invisible') >= 0) {
+                return
+              }
+              this.api.elementIdAttribute(element.ELEMENT, 'aria-label', attr => {
+                switch (attr.value) {
+                  case 'Directly shared with collaborators':
+                    indicators.push('user-direct')
+                    break
+                  case 'Shared with collaborators through one of the parent folders':
+                    indicators.push('user-indirect')
+                    break
+                  case 'Directly shared with links':
+                    indicators.push('link-direct')
+                    break
+                  case 'Shared with links through one of the parent folders':
+                    indicators.push('link-indirect')
+                    break
+                  default:
+                    console.warn('Unknown share indicator found: "' + attr + '"')
                 }
-                this.api.elementIdAttribute(element.ELEMENT, 'aria-label', (attr) => {
-                  switch (attr.value) {
-                    case 'Directly shared with collaborators':
-                      indicators.push('user-direct')
-                      break
-                    case 'Shared with collaborators through one of the parent folders':
-                      indicators.push('user-indirect')
-                      break
-                    case 'Directly shared with links':
-                      indicators.push('link-direct')
-                      break
-                    case 'Shared with links through one of the parent folders':
-                      indicators.push('link-indirect')
-                      break
-                    default:
-                      console.warn('Unknown share indicator found: "' + attr + '"')
-                  }
-                })
               })
             })
-          }
-        )
+          })
+        }
+      )
       return indicators
     },
 
-    setSort: async function (column, isDesc = false) {
-      const columnSelector = util.format(this.elements.filesTableHeaderColumn.selector, xpathHelper.buildXpathLiteral(column))
+    setSort: async function(column, isDesc = false) {
+      const columnSelector = util.format(
+        this.elements.filesTableHeaderColumn.selector,
+        xpathHelper.buildXpathLiteral(column)
+      )
       await this.useXpath()
         .waitForElementVisible(columnSelector)
         .click(columnSelector)
@@ -617,25 +610,24 @@ module.exports = {
       return this.useCss()
     },
 
-    getCollaboratorsForResource: async function (fileName) {
+    getCollaboratorsForResource: async function(fileName) {
       const resourceRowXpath = this.getFileRowSelectorByFileName(fileName)
       const collaboratorsXpath = resourceRowXpath + this.elements.collaboratorsInFileRow.selector
       const collaborators = []
 
       await this.waitForFileVisible(fileName)
 
-      await this
-        .api.elements(
-          this.elements.collaboratorsInFileRow.locateStrategy,
-          collaboratorsXpath,
-          (result) => {
-            result.value.forEach(element => {
-              return this.api.elementIdText(element.ELEMENT, (attr) => {
-                collaborators.push(attr.value)
-              })
+      await this.api.elements(
+        this.elements.collaboratorsInFileRow.locateStrategy,
+        collaboratorsXpath,
+        result => {
+          result.value.forEach(element => {
+            return this.api.elementIdText(element.ELEMENT, attr => {
+              collaborators.push(attr.value)
             })
-          }
-        )
+          })
+        }
+      )
       return collaborators
     },
 
@@ -646,7 +638,7 @@ module.exports = {
      * @param   {string} newChar    New character which will replace target character
      * @returns {string}            String with replaced target character
      */
-    replaceChar: function (string, targetChar, newChar) {
+    replaceChar: function(string, targetChar, newChar) {
       const regex = new RegExp(targetChar, 'g')
       return string.replace(regex, newChar)
     }
@@ -686,11 +678,13 @@ module.exports = {
       locateStrategy: 'xpath'
     },
     fileRowByName: {
-      selector: '//span[@class="oc-file-name"][text()=%s and not(../span[@class="oc-file-extension"])]/../../../../../div[@data-is-visible="true"]',
+      selector:
+        '//span[@class="oc-file-name"][text()=%s and not(../span[@class="oc-file-extension"])]/../../../../../div[@data-is-visible="true"]',
       locateStrategy: 'xpath'
     },
     fileRowByNameAndExtension: {
-      selector: '//span[span/text()=%s and span/text()="%s"]/../../../../div[@data-is-visible="true"]',
+      selector:
+        '//span[span/text()=%s and span/text()="%s"]/../../../../div[@data-is-visible="true"]',
       locateStrategy: 'xpath'
     },
     fileLinkInFileRow: {
@@ -710,7 +704,8 @@ module.exports = {
       locateStrategy: 'xpath'
     },
     filePreviewLoadedInFileRow: {
-      selector: '//span[contains(@class, "file-row-name") and (@data-preview-loaded="true" or not(@data-preview-loaded))]',
+      selector:
+        '//span[contains(@class, "file-row-name") and (@data-preview-loaded="true" or not(@data-preview-loaded))]',
       locateStrategy: 'xpath'
     },
     notMarkedFavoriteInFileRow: {

--- a/tests/acceptance/pageObjects/FilesPageElement/filesRow.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesRow.js
@@ -3,15 +3,15 @@ const filesList = client.page.FilesPageElement.filesList()
 
 module.exports = {
   commands: {
-
     /**
      *
      * @param {string} path
      */
-    markAsFavorite: async function (path) {
+    markAsFavorite: async function(path) {
       await filesList.waitForFileVisible(path)
 
-      const favoriteIconButton = filesList.getFileRowSelectorByFileName(path) +
+      const favoriteIconButton =
+        filesList.getFileRowSelectorByFileName(path) +
         this.elements.notMarkedFavoriteInFileRow.selector
 
       await this.initAjaxCounters()
@@ -28,22 +28,23 @@ module.exports = {
      *
      * @return {Promise<boolean>}
      */
-    isMarkedFavorite: async function (path) {
+    isMarkedFavorite: async function(path) {
       let visible = false
-      const markedFavoriteIcon = filesList.getFileRowSelectorByFileName(path) +
+      const markedFavoriteIcon =
+        filesList.getFileRowSelectorByFileName(path) +
         this.elements.markedFavoriteInFileRow.selector
       await filesList.waitForFileVisible(path)
-      await this.api
-        .element('xpath', markedFavoriteIcon, (result) => {
-          visible = !!result.value.ELEMENT
-        })
+      await this.api.element('xpath', markedFavoriteIcon, result => {
+        visible = !!result.value.ELEMENT
+      })
       return visible
     },
     /**
      * @param {string} path
      */
-    unmarkFavorite: async function (path) {
-      const unFavoriteBtn = filesList.getFileRowSelectorByFileName(path) +
+    unmarkFavorite: async function(path) {
+      const unFavoriteBtn =
+        filesList.getFileRowSelectorByFileName(path) +
         this.elements.markedFavoriteInFileRow.selector
 
       await filesList.waitForFileVisible(path)
@@ -63,9 +64,11 @@ module.exports = {
      * @param {string} elementType
      * @returns {string} file action button selector
      */
-    getFileActionBtnSelector: function (fileName, elementType = 'file') {
-      return filesList.getFileRowSelectorByFileName(fileName, elementType) +
+    getFileActionBtnSelector: function(fileName, elementType = 'file') {
+      return (
+        filesList.getFileRowSelectorByFileName(fileName, elementType) +
         this.elements.fileActionsButtonInFileRow.selector
+      )
     },
     /**
      * opens file-actions menu for given resource
@@ -75,10 +78,9 @@ module.exports = {
      *
      * @returns {*}
      */
-    openFileActionsMenu: function (resource, elementType = 'file') {
+    openFileActionsMenu: function(resource, elementType = 'file') {
       const fileActionsBtnSelector = this.getFileActionBtnSelector(resource, elementType)
-      this
-        .useXpath()
+      this.useXpath()
         .waitForElementVisible(fileActionsBtnSelector)
         .click(fileActionsBtnSelector)
         .useCss()

--- a/tests/acceptance/pageObjects/FilesPageElement/publicLinksDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/publicLinksDialog.js
@@ -10,15 +10,15 @@ module.exports = {
      * @param linkName Name of the public link
      * @returns {Promise<void>}
      */
-    clickLinkEditBtn: function (linkName) {
-      const linkRowEditButtonSelector = this.elements.publicLinkContainer.selector +
+    clickLinkEditBtn: function(linkName) {
+      const linkRowEditButtonSelector =
+        this.elements.publicLinkContainer.selector +
         util.format(this.elements.publicLinkEditButton.selector, linkName)
       const linkRowEditButton = {
         locateStrategy: this.elements.publicLinkEditButton.locateStrategy,
         selector: linkRowEditButtonSelector
       }
-      return this
-        .initAjaxCounters()
+      return this.initAjaxCounters()
         .waitForElementVisible(linkRowEditButton)
         .click(linkRowEditButton)
         .waitForOutstandingAjaxCalls()
@@ -29,8 +29,13 @@ module.exports = {
      * @param {string} role - e.g. Viewer, Contributor, Editor, Uploader
      * @returns {Promise<void>}
      */
-    setPublicLinkRole: function (role) {
-      role = _(role).chain().toLower().startCase().replace(/\s/g, '').value()
+    setPublicLinkRole: function(role) {
+      role = _(role)
+        .chain()
+        .toLower()
+        .startCase()
+        .replace(/\s/g, '')
+        .value()
       return this.waitForElementPresent('@selectRoleButton')
         .click('@selectRoleButton')
         .waitForElementVisible('@rolesDropdown')
@@ -44,9 +49,8 @@ module.exports = {
      * @param {string} linkName Name of the public link share
      *
      */
-    setPublicLinkName: function (linkName) {
-      return this
-        .waitForElementVisible('@publicLinkNameInputField')
+    setPublicLinkName: function(linkName) {
+      return this.waitForElementVisible('@publicLinkNameInputField')
         .clearValue('@publicLinkNameInputField')
         .setValue('@publicLinkNameInputField', linkName)
     },
@@ -56,14 +60,15 @@ module.exports = {
      * @param {string} linkPassword
      * @returns {Promise<void>}
      */
-    setPublicLinkPassword: function (linkPassword) {
+    setPublicLinkPassword: function(linkPassword) {
       this.waitForElementVisible('@publicLinkPasswordField')
       if (linkPassword === '') {
         return this.click('@publicLinkDeletePasswordButton')
       }
-      return this
-        .clearValue('@publicLinkPasswordField')
-        .setValue('@publicLinkPasswordField', linkPassword)
+      return this.clearValue('@publicLinkPasswordField').setValue(
+        '@publicLinkPasswordField',
+        linkPassword
+      )
     },
     /**
      * function sets different fields for public link
@@ -72,7 +77,7 @@ module.exports = {
      * @param value values for the different fields to be set
      * @returns {*|Promise<void>|exports}
      */
-    setPublicLinkForm: function (key, value) {
+    setPublicLinkForm: function(key, value) {
       if (key === 'role') {
         return this.setPublicLinkRole(value)
       } else if (key === 'name') {
@@ -81,9 +86,7 @@ module.exports = {
         return this.setPublicLinkPassword(value)
       } else if (key === 'expireDate') {
         value = sharingHelper.calculateDate(value)
-        return this.api.page
-          .FilesPageElement
-          .sharingDialog()
+        return this.api.page.FilesPageElement.sharingDialog()
           .openExpirationDatePicker()
           .setExpirationDate(value, 'link')
       }
@@ -100,7 +103,7 @@ module.exports = {
      * @param {string} editData.expireDate - Expire date for a public link share
      * @returns {exports}
      */
-    editPublicLink: async function (linkName, editData) {
+    editPublicLink: async function(linkName, editData) {
       await this.clickLinkEditBtn(linkName)
       for (const [key, value] of Object.entries(editData)) {
         await this.setPublicLinkForm(key, value)
@@ -112,9 +115,8 @@ module.exports = {
      *
      * @returns {exports}
      */
-    savePublicLink: function () {
-      return this
-        .initAjaxCounters()
+    savePublicLink: function() {
+      return this.initAjaxCounters()
         .waitForElementVisible('@publicLinkSaveButton')
         .click('@publicLinkSaveButton')
         .waitForElementNotPresent({ selector: '@publicLinkSaveButton', abortOnFailure: false })
@@ -126,15 +128,15 @@ module.exports = {
      * @param {string} linkName Name of the public link share of a resource to be deleted
      * @returns {exports}
      */
-    removePublicLink: function (linkName) {
-      const linkRowDeleteButtonSelector = this.elements.publicLinkContainer.selector +
+    removePublicLink: function(linkName) {
+      const linkRowDeleteButtonSelector =
+        this.elements.publicLinkContainer.selector +
         util.format(this.elements.publicLinkDeleteButton.selector, linkName)
       const linkRowDeleteButton = {
         locateStrategy: this.elements.publicLinkDeleteButton.locateStrategy,
         selector: linkRowDeleteButtonSelector
       }
-      return this
-        .initAjaxCounters()
+      return this.initAjaxCounters()
         .waitForElementVisible(linkRowDeleteButton)
         .pause(500)
         .click(linkRowDeleteButton)
@@ -146,17 +148,17 @@ module.exports = {
      * @param {string} linkName - Name of the public link share to be asserted
      * @returns {boolean}
      */
-    isPublicLinkPresent: async function (linkName) {
-      const fileNameSelectorXpath = this.elements.publicLinkContainer.selector + this.elements.publicLinkName.selector
+    isPublicLinkPresent: async function(linkName) {
+      const fileNameSelectorXpath =
+        this.elements.publicLinkContainer.selector + this.elements.publicLinkName.selector
       let isPresent
-      await this
-        .waitForAnimationToFinish()
-        .api.elements(
-          this.elements.publicLinkName.locateStrategy,
-          util.format(fileNameSelectorXpath, linkName),
-          (result) => {
-            isPresent = result.value.length > 0
-          })
+      await this.waitForAnimationToFinish().api.elements(
+        this.elements.publicLinkName.locateStrategy,
+        util.format(fileNameSelectorXpath, linkName),
+        result => {
+          isPresent = result.value.length > 0
+        }
+      )
       return isPresent
     },
     /**
@@ -169,9 +171,8 @@ module.exports = {
      * @param {string} settings.expireDate - Expire date for a public link share
      * @returns {*}
      */
-    addNewLink: async function (settings = null) {
-      await this
-        .waitForElementVisible('@publicLinkAddButton')
+    addNewLink: async function(settings = null) {
+      await this.waitForElementVisible('@publicLinkAddButton')
         .click('@publicLinkAddButton')
         .waitForElementVisible('@publicLinkCreateButton')
       if (settings !== null) {
@@ -179,8 +180,7 @@ module.exports = {
           await this.setPublicLinkForm(key, value)
         }
       }
-      return this
-        .initAjaxCounters()
+      return this.initAjaxCounters()
         .waitForElementVisible('@publicLinkCreateButton')
         .click('@publicLinkCreateButton')
         .waitForElementNotPresent('@publicLinkCreateButton')
@@ -192,9 +192,8 @@ module.exports = {
      * @param {string} settings.expireDate - Expire date for a public link share
      * @returns {*}
      */
-    setPublicLinkDate: async function (days) {
-      await this
-        .waitForElementVisible('@publicLinkAddButton')
+    setPublicLinkDate: async function(days) {
+      await this.waitForElementVisible('@publicLinkAddButton')
         .click('@publicLinkAddButton')
         .waitForElementVisible('@publicLinkCreateButton')
       if (days) {
@@ -204,8 +203,7 @@ module.exports = {
           return
         }
       }
-      return this
-        .initAjaxCounters()
+      return this.initAjaxCounters()
         .waitForElementVisible('@publicLinkCreateButton')
         .click('@publicLinkCreateButton')
         .waitForElementNotPresent('@publicLinkCreateButton')
@@ -218,7 +216,7 @@ module.exports = {
      * inside the collaborator element, defaults to all when null
      * @returns {Array.<Object>} array of link data
      */
-    getPublicLinkList: async function (subSelectors = null) {
+    getPublicLinkList: async function(subSelectors = null) {
       if (subSelectors === null) {
         subSelectors = {
           name: this.elements.publicLinkSubName,
@@ -227,19 +225,24 @@ module.exports = {
         }
       }
 
-      const informationSelector = this.elements.publicLinkContainer.selector + this.elements.publicLinkInformation.selector
+      const informationSelector =
+        this.elements.publicLinkContainer.selector + this.elements.publicLinkInformation.selector
 
       let results = []
 
       let linkElementIds = null
       await this.initAjaxCounters()
-        .waitForElementPresent({ locateStrategy: 'xpath', selector: informationSelector, abortOnFailure: false })
+        .waitForElementPresent({
+          locateStrategy: 'xpath',
+          selector: informationSelector,
+          abortOnFailure: false
+        })
         .waitForOutstandingAjaxCalls()
         .api.elements('xpath', informationSelector, result => {
           linkElementIds = result.value.map(item => item[Object.keys(item)[0]])
         })
 
-      results = linkElementIds.map(async (linkElementId) => {
+      results = linkElementIds.map(async linkElementId => {
         const linkResult = {}
         for (const attrName in subSelectors) {
           let attrElementId = null
@@ -247,7 +250,7 @@ module.exports = {
             linkElementId,
             'css selector',
             subSelectors[attrName],
-            (result) => {
+            result => {
               if (result.status !== -1) {
                 attrElementId = result.value.ELEMENT
               }
@@ -255,7 +258,7 @@ module.exports = {
           )
 
           if (attrElementId) {
-            await this.api.elementIdText(attrElementId, (text) => {
+            await this.api.elementIdText(attrElementId, text => {
               linkResult[attrName] = text.value
             })
           } else {
@@ -274,9 +277,10 @@ module.exports = {
      *
      * @returns {Promise<string>}
      */
-    getPublicLinkUrls: async function () {
+    getPublicLinkUrls: async function() {
       const promiseList = []
-      const publicLinkUrlXpath = this.elements.publicLinkContainer.selector +
+      const publicLinkUrlXpath =
+        this.elements.publicLinkContainer.selector +
         this.elements.publicLinkInformation.selector +
         this.elements.publicLinkUrl.selector
       await this.initAjaxCounters()
@@ -288,11 +292,12 @@ module.exports = {
         .waitForOutstandingAjaxCalls()
         .api.elements('xpath', publicLinkUrlXpath, result => {
           result.value.map(item => {
-            promiseList.push(new Promise((resolve) => {
-              this.api.elementIdAttribute(item.ELEMENT, 'href', href => {
-                resolve(href.value)
+            promiseList.push(
+              new Promise(resolve => {
+                this.api.elementIdAttribute(item.ELEMENT, 'href', href => {
+                  resolve(href.value)
+                })
               })
-            })
             )
           })
         })
@@ -302,11 +307,12 @@ module.exports = {
      *
      * @returns {Promise<string>}
      */
-    getErrorMessage: async function () {
+    getErrorMessage: async function() {
       let message
-      const errorMessageXpath = this.elements.publicLinkContainer.selector +
+      const errorMessageXpath =
+        this.elements.publicLinkContainer.selector +
         this.elements.errorMessageInsidePublicLinkContainer.selector
-      await this.getText('xpath', errorMessageXpath, function (result) {
+      await this.getText('xpath', errorMessageXpath, function(result) {
         message = result.value
       })
       return message
@@ -316,24 +322,22 @@ module.exports = {
      *
      * @param {string} linkName Name of the public link whose URL is to be copied
      */
-    copyPublicLinkURI: function (linkName) {
-      const copyBtnXpath = this.elements.publicLinkContainer.selector +
+    copyPublicLinkURI: function(linkName) {
+      const copyBtnXpath =
+        this.elements.publicLinkContainer.selector +
         util.format(this.elements.publicLinkURLCopyButton.selector, linkName)
       const copyBtnSelector = {
         selector: copyBtnXpath,
         locateStrategy: this.elements.publicLinkURLCopyButton.locateStrategy
       }
-      return this
-        .waitForElementVisible(copyBtnSelector)
-        .click(copyBtnSelector)
+      return this.waitForElementVisible(copyBtnSelector).click(copyBtnSelector)
     },
-    copyPrivateLink: function () {
+    copyPrivateLink: function() {
       const appSideBarElements = this.api.page.FilesPageElement.appSideBar().elements
       const sidebarLinksTabXpath = appSideBarElements.sidebarLinksTab.selector
       const sidebarCss = appSideBarElements.sideBar.selector
 
-      return this
-        .waitForElementVisible(sidebarCss)
+      return this.waitForElementVisible(sidebarCss)
         .useXpath()
         .waitForElementVisible(sidebarLinksTabXpath)
         .click(sidebarLinksTabXpath)

--- a/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
@@ -15,7 +15,7 @@ module.exports = {
      *
      * @param {string} permissions
      */
-    getArrayFromPermissionString: function (permissions) {
+    getArrayFromPermissionString: function(permissions) {
       permissions = permissions.replace(/\s/g, '')
       return permissions.split(',').filter(x => x)
     },
@@ -23,7 +23,7 @@ module.exports = {
      *
      * @param {string} permission
      */
-    getPermissionCheckbox: function (permission) {
+    getPermissionCheckbox: function(permission) {
       return util.format(this.elements.permissionCheckbox.selector, permission)
     },
     /**
@@ -31,15 +31,13 @@ module.exports = {
      *
      * @returns {Promise<string>}
      */
-    getSharingPermissionMsg: async function () {
+    getSharingPermissionMsg: async function() {
       let shareResponse
       // eslint-disable-next-line no-unused-expressions
       this.api.expect.element(this.elements.addShareSaveButton.selector).not.to.be.present
-      await this.api.getText(this.elements.noResharePermissions.selector,
-        function (result) {
-          shareResponse = result.value
-        }
-      )
+      await this.api.getText(this.elements.noResharePermissions.selector, function(result) {
+        shareResponse = result.value
+      })
       return shareResponse
     },
 
@@ -51,11 +49,11 @@ module.exports = {
      *
      * @return {Promise<string|null>}
      */
-    getVisibleElementID: async function (using, value) {
+    getVisibleElementID: async function(using, value) {
       let visibleElementID = null
       await this.api.elements(using, value, response => {
         for (const { ELEMENT } of response.value) {
-          this.api.elementIdDisplayed(ELEMENT, function (result) {
+          this.api.elementIdDisplayed(ELEMENT, function(result) {
             if (result.value === true) {
               visibleElementID = ELEMENT
             }
@@ -70,11 +68,14 @@ module.exports = {
      *
      * @param {string} sharee
      */
-    removePendingCollaboratorForShare: function (sharee) {
+    removePendingCollaboratorForShare: function(sharee) {
       const newCollaboratorXpath = util.format(this.elements.newCollaboratorItems.selector, sharee)
-      const removeCollaboratorBtnXpath = newCollaboratorXpath + this.elements.newCollaboratorRemoveButton.selector
+      const removeCollaboratorBtnXpath =
+        newCollaboratorXpath + this.elements.newCollaboratorRemoveButton.selector
 
-      return this.useXpath().click(removeCollaboratorBtnXpath).useCss()
+      return this.useXpath()
+        .click(removeCollaboratorBtnXpath)
+        .useCss()
     },
 
     /**
@@ -83,16 +84,21 @@ module.exports = {
      * @param {boolean} [shareWithGroup=false]
      * @param {boolean} remoteShare
      */
-    selectCollaboratorForShare: async function (receiver, shareWithGroup = false, remoteShare = false) {
+    selectCollaboratorForShare: async function(
+      receiver,
+      shareWithGroup = false,
+      remoteShare = false
+    ) {
       let sharee = receiver
       if (remoteShare) sharee = util.format('%s@%s', receiver, this.api.globals.remote_backend_url)
       // We need waitForElementPresent here.
       // waitForElementVisible would break even with 'abortOnFailure: false' if the element is not present
-      await this.enterAutoComplete(sharee)
-        .waitForElementPresent({
+      await this.enterAutoComplete(sharee).waitForElementPresent(
+        {
           selector: '@sharingAutoCompleteDropDownElements',
           abortOnFailure: false
-        }, (result) => {
+        },
+        result => {
           if (result.value === false) {
             // sharing dropdown was not shown
             console.log('WARNING: no sharing autocomplete dropdown found, retry typing')
@@ -100,12 +106,16 @@ module.exports = {
               .enterAutoComplete(sharee)
               .waitForElementVisible('@sharingAutoCompleteDropDownElements')
           }
-        })
+        }
+      )
 
-      let receiverType = (shareWithGroup === true) ? SHARE_TYPE_STRING.group : SHARE_TYPE_STRING.user
-      receiverType = (remoteShare === true) ? SHARE_TYPE_STRING.federation : receiverType
+      let receiverType = shareWithGroup === true ? SHARE_TYPE_STRING.group : SHARE_TYPE_STRING.user
+      receiverType = remoteShare === true ? SHARE_TYPE_STRING.federation : receiverType
 
-      const collaboratorSelector = this.getCollaboratorInAutocompleteListSelector(sharee, receiverType)
+      const collaboratorSelector = this.getCollaboratorInAutocompleteListSelector(
+        sharee,
+        receiverType
+      )
 
       await this.useXpath().click(collaboratorSelector)
 
@@ -115,7 +125,7 @@ module.exports = {
     /**
      * @param {string} permissions
      */
-    selectPermissionsOnPendingShare: async function (permissions) {
+    selectPermissionsOnPendingShare: async function(permissions) {
       const permissionArray = this.getArrayFromPermissionString(permissions)
       for (const permission of permissionArray) {
         const permissionCheckbox = this.getPermissionCheckbox(permission)
@@ -139,7 +149,14 @@ module.exports = {
      *
      * @return void
      */
-    shareWithUserOrGroup: async function (sharee, shareWithGroup = false, role, permissions, remote = false, days) {
+    shareWithUserOrGroup: async function(
+      sharee,
+      shareWithGroup = false,
+      role,
+      permissions,
+      remote = false,
+      days
+    ) {
       await collaboratorDialog.clickCreateShare()
       await this.selectCollaboratorForShare(sharee, shareWithGroup, remote)
       await this.selectRoleForNewCollaborator(role)
@@ -150,9 +167,9 @@ module.exports = {
 
       if (days) {
         const dateToSet = calculateDate(days)
-        const isExpiryDateChanged = await this
-          .openExpirationDatePicker()
-          .setExpirationDate(dateToSet)
+        const isExpiryDateChanged = await this.openExpirationDatePicker().setExpirationDate(
+          dateToSet
+        )
         if (!isExpiryDateChanged) {
           console.log('WARNING: Cannot create share with disabled expiration date!')
           return
@@ -165,8 +182,13 @@ module.exports = {
      *
      * @param {String} role
      */
-    selectRoleForNewCollaborator: function (role) {
-      role = _(role).chain().toLower().startCase().replace(/\s/g, '').value()
+    selectRoleForNewCollaborator: function(role) {
+      role = _(role)
+        .chain()
+        .toLower()
+        .startCase()
+        .replace(/\s/g, '')
+        .value()
       return this.waitForElementPresent('@newCollaboratorSelectRoleButton')
         .click('@newCollaboratorSelectRoleButton')
         .waitForElementVisible('@newCollaboratorRolesDropdown')
@@ -174,24 +196,22 @@ module.exports = {
         .click(`@newCollaboratorRole${role}`)
         .waitForElementNotVisible('@newCollaboratorRolesDropdown')
     },
-    confirmShare: function () {
+    confirmShare: function() {
       return this.waitForElementPresent('@addShareSaveButton')
         .initAjaxCounters()
         .click('@addShareSaveButton')
         .waitForOutstandingAjaxCalls()
         .waitForElementNotPresent('@addShareSaveButton')
     },
-    saveChanges: function () {
+    saveChanges: function() {
       return this.waitForElementVisible('@saveShareButton')
         .initAjaxCounters()
         .click('@saveShareButton')
         .waitForOutstandingAjaxCalls()
         .waitForElementNotPresent('@saveShareButton')
     },
-    clickCancel: function () {
-      return this
-        .waitForElementVisible('@cancelButton')
-        .click('@cancelButton')
+    clickCancel: function() {
+      return this.waitForElementVisible('@cancelButton').click('@cancelButton')
     },
     /**
      * Toggle the checkbox to set a certain permission for a share
@@ -199,7 +219,7 @@ module.exports = {
      *
      * @param {string} permission
      */
-    toggleSinglePermission: async function (permission) {
+    toggleSinglePermission: async function(permission) {
       const permissionCheckbox = this.getPermissionCheckbox(permission)
       const elementID = await this.getVisibleElementID('xpath', permissionCheckbox)
       if (!elementID) {
@@ -216,15 +236,14 @@ module.exports = {
      *
      * @return {Promise<Object.<string, boolean>>}  eg - {share: true, change: false}
      */
-    getSharePermissions: async function () {
+    getSharePermissions: async function() {
       const permissions = {}
       const panelSelector = this.elements.sharingSidebarRoot.selector
       let permissionToggle
       for (let i = 0; i < COLLABORATOR_PERMISSION_ARRAY.length; i++) {
-        permissionToggle = panelSelector + util.format(
-          this.elements.permissionCheckbox.selector,
-          COLLABORATOR_PERMISSION_ARRAY[i]
-        )
+        permissionToggle =
+          panelSelector +
+          util.format(this.elements.permissionCheckbox.selector, COLLABORATOR_PERMISSION_ARRAY[i])
 
         await this.api.element('xpath', permissionToggle, result => {
           if (!result.value.ELEMENT) {
@@ -242,7 +261,7 @@ module.exports = {
      * @param {string} collaborator
      * @param {string} requiredPermissions
      */
-    changeCustomPermissionsTo: async function (collaborator, requiredPermissions) {
+    changeCustomPermissionsTo: async function(collaborator, requiredPermissions) {
       await collaboratorDialog.clickEditShare(collaborator)
 
       const requiredPermissionArray = this.getArrayFromPermissionString(requiredPermissions)
@@ -269,7 +288,7 @@ module.exports = {
      * @param {string} collaborator
      * @param {string} permissions
      */
-    getDisplayedPermission: async function (collaborator) {
+    getDisplayedPermission: async function(collaborator) {
       await collaboratorDialog.clickEditShare(collaborator)
       // read the permissions from the checkboxes
       const currentSharePermissions = await this.getSharePermissions()
@@ -280,11 +299,12 @@ module.exports = {
      *
      * @param {string} collaborator
      */
-    disableAllCustomPermissions: async function (collaborator) {
+    disableAllCustomPermissions: async function(collaborator) {
       await collaboratorDialog.clickEditShare(collaborator)
       const sharePermissions = await this.getSharePermissions(collaborator)
-      const enabledPermissions = Object.keys(sharePermissions)
-        .filter(permission => sharePermissions[permission] === true)
+      const enabledPermissions = Object.keys(sharePermissions).filter(
+        permission => sharePermissions[permission] === true
+      )
 
       for (const permission of enabledPermissions) {
         await this.toggleSinglePermission(permission)
@@ -295,7 +315,7 @@ module.exports = {
      *
      * @param {string} input
      */
-    enterAutoComplete: function (input) {
+    enterAutoComplete: function(input) {
       return this.initAjaxCounters()
         .waitForElementVisible('@sharingAutoComplete')
         .setValueBySingleKeys('@sharingAutoComplete', input)
@@ -305,11 +325,11 @@ module.exports = {
      *
      * @returns {Promise.<string[]>} Array of autocomplete items
      */
-    getShareAutocompleteItemsList: async function () {
+    getShareAutocompleteItemsList: async function() {
       const webElementIdList = await this.getShareAutocompleteWebElementIdList()
-      const itemsListPromises = webElementIdList.map((webElementId) => {
+      const itemsListPromises = webElementIdList.map(webElementId => {
         return new Promise((resolve, reject) => {
-          this.api.elementIdText(webElementId, (text) => {
+          this.api.elementIdText(webElementId, text => {
             resolve(text.value.trim())
           })
         })
@@ -323,7 +343,7 @@ module.exports = {
      *
      * @returns {Promise.<string[]>} Array of autocomplete webElementIds
      */
-    getShareAutocompleteWebElementIdList: async function () {
+    getShareAutocompleteWebElementIdList: async function() {
       const webElementIdList = []
       const showAllResultsXpath = this.elements.sharingAutoCompleteShowAllResultsButton.selector
       // wait for autocomplete to finish loading
@@ -338,18 +358,21 @@ module.exports = {
       await this.waitForElementNotPresent('@sharingAutoCompleteSpinner')
       // note: some result lists don't have the "show all" button depending on the number of entries,
       // so we only click it if present
-      await this.api.element('css selector', showAllResultsXpath, (result) => {
+      await this.api.element('css selector', showAllResultsXpath, result => {
         if (result.status !== -1) {
           return this.click('@sharingAutoCompleteShowAllResultsButton')
         }
       })
 
-      await this
-        .api.elements('css selector', this.elements.sharingAutoCompleteDropDownElements.selector, (result) => {
-          result.value.forEach((value) => {
+      await this.api.elements(
+        'css selector',
+        this.elements.sharingAutoCompleteDropDownElements.selector,
+        result => {
+          result.value.forEach(value => {
             webElementIdList.push(value[Object.keys(value)[0]])
           })
-        })
+        }
+      )
       return webElementIdList
     },
     /**
@@ -358,7 +381,7 @@ module.exports = {
      * @param {string} newRole
      * @returns {Promise}
      */
-    changeCollaboratorRole: async function (collaborator, newRole) {
+    changeCollaboratorRole: async function(collaborator, newRole) {
       await collaboratorDialog.clickEditShare(collaborator)
       await this.changeCollaboratorRoleInDropdown(newRole)
       return this.saveChanges()
@@ -367,12 +390,12 @@ module.exports = {
      * @params {string} newRole
      * @returns {Promise}
      */
-    changeCollaboratorRoleInDropdown: function (newRole) {
+    changeCollaboratorRoleInDropdown: function(newRole) {
       const newRoleButton = util.format(
-        this.elements.roleButtonInDropdown.selector, newRole.toLowerCase()
+        this.elements.roleButtonInDropdown.selector,
+        newRole.toLowerCase()
       )
-      return this
-        .initAjaxCounters()
+      return this.initAjaxCounters()
         .useXpath()
         .waitForElementVisible('@selectRoleButtonInCollaboratorInformation')
         .click('@selectRoleButtonInCollaboratorInformation')
@@ -385,14 +408,11 @@ module.exports = {
      *
      * @returns {Promise<boolean>}
      */
-    isAutocompleteListVisible: async function () {
+    isAutocompleteListVisible: async function() {
       let isVisible = false
-      await this.api.elements(
-        '@sharingAutoCompleteDropDownElements',
-        (result) => {
-          isVisible = result.value.length > 0
-        }
-      )
+      await this.api.elements('@sharingAutoCompleteDropDownElements', result => {
+        isVisible = result.value.length > 0
+      })
       return isVisible
     },
 
@@ -403,7 +423,7 @@ module.exports = {
      * @param {string} usersMatchingPattern
      *
      */
-    assertUsersInAutocompleteList: function (usersMatchingPattern) {
+    assertUsersInAutocompleteList: function(usersMatchingPattern) {
       usersMatchingPattern.map(user => {
         const collaboratorSelector = this.getCollaboratorInAutocompleteListSelector(user, 'user')
 
@@ -419,14 +439,14 @@ module.exports = {
      * @param {string} type Type of the collaborator which should be found
      * @returns {string} xpath of the collaborator
      */
-    getCollaboratorInAutocompleteListSelector: function (collaborator, type) {
+    getCollaboratorInAutocompleteListSelector: function(collaborator, type) {
       return (
         util.format(this.elements.collaboratorAutocompleteItem.selector, type) +
         util.format(this.elements.collaboratorAutocompleteItemName.selector, collaborator)
       )
     },
 
-    displayAllCollaboratorsAutocompleteResults: function () {
+    displayAllCollaboratorsAutocompleteResults: function() {
       return this.click('@sharingAutoCompleteShowAllResultsButton')
     },
 
@@ -437,7 +457,7 @@ module.exports = {
      * @param {string} groupMatchingPattern
      *
      */
-    assertGroupsInAutocompleteList: function (groupMatchingPattern) {
+    assertGroupsInAutocompleteList: function(groupMatchingPattern) {
       groupMatchingPattern.map(user => {
         const collaboratorSelector = this.getCollaboratorInAutocompleteListSelector(user, 'group')
 
@@ -454,7 +474,7 @@ module.exports = {
      * @param {string} type Type of the collaborator. Can be either user, group or remote
      *
      */
-    assertAlreadyExistingCollaboratorIsNotInAutocompleteList: function (name, type) {
+    assertAlreadyExistingCollaboratorIsNotInAutocompleteList: function(name, type) {
       const collaboratorSelector = this.getCollaboratorInAutocompleteListSelector(name, type)
 
       return this.useXpath().expect.element(collaboratorSelector).to.not.be.present
@@ -468,7 +488,7 @@ module.exports = {
      * @param {boolean} shouldBePresent Whether the collaborator should be found in the list or not
      *
      */
-    assertCollaboratorsInAutocompleteList: function (name, type, shouldBePresent = true) {
+    assertCollaboratorsInAutocompleteList: function(name, type, shouldBePresent = true) {
       const collaboratorSelector = this.getCollaboratorInAutocompleteListSelector(name, type)
 
       if (shouldBePresent) {
@@ -483,12 +503,10 @@ module.exports = {
      *
      * @return {Promise<*>}
      */
-    changeCollaboratorExpiryDate: async function (collaborator, days) {
+    changeCollaboratorExpiryDate: async function(collaborator, days) {
       await collaboratorDialog.clickEditShare(collaborator)
       const dateToSet = calculateDate(days)
-      const isExpiryDateChanged = await this
-        .openExpirationDatePicker()
-        .setExpirationDate(dateToSet)
+      const isExpiryDateChanged = await this.openExpirationDatePicker().setExpirationDate(dateToSet)
       if (!isExpiryDateChanged) {
         console.log('WARNING: Cannot create share with disabled expiration date!')
         return
@@ -499,9 +517,8 @@ module.exports = {
      * opens expiration date field on the webUI
      * @return {*}
      */
-    openExpirationDatePicker: function () {
-      this
-        .initAjaxCounters()
+    openExpirationDatePicker: function() {
+      this.initAjaxCounters()
         .waitForElementVisible('@expirationDateField')
         .waitForElementNotPresent('@elementInterceptingCollaboratorsExpirationInput')
         .click('@expirationDateField')
@@ -511,26 +528,29 @@ module.exports = {
      * extracts set value in expiration date field
      * @return {Promise<*>}
      */
-    getExpirationDateFromInputField: async function () {
+    getExpirationDateFromInputField: async function() {
       let expirationDate
-      await this
-        .waitForElementVisible('@expirationDateField')
-        .getValue('@expirationDateField', (result) => {
+      await this.waitForElementVisible('@expirationDateField').getValue(
+        '@expirationDateField',
+        result => {
           expirationDate = result.value
-        })
+        }
+      )
       return expirationDate
     },
     /**
      * gets disabled status of save share button
      * @return {Promise<*>}
      */
-    getDisabledAttributeOfSaveShareButton: async function () {
+    getDisabledAttributeOfSaveShareButton: async function() {
       let disabled
-      await this
-        .waitForElementVisible('@saveShareButton')
-        .getAttribute('@saveShareButton', 'disabled', (result) => {
+      await this.waitForElementVisible('@saveShareButton').getAttribute(
+        '@saveShareButton',
+        'disabled',
+        result => {
           disabled = result.value
-        })
+        }
+      )
       return disabled
     },
     /**
@@ -538,13 +558,12 @@ module.exports = {
      * @param {string} collaborator Name of the collaborator
      * @return {*}
      */
-    changeCollaboratorSettings: async function (collaborator, editData) {
+    changeCollaboratorSettings: async function(collaborator, editData) {
       await collaboratorDialog.clickEditShare(collaborator)
       for (const [key, value] of Object.entries(editData)) {
         await this.setCollaboratorForm(key, value)
       }
-      return this.waitForElementVisible('@saveShareButton')
-        .click('@saveShareButton')
+      return this.waitForElementVisible('@saveShareButton').click('@saveShareButton')
     },
     /**
      * function sets different fields for collaborator form
@@ -553,13 +572,12 @@ module.exports = {
      * @param value values for the different fields to be set
      * @returns {*|Promise<void>|exports}
      */
-    setCollaboratorForm: function (key, value) {
+    setCollaboratorForm: function(key, value) {
       if (key === 'permissionString') {
         return this.changeCollaboratorRoleInDropdown(value)
       } else if (key === 'expireDate') {
         const dateToSet = calculateDate(value)
-        return this.openExpirationDatePicker()
-          .setExpirationDate(dateToSet)
+        return this.openExpirationDatePicker().setExpirationDate(dateToSet)
       }
       return this
     },
@@ -567,12 +585,15 @@ module.exports = {
      *
      * @returns {Promise<string>}
      */
-    getErrorMessage: async function () {
+    getErrorMessage: async function() {
       let message
-      await this.waitForElementVisible('@collaboratorErrorAlert')
-        .getText('xpath', this.elements.collaboratorErrorAlert.selector, function (result) {
+      await this.waitForElementVisible('@collaboratorErrorAlert').getText(
+        'xpath',
+        this.elements.collaboratorErrorAlert.selector,
+        function(result) {
           message = result.value
-        })
+        }
+      )
       return message
     }
   },
@@ -598,7 +619,8 @@ module.exports = {
       selector: '#oc-sharing-autocomplete .oc-autocomplete-suggestion-list'
     },
     sharingAutoCompleteDropDownElements: {
-      selector: '#oc-sharing-autocomplete .oc-autocomplete-suggestion .files-collaborators-autocomplete-user-text'
+      selector:
+        '#oc-sharing-autocomplete .oc-autocomplete-suggestion .files-collaborators-autocomplete-user-text'
     },
     sharingAutoCompleteShowAllResultsButton: {
       selector: '.oc-autocomplete-suggestion-overflow'
@@ -634,10 +656,12 @@ module.exports = {
       selector: '#files-collaborators-role-editor'
     },
     newCollaboratorItems: {
-      selector: "//div[@id='oc-files-sharing-sidebar']//table[contains(@class, 'files-collaborators-collaborator-autocomplete-item')]//div[contains(., '%s')]/ancestor::tr[position()=1]"
+      selector:
+        "//div[@id='oc-files-sharing-sidebar']//table[contains(@class, 'files-collaborators-collaborator-autocomplete-item')]//div[contains(., '%s')]/ancestor::tr[position()=1]"
     },
     newCollaboratorRemoveButton: {
-      selector: "//button[contains(@class, 'files-collaborators-collaborator-autocomplete-item-remove')]"
+      selector:
+        "//button[contains(@class, 'files-collaborators-collaborator-autocomplete-item-remove')]"
     },
     newCollaboratorRoleAdvancedPermissions: {
       selector: '#files-collaborators-role-advancedRole'
@@ -652,7 +676,8 @@ module.exports = {
     },
     roleButtonInDropdown: {
       // the translate bit is to make it case-insensitive
-      selector: '//ul[contains(@class,"oc-autocomplete-suggestion-list")]//span[translate(.,"ABCDEFGHJIKLMNOPQRSTUVWXYZ","abcdefghjiklmnopqrstuvwxyz") ="%s"]',
+      selector:
+        '//ul[contains(@class,"oc-autocomplete-suggestion-list")]//span[translate(.,"ABCDEFGHJIKLMNOPQRSTUVWXYZ","abcdefghjiklmnopqrstuvwxyz") ="%s"]',
       locateStrategy: 'xpath'
     },
     permissionCheckbox: {
@@ -673,7 +698,8 @@ module.exports = {
       selector: '.vdatetime-popup__actions__button--confirm'
     },
     collaboratorExpirationDate: {
-      selector: '//span[contains(@class, "files-collaborators-collaborator-name") and text()="%s"]/../../span/span[contains(@class, "files-collaborators-collaborator-expires")]',
+      selector:
+        '//span[contains(@class, "files-collaborators-collaborator-name") and text()="%s"]/../../span/span[contains(@class, "files-collaborators-collaborator-expires")]',
       locateStrategy: 'xpath'
     },
     collaboratorAutocompleteItem: {
@@ -681,7 +707,8 @@ module.exports = {
       locateStrategy: 'xpath'
     },
     collaboratorAutocompleteItemName: {
-      selector: '//div[contains(@class, "files-collaborators-autocomplete-username") and text()="%s"]',
+      selector:
+        '//div[contains(@class, "files-collaborators-autocomplete-username") and text()="%s"]',
       locateStrategy: 'xpath'
     },
     collaboratorsListItemInfo: {
@@ -696,7 +723,8 @@ module.exports = {
       selector: '.vdatetime-input'
     },
     requiredLabelInCollaboratorsExpirationDate: {
-      selector: '//label[@for="files-collaborators-collaborator-expiration-input"]/em[.="(required)"]',
+      selector:
+        '//label[@for="files-collaborators-collaborator-expiration-input"]/em[.="(required)"]',
       locateStrategy: 'xpath'
     },
     elementInterceptingCollaboratorsExpirationInput: {

--- a/tests/acceptance/pageObjects/FilesPageElement/versionsDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/versionsDialog.js
@@ -3,22 +3,18 @@ module.exports = {
     /**
      * @returns {Promise<number>}
      */
-    getVersionsCount: async function () {
+    getVersionsCount: async function() {
       let count = 0
-      await this
-        .api.elements(
-          '@versionsList',
-          function (result) {
-            count = result.value.length
-          })
+      await this.api.elements('@versionsList', function(result) {
+        count = result.value.length
+      })
       return count
     },
     /**
      * @returns {*}
      */
-    restoreToPreviousVersion: function () {
-      return this
-        .initAjaxCounters()
+    restoreToPreviousVersion: function() {
+      return this.initAjaxCounters()
         .waitForElementVisible('@restorePreviousVersion')
         .click('@restorePreviousVersion')
         .waitForOutstandingAjaxCalls()
@@ -30,7 +26,8 @@ module.exports = {
       locateStrategy: 'xpath'
     },
     restorePreviousVersion: {
-      selector: '(//div[contains(@id,"oc-file-versions")]//tbody/tr[@class="file-row"])[1]//button[1]',
+      selector:
+        '(//div[contains(@id,"oc-file-versions")]//tbody/tr[@class="file-row"])[1]//button[1]',
       locateStrategy: 'xpath'
     }
   }

--- a/tests/acceptance/pageObjects/accountPage.js
+++ b/tests/acceptance/pageObjects/accountPage.js
@@ -1,7 +1,7 @@
 const { join } = require('../helpers/path')
 
 module.exports = {
-  url: function () {
+  url: function() {
     return join(this.api.launchUrl, '/index.html#/account/')
   },
   commands: {
@@ -9,9 +9,8 @@ module.exports = {
      * like build-in navigate() but also waits for the account display element
      * @returns {Promise}
      */
-    navigateAndWaitTillLoaded: function () {
-      return this.navigate(this.url())
-        .waitForElementVisible('@accountDisplay')
+    navigateAndWaitTillLoaded: function() {
+      return this.navigate(this.url()).waitForElementVisible('@accountDisplay')
     },
 
     /**
@@ -19,15 +18,19 @@ module.exports = {
      *
      * @returns {object}
      */
-    getAccountInformation: async function () {
+    getAccountInformation: async function() {
       const accountInformation = []
       let accountInfoElementIds = []
-      await this.waitForElementVisible('@accountInformationElements')
-        .api.elements('@accountInformationElements', function (result) {
+      await this.waitForElementVisible('@accountInformationElements').api.elements(
+        '@accountInformationElements',
+        function(result) {
           accountInfoElementIds = result.value
-        })
+        }
+      )
       for (const elementIdIndex in accountInfoElementIds) {
-        await this.api.elementIdText(accountInfoElementIds[elementIdIndex].ELEMENT, function (elementText) {
+        await this.api.elementIdText(accountInfoElementIds[elementIdIndex].ELEMENT, function(
+          elementText
+        ) {
           accountInformation.push(elementText.value)
         })
       }
@@ -39,14 +42,13 @@ module.exports = {
       }
       return actualAccInfo
     },
-    logout: function () {
-      return this.waitForElementVisible('@logoutButton')
-        .click('@logoutButton')
+    logout: function() {
+      return this.waitForElementVisible('@logoutButton').click('@logoutButton')
     },
-    isPageVisible: async function () {
+    isPageVisible: async function() {
       let isVisible = false
       const handle = []
-      await this.api.windowHandles(function (result) {
+      await this.api.windowHandles(function(result) {
         handle.push(result.value[1])
       })
       await this.api.switchWindow(handle[0])

--- a/tests/acceptance/pageObjects/favoritesPage.js
+++ b/tests/acceptance/pageObjects/favoritesPage.js
@@ -2,7 +2,7 @@ const navigationHelper = require('../helpers/navigationHelper')
 const { join } = require('../helpers/path')
 
 module.exports = {
-  url: function () {
+  url: function() {
     return join(this.api.launchUrl, '/#/files/favorites/')
   },
   commands: {
@@ -10,9 +10,10 @@ module.exports = {
      * like build-in navigate() but also waits till for the progressbar to appear and disappear
      * @returns {*}
      */
-    navigateAndWaitTillLoaded: function () {
+    navigateAndWaitTillLoaded: function() {
       return navigationHelper.navigateAndWaitTillLoaded(
-        this.url(), this.page.FilesPageElement.filesList().elements.filesListProgressBar
+        this.url(),
+        this.page.FilesPageElement.filesList().elements.filesListProgressBar
       )
     }
   }

--- a/tests/acceptance/pageObjects/filesDropPage.js
+++ b/tests/acceptance/pageObjects/filesDropPage.js
@@ -1,7 +1,7 @@
 const { join } = require('../helpers/path')
 
 module.exports = {
-  url: function () {
+  url: function() {
     return join(this.api.launchUrl, '/#/files/files-drop/')
   },
   commands: {
@@ -9,18 +9,18 @@ module.exports = {
      * like build-in navigate() but also waits till for the progressbar to appear and disappear
      * @returns {*}
      */
-    navigateAndWaitTillLoaded: function (token) {
+    navigateAndWaitTillLoaded: function(token) {
       this.navigate(this.url() + token)
       return this.waitForElementPresent('@fileDropzone')
     },
-    navigateAndWaitForPasswordPage: function (token) {
+    navigateAndWaitForPasswordPage: function(token) {
       this.navigate(this.url() + token)
       return this.page.publicLinkPasswordPage().waitForElementPresent('@passwordInput')
     },
     /**
      * @return {Promise}
      */
-    waitForPage: function () {
+    waitForPage: function() {
       return this.api.waitForElementVisible(this.elements.fileDropzone)
     },
     /**
@@ -29,22 +29,21 @@ module.exports = {
      * @param {string} path - absolute path of the file to upload
      * @returns {Promise}
      */
-    uploadFile: function (path) {
+    uploadFile: function(path) {
       return this.api.setValue(this.elements.fileUploadInput.selector, path)
     },
     /**
      * Get the list of uploaded files
      */
-    getUploadedFiles: async function () {
+    getUploadedFiles: async function() {
       let elements = []
-      await this.api.elements(
-        '@uploadedFiles',
-        result => { elements = result.value }
-      )
+      await this.api.elements('@uploadedFiles', result => {
+        elements = result.value
+      })
 
       const files = []
       for (const { ELEMENT } of elements) {
-        await this.api.elementIdText(ELEMENT, function (result) {
+        await this.api.elementIdText(ELEMENT, function(result) {
           files.push(result.value)
         })
       }

--- a/tests/acceptance/pageObjects/filesPage.js
+++ b/tests/acceptance/pageObjects/filesPage.js
@@ -3,7 +3,7 @@ const navigationHelper = require('../helpers/navigationHelper')
 const { join, normalize } = require('../helpers/path')
 
 module.exports = {
-  url: function () {
+  url: function() {
     return this.api.launchUrl + ''
   },
   commands: {
@@ -12,7 +12,7 @@ module.exports = {
      * @param {string} folder - if given navigate to the folder without clicking the links
      * @returns {*}
      */
-    navigateAndWaitTillLoaded: async function (folder = '') {
+    navigateAndWaitTillLoaded: async function(folder = '') {
       await navigationHelper.navigateAndWaitTillLoaded(
         join(this.api.launchUrl, '#/files/list', folder),
         this.page.FilesPageElement.filesList().elements.filesListProgressBar
@@ -24,8 +24,9 @@ module.exports = {
      *
      * @param {string} folder
      */
-    navigateToFolder: function (folder) {
-      return this.page.FilesPageElement.filesList().navigateToFolder(folder)
+    navigateToFolder: function(folder) {
+      return this.page.FilesPageElement.filesList()
+        .navigateToFolder(folder)
         .waitForElementVisible('@breadcrumb')
         .assert.containsText('@breadcrumb', folder)
     },
@@ -33,7 +34,7 @@ module.exports = {
      *
      * @param {string} resource
      */
-    navigateToBreadcrumb: function (resource) {
+    navigateToBreadcrumb: function(resource) {
       const breadcrumbElement = this.elements.resourceBreadcrumb
       const resourceXpath = util.format(breadcrumbElement.selector, resource)
       return this.useStrategy(breadcrumbElement)
@@ -47,9 +48,8 @@ module.exports = {
      * @param {string} name to set or null to use default value from dialog
      * @param {boolean} expectToSucceed
      */
-    createFolder: async function (name, expectToSucceed = true) {
-      await this
-        .waitForElementVisible('@newFileMenuButton', 500000)
+    createFolder: async function(name, expectToSucceed = true) {
+      await this.waitForElementVisible('@newFileMenuButton', 500000)
         .click('@newFileMenuButton')
         .waitForElementVisible('@newFolderButton')
         .click('@newFolderButton')
@@ -58,12 +58,11 @@ module.exports = {
         await this.clearValueWithEvent('@newFolderInput')
         await this.setValue('@newFolderInput', name)
       }
-      await this
-        .click('@newFolderOkButton')
-        .waitForElementNotPresent('@createFolderLoadingIndicator')
+      await this.click('@newFolderOkButton').waitForElementNotPresent(
+        '@createFolderLoadingIndicator'
+      )
       if (expectToSucceed) {
-        await this.waitForElementNotVisible('@newFolderDialog')
-          .waitForAnimationToFinish()
+        await this.waitForElementNotVisible('@newFolderDialog').waitForAnimationToFinish()
       }
       return this
     },
@@ -73,9 +72,8 @@ module.exports = {
      * @param {string} name to set or null to use default value from dialog
      * @param {boolean} expectToSucceed
      */
-    createFile: function (name, expectToSucceed = true) {
-      this
-        .waitForElementVisible('@newFileMenuButton')
+    createFile: function(name, expectToSucceed = true) {
+      this.waitForElementVisible('@newFileMenuButton')
         .click('@newFileMenuButton')
         .waitForElementVisible('@newFileButton')
         .click('@newFileButton')
@@ -84,18 +82,14 @@ module.exports = {
         this.clearValueWithEvent('@newFileInput')
         this.setValue('@newFileInput', name)
       }
-      this
-        .click('@newFileOkButton')
-        .waitForElementNotPresent('@createFileLoadingIndicator')
+      this.click('@newFileOkButton').waitForElementNotPresent('@createFileLoadingIndicator')
       if (expectToSucceed) {
-        this.waitForElementNotVisible('@newFileDialog')
-          .waitForAnimationToFinish()
+        this.waitForElementNotVisible('@newFileDialog').waitForAnimationToFinish()
       }
       return this
     },
-    selectFileForUpload: function (filePath) {
-      return this
-        .waitForElementVisible('@newFileMenuButton')
+    selectFileForUpload: function(filePath) {
+      return this.waitForElementVisible('@newFileMenuButton')
         .click('@newFileMenuButton')
         .waitForElementVisible('@fileUploadButton')
         .setValue('@fileUploadInput', filePath)
@@ -104,9 +98,8 @@ module.exports = {
      *
      * @param {string} filePath
      */
-    uploadFile: function (filePath) {
-      return this
-        .selectFileForUpload(filePath)
+    uploadFile: function(filePath) {
+      return this.selectFileForUpload(filePath)
         .waitForElementVisible(
           '@fileUploadProgress',
           this.api.globals.waitForConditionTimeout,
@@ -132,7 +125,7 @@ module.exports = {
      *
      * @param {string} [folderName] - should be passed in as format "/upload<uniqueId>file" or "upload<uniqueId>file"
      */
-    uploadSessionFolder: function (folderName = '') {
+    uploadSessionFolder: function(folderName = '') {
       /*
       files uploaded through selenium endpoints are saved in
       /tmp/<sessionId>/upload<uniqueId>file/<filename>.
@@ -152,7 +145,7 @@ module.exports = {
      *
      * @param {string} folderName
      */
-    uploadFolder: function (folderName) {
+    uploadFolder: function(folderName) {
       return this.waitForElementVisible('@newFileMenuButton')
         .click('@newFileMenuButton')
         .waitForElementVisible('@fileUploadButton')
@@ -171,17 +164,18 @@ module.exports = {
      *
      * @param {Function} callback callback with result
      */
-    canCreateFiles: function (callback) {
-      return this
-        .waitForElementVisible('@newFileMenuButtonAnyState')
-        .getAttribute('@newFileMenuButtonAnyState', 'disabled', (result) => {
+    canCreateFiles: function(callback) {
+      return this.waitForElementVisible('@newFileMenuButtonAnyState').getAttribute(
+        '@newFileMenuButtonAnyState',
+        'disabled',
+        result => {
           const isDisabled = result.value === 'true'
           callback(isDisabled)
-        })
+        }
+      )
     },
-    deleteAllCheckedFiles: function () {
-      return this
-        .waitForElementVisible('@deleteSelectedButton')
+    deleteAllCheckedFiles: function() {
+      return this.waitForElementVisible('@deleteSelectedButton')
         .click('@deleteSelectedButton')
         .waitForElementVisible('@deleteFileConfirmationBtn')
         .waitForAnimationToFinish()
@@ -194,26 +188,23 @@ module.exports = {
      * @param tab
      * @returns {string}
      */
-    getXpathOfLinkToTabInSidePanel: function (tab) {
-      return this.elements.sideBar.selector +
-        util.format(this.elements.tabOfSideBar.selector, tab)
+    getXpathOfLinkToTabInSidePanel: function(tab) {
+      return this.elements.sideBar.selector + util.format(this.elements.tabOfSideBar.selector, tab)
     },
-    selectTabInSidePanel: function (tab) {
-      return this
-        .useXpath()
+    selectTabInSidePanel: function(tab) {
+      return this.useXpath()
         .waitForElementVisible('@sideBar')
         .click(this.getXpathOfLinkToTabInSidePanel(tab))
         .useCss()
     },
-    isSidebarVisible: function (callback) {
-      return this
-        .useXpath()
-        .isVisible('@sideBar', (result) => {
+    isSidebarVisible: function(callback) {
+      return this.useXpath()
+        .isVisible('@sideBar', result => {
           callback(result.value)
         })
         .useCss()
     },
-    isPanelVisible: function (panelName, callback) {
+    isPanelVisible: function(panelName, callback) {
       let selector = ''
       if (panelName === 'collaborators') {
         selector = this.elements.collaboratorsPanel
@@ -224,46 +215,49 @@ module.exports = {
       } else {
         throw new Error('invalid panel')
       }
-      return this
-        .isVisible(selector, (result) => {
-          callback(result.value)
-        })
+      return this.isVisible(selector, result => {
+        callback(result.value)
+      })
     },
-    getVisibleTabs: async function () {
+    getVisibleTabs: async function() {
       const tabs = []
       let elements
-      await this.api.elements('@tabsInSideBar', function (result) {
+      await this.api.elements('@tabsInSideBar', function(result) {
         elements = result.value
       })
       for (const { ELEMENT } of elements) {
-        await this.api.elementIdText(ELEMENT, function (result) {
+        await this.api.elementIdText(ELEMENT, function(result) {
           tabs.push(result.value.toLowerCase())
         })
       }
       return tabs
     },
-    copyPermalinkFromFilesAppBar: function () {
-      return this
-        .waitForElementVisible('@permalinkCopyButton')
-        .click('@permalinkCopyButton')
+    copyPermalinkFromFilesAppBar: function() {
+      return this.waitForElementVisible('@permalinkCopyButton').click('@permalinkCopyButton')
     },
-    checkSidebarItem: function (resourceName) {
-      return this.getAttribute('@sidebarItemName', 'innerText', function (itemName) {
-        this.assert.strictEqual(itemName.value, resourceName, `In sidebar is different item - ${itemName.value}`)
+    checkSidebarItem: function(resourceName) {
+      return this.getAttribute('@sidebarItemName', 'innerText', function(itemName) {
+        this.assert.strictEqual(
+          itemName.value,
+          resourceName,
+          `In sidebar is different item - ${itemName.value}`
+        )
       })
     },
-    confirmFileOverwrite: function () {
-      return this.waitForElementVisible('@fileOverwriteConfirm')
-        // clicking file overwrite dialog overlay to remove file upload
-        // popup, as we upload the file directly using `setValue`. The overwrite
-        // dialog is too fast and does not give time to close the dropdown beforehand
-        .clickElementAt(this.elements.fileOverwriteDialog.selector, 0, 0)
-        .waitForElementNotVisible(this.elements.newFolderButton.selector)
-        .click(this.elements.fileOverwriteConfirm.selector)
-        .waitForElementNotVisible(this.elements.fileOverwriteConfirm.selector)
-        .waitForAjaxCallsToStartAndFinish()
+    confirmFileOverwrite: function() {
+      return (
+        this.waitForElementVisible('@fileOverwriteConfirm')
+          // clicking file overwrite dialog overlay to remove file upload
+          // popup, as we upload the file directly using `setValue`. The overwrite
+          // dialog is too fast and does not give time to close the dropdown beforehand
+          .clickElementAt(this.elements.fileOverwriteDialog.selector, 0, 0)
+          .waitForElementNotVisible(this.elements.newFolderButton.selector)
+          .click(this.elements.fileOverwriteConfirm.selector)
+          .waitForElementNotVisible(this.elements.fileOverwriteConfirm.selector)
+          .waitForAjaxCallsToStartAndFinish()
+      )
     },
-    triesToCreateExistingFile: function (fileName) {
+    triesToCreateExistingFile: function(fileName) {
       return this.waitForElementVisible('@newFileMenuButton')
         .click('@newFileMenuButton')
         .waitForElementVisible('@newFileButton')
@@ -271,7 +265,7 @@ module.exports = {
         .waitForElementVisible('@newFileInput')
         .setValue('@newFileInput', fileName)
     },
-    checkForButtonDisabled: function () {
+    checkForButtonDisabled: function() {
       return this.waitForElementVisible('@createFileOkButtonDisabled')
     }
   },
@@ -370,14 +364,16 @@ module.exports = {
      */
     tabOfSideBar: {
       // the translate bit is to make it case-insensitive
-      selector: '//a[contains(translate(.,\'ABCDEFGHJIKLMNOPQRSTUVWXYZ\',\'abcdefghjiklmnopqrstuvwxyz\'),\'%s\')]',
+      selector:
+        "//a[contains(translate(.,'ABCDEFGHJIKLMNOPQRSTUVWXYZ','abcdefghjiklmnopqrstuvwxyz'),'%s')]",
       locateStrategy: 'xpath'
     },
     sidebarItemName: {
       selector: '#files-sidebar-item-name'
     },
     createFileOkButtonDisabled: {
-      selector: "//div[@id='new-file-dialog']//button[@disabled='disabled']/span[contains(text(), 'Ok')]",
+      selector:
+        "//div[@id='new-file-dialog']//button[@disabled='disabled']/span[contains(text(), 'Ok')]",
       locateStrategy: 'xpath'
     },
     tabsInSideBar: {

--- a/tests/acceptance/pageObjects/kopanoAuthorizePage.js
+++ b/tests/acceptance/pageObjects/kopanoAuthorizePage.js
@@ -1,5 +1,5 @@
 module.exports = {
-  url: function () {
+  url: function() {
     return this.api.launchUrl
   },
   elements: {
@@ -10,23 +10,25 @@ module.exports = {
   },
   commands: [
     {
-      authorize: function () {
-        return this
-          .waitForElementVisible('@authorizeButton')
+      authorize: function() {
+        return this.waitForElementVisible('@authorizeButton')
           .click('@authorizeButton')
-          .waitForElementNotPresent({
-            selector: '@authorizeButton',
-            abortOnFailure: false
-          }, (result) => {
-            if (result.value.length > 0) {
-              // click failed
-              console.log('WARNING: looks like I\'m still on auth page. ' +
-                'I will click the auth button again')
-              this
-                .click('@authorizeButton')
-                .waitForElementNotPresent('@authorizeButton')
+          .waitForElementNotPresent(
+            {
+              selector: '@authorizeButton',
+              abortOnFailure: false
+            },
+            result => {
+              if (result.value.length > 0) {
+                // click failed
+                console.log(
+                  "WARNING: looks like I'm still on auth page. " +
+                    'I will click the auth button again'
+                )
+                this.click('@authorizeButton').waitForElementNotPresent('@authorizeButton')
+              }
             }
-          })
+          )
       }
     }
   ]

--- a/tests/acceptance/pageObjects/loginPage.js
+++ b/tests/acceptance/pageObjects/loginPage.js
@@ -1,7 +1,7 @@
 const { join } = require('../helpers/path')
 
 module.exports = {
-  url: function () {
+  url: function() {
     return join(this.api.launchUrl, '/#/login')
   },
   elements: {
@@ -12,9 +12,8 @@ module.exports = {
   },
   commands: [
     {
-      authenticate: function () {
-        return this.waitForElementVisible('@authenticateButton')
-          .click('@authenticateButton')
+      authenticate: function() {
+        return this.waitForElementVisible('@authenticateButton').click('@authenticateButton')
       }
     }
   ]

--- a/tests/acceptance/pageObjects/ocisLoginPage.js
+++ b/tests/acceptance/pageObjects/ocisLoginPage.js
@@ -1,5 +1,5 @@
 module.exports = {
-  url: function () {
+  url: function() {
     return this.api.launchUrl
   },
   elements: {
@@ -24,25 +24,25 @@ module.exports = {
        * @param {string} username
        * @param {string} password
        */
-      login: function (username, password) {
-        return this
-          .waitForElementVisible('@usernameInput')
+      login: function(username, password) {
+        return this.waitForElementVisible('@usernameInput')
           .clearValue('@usernameInput')
           .setValue('@usernameInput', username)
           .clearValue('@passwordInput')
           .setValue('@passwordInput', password)
           .click('@loginSubmitButton')
       },
-      getLoginErrorMessage: async function () {
+      getLoginErrorMessage: async function() {
         let errorMessage
         await this.api.assert.visible(this.elements.usernameInput.selector)
         await this.api.assert.visible(this.elements.passwordInput.selector)
         await this.api.assert.visible(this.elements.loginSubmitButton.selector)
-        await this
-          .waitForElementVisible('@invalidCredentialsMessage')
-          .getText('@invalidCredentialsMessage', (result) => {
+        await this.waitForElementVisible('@invalidCredentialsMessage').getText(
+          '@invalidCredentialsMessage',
+          result => {
             errorMessage = result.value
-          })
+          }
+        )
         return errorMessage
       }
     }

--- a/tests/acceptance/pageObjects/ownCloudAuthorizePage.js
+++ b/tests/acceptance/pageObjects/ownCloudAuthorizePage.js
@@ -1,5 +1,5 @@
 module.exports = {
-  url: function () {
+  url: function() {
     return this.api.launchUrl
   },
   elements: {
@@ -10,23 +10,25 @@ module.exports = {
   },
   commands: [
     {
-      authorize: function () {
-        return this
-          .waitForElementVisible('@authorizeButton')
+      authorize: function() {
+        return this.waitForElementVisible('@authorizeButton')
           .click('@authorizeButton')
-          .waitForElementNotPresent({
-            selector: '@authorizeButton',
-            abortOnFailure: false
-          }, (result) => {
-            if (result.value.length > 0) {
-              // click failed
-              console.log('WARNING: looks like I\'m still on auth page. ' +
-                'I will click the auth button again')
-              this
-                .click('@authorizeButton')
-                .waitForElementNotPresent('@authorizeButton')
+          .waitForElementNotPresent(
+            {
+              selector: '@authorizeButton',
+              abortOnFailure: false
+            },
+            result => {
+              if (result.value.length > 0) {
+                // click failed
+                console.log(
+                  "WARNING: looks like I'm still on auth page. " +
+                    'I will click the auth button again'
+                )
+                this.click('@authorizeButton').waitForElementNotPresent('@authorizeButton')
+              }
             }
-          })
+          )
       }
     }
   ]

--- a/tests/acceptance/pageObjects/ownCloudLoginPage.js
+++ b/tests/acceptance/pageObjects/ownCloudLoginPage.js
@@ -1,5 +1,5 @@
 module.exports = {
-  url: function () {
+  url: function() {
     return this.api.launchUrl
   },
   elements: {
@@ -24,25 +24,25 @@ module.exports = {
        * @param {string} username
        * @param {string} password
        */
-      login: function (username, password) {
-        return this
-          .waitForElementVisible('@usernameInput')
+      login: function(username, password) {
+        return this.waitForElementVisible('@usernameInput')
           .clearValue('@usernameInput')
           .setValue('@usernameInput', username)
           .clearValue('@passwordInput')
           .setValue('@passwordInput', password)
           .click('@loginSubmitButton')
       },
-      getLoginErrorMessage: async function () {
+      getLoginErrorMessage: async function() {
         let errorMessage
         await this.api.assert.visible(this.elements.usernameInput.selector)
         await this.api.assert.visible(this.elements.passwordInput.selector)
         await this.api.assert.visible(this.elements.loginSubmitButton.selector)
-        await this
-          .waitForElementVisible('@invalidCredentialsMessage')
-          .getText('@invalidCredentialsMessage', (result) => {
+        await this.waitForElementVisible('@invalidCredentialsMessage').getText(
+          '@invalidCredentialsMessage',
+          result => {
             errorMessage = result.value
-          })
+          }
+        )
         return errorMessage
       }
     }

--- a/tests/acceptance/pageObjects/phoenixPage.js
+++ b/tests/acceptance/pageObjects/phoenixPage.js
@@ -2,7 +2,7 @@ const util = require('util')
 const { join } = require('../helpers/path')
 
 module.exports = {
-  url: function () {
+  url: function() {
     return join(this.api.launchUrl, '/#/')
   },
   commands: {
@@ -10,19 +10,18 @@ module.exports = {
      *
      * @param {string} searchTerm
      */
-    search: function (searchTerm) {
-      return this
-        .initAjaxCounters()
-        .isVisible('#files-open-search-btn', (result) => {
+    search: function(searchTerm) {
+      return this.initAjaxCounters()
+        .isVisible('#files-open-search-btn', result => {
           if (result.value === true) {
-            this
-              .click('#files-open-search-btn')
+            this.click('#files-open-search-btn')
               .waitForElementVisible('@searchInputFieldLowResolution')
               .setValue('@searchInputFieldLowResolution', [searchTerm, this.api.Keys.ENTER])
           } else {
-            this
-              .waitForElementVisible('@searchInputFieldHighResolution')
-              .setValue('@searchInputFieldHighResolution', [searchTerm, this.api.Keys.ENTER])
+            this.waitForElementVisible('@searchInputFieldHighResolution').setValue(
+              '@searchInputFieldHighResolution',
+              [searchTerm, this.api.Keys.ENTER]
+            )
           }
         })
         .waitForElementNotVisible('@searchLoadingIndicator')
@@ -31,10 +30,9 @@ module.exports = {
     /**
      * @param {string} page
      */
-    navigateToUsingMenu: function (page) {
+    navigateToUsingMenu: function(page) {
       const menuItemSelector = util.format(this.elements.menuItem.selector, page)
-      return this
-        .waitForElementVisible('@menuButton')
+      return this.waitForElementVisible('@menuButton')
         .click('@menuButton')
         .useXpath()
         .waitForElementVisible(menuItemSelector)
@@ -44,18 +42,18 @@ module.exports = {
         .waitForElementPresent({ selector: '@filesListProgressBar', abortOnFailure: false }) // don't fail if we are too late
         .waitForElementNotPresent('@filesListProgressBar')
     },
-    markNotificationAsRead: function () {
+    markNotificationAsRead: function() {
       return this.waitForElementVisible('@notificationBell')
         .click('@notificationBell')
         .waitForElementVisible('@markNotificationAsReadLink')
         .click('@markNotificationAsReadLink')
     },
-    closeMessage: function () {
+    closeMessage: function() {
       return this.waitForElementPresent('@messageCloseIcon')
         .click('@messageCloseIcon')
         .waitForElementNotPresent('@messageCloseIcon')
     },
-    toggleNotificationDrawer: function () {
+    toggleNotificationDrawer: function() {
       return this.waitForElementVisible('@notificationBell').click('@notificationBell')
     },
     /**
@@ -63,7 +61,7 @@ module.exports = {
      *
      * @return {Promise<array>}
      */
-    getNotifications: async function () {
+    getNotifications: async function() {
       const notifications = []
       await this.toggleNotificationDrawer()
       await this.api.elements('@notificationElement', result => {
@@ -79,13 +77,15 @@ module.exports = {
     /**
      * Perform accept action on the offered shares in the notifications
      */
-    acceptAllSharesInNotification: async function () {
+    acceptAllSharesInNotification: async function() {
       const notifications = await this.getNotifications()
       await this.toggleNotificationDrawer()
       for (const element of notifications) {
-        const acceptShareButton = util.format(this.elements.acceptSharesInNotifications.selector, element)
-        await this
-          .useXpath()
+        const acceptShareButton = util.format(
+          this.elements.acceptSharesInNotifications.selector,
+          element
+        )
+        await this.useXpath()
           .waitForElementVisible(acceptShareButton)
           .click(acceptShareButton)
           .waitForAjaxCallsToStartAndFinish()
@@ -99,27 +99,25 @@ module.exports = {
      *
      * @return boolean
      */
-    isNotificationBellVisible: async function () {
+    isNotificationBellVisible: async function() {
       let isVisible = false
-      await this
-        .api.element(
-          '@notificationBell',
-          result => {
-            isVisible = result.value === 0
-          }
-        )
+      await this.api.element('@notificationBell', result => {
+        isVisible = result.value === 0
+      })
       return isVisible
     },
     /**
      * Perform decline action on the offered shares in the notifications
      */
-    declineAllSharesInNotification: async function () {
+    declineAllSharesInNotification: async function() {
       const notifications = await this.getNotifications()
       await this.toggleNotificationDrawer()
       for (const element of notifications) {
-        const declineShareButton = util.format(this.elements.declineSharesInNotifications.selector, element)
-        await this
-          .useXpath()
+        const declineShareButton = util.format(
+          this.elements.declineSharesInNotifications.selector,
+          element
+        )
+        await this.useXpath()
           .waitForElementVisible(declineShareButton)
           .click(declineShareButton)
           .waitForAjaxCallsToStartAndFinish()
@@ -131,12 +129,15 @@ module.exports = {
      *
      * @returns {boolean}
      */
-    isPageVisible: async function () {
+    isPageVisible: async function() {
       let isVisible = true
-      await this.api.elements(this.elements.phoenixContainer.locateStrategy,
-        this.elements.phoenixContainer.selector, function (result) {
+      await this.api.elements(
+        this.elements.phoenixContainer.locateStrategy,
+        this.elements.phoenixContainer.selector,
+        function(result) {
           isVisible = result.value.length > 0
-        })
+        }
+      )
       return isVisible
     },
 
@@ -145,7 +146,7 @@ module.exports = {
      *
      * @returns {Promise<void>}
      */
-    clearAllErrorMessages: async function () {
+    clearAllErrorMessages: async function() {
       let notificationElements, cancelButtons
       await this.api.element('@messages', result => {
         notificationElements = result.value.ELEMENT
@@ -153,23 +154,26 @@ module.exports = {
       if (!notificationElements) {
         return
       }
-      await this.api.elementIdElements(notificationElements,
+      await this.api.elementIdElements(
+        notificationElements,
         this.elements.clearErrorMessage.locateStrategy,
         this.elements.clearErrorMessage.selector,
         res => {
           cancelButtons = res.value
-        })
+        }
+      )
       for (const btn of cancelButtons) {
         await this.api.elementIdClick(btn.ELEMENT).waitForAnimationToFinish()
       }
     },
-    browseToUserProfile: function () {
+    browseToUserProfile: function() {
       return this.click('@userMenuButton')
     }
   },
   elements: {
     message: {
-      selector: '//*[contains(@class, "uk-notification-message")]/div/div[contains(@class, "oc-notification-message-title")]',
+      selector:
+        '//*[contains(@class, "uk-notification-message")]/div/div[contains(@class, "oc-notification-message-title")]',
       locateStrategy: 'xpath'
     },
     messages: {
@@ -228,11 +232,13 @@ module.exports = {
       locateStrategy: 'xpath'
     },
     declineSharesInNotifications: {
-      selector: '//div[@id="oc-notification"]//h5[contains(text(),\'%s\')]/../div/button/span[.="Decline"]',
+      selector:
+        '//div[@id="oc-notification"]//h5[contains(text(),\'%s\')]/../div/button/span[.="Decline"]',
       locateStrategy: 'xpath'
     },
     acceptSharesInNotifications: {
-      selector: '//div[@id="oc-notification"]//h5[contains(text(),\'%s\')]/../div/button/span[.="Accept"]',
+      selector:
+        '//div[@id="oc-notification"]//h5[contains(text(),\'%s\')]/../div/button/span[.="Accept"]',
       locateStrategy: 'xpath'
     }
   }

--- a/tests/acceptance/pageObjects/profilePage.js
+++ b/tests/acceptance/pageObjects/profilePage.js
@@ -1,9 +1,8 @@
 module.exports = {
   commands: {
-    getUserProfileName: async function () {
+    getUserProfileName: async function() {
       let userInfo
-      await this
-        .waitForElementVisible('@profileInfoContainer')
+      await this.waitForElementVisible('@profileInfoContainer')
         .waitForElementVisible('@userProfileName')
         .api.element('@userProfileName', result => {
           this.api.elementIdText(result.value.ELEMENT, text => {
@@ -12,9 +11,8 @@ module.exports = {
         })
       return userInfo
     },
-    browseToManageAccount: function () {
-      return this.waitForElementVisible('@manageAccount')
-        .click('@manageAccount')
+    browseToManageAccount: function() {
+      return this.waitForElementVisible('@manageAccount').click('@manageAccount')
     }
   },
   elements: {

--- a/tests/acceptance/pageObjects/publicLinkFilesPage.js
+++ b/tests/acceptance/pageObjects/publicLinkFilesPage.js
@@ -7,13 +7,13 @@ module.exports = {
      * like build-in navigate() but also waits till for the progressbar to appear and disappear
      * @returns {*}
      */
-    navigateAndWaitTillLoaded: function (token) {
-      return navigationHelper.navigateAndWaitTillLoaded(join(
-        this.api.launchUrl, '/#/files/public-files/', token),
-      this.page.FilesPageElement.filesList().elements.filesListProgressBar
+    navigateAndWaitTillLoaded: function(token) {
+      return navigationHelper.navigateAndWaitTillLoaded(
+        join(this.api.launchUrl, '/#/files/public-files/', token),
+        this.page.FilesPageElement.filesList().elements.filesListProgressBar
       )
     },
-    navigateAndWaitForPasswordPage: function (token) {
+    navigateAndWaitForPasswordPage: function(token) {
       this.navigate(join(this.api.launchUrl, '/#/files/public-files/', token))
       return this.page.publicLinkPasswordPage().waitForElementPresent('@passwordInput')
     },
@@ -24,9 +24,10 @@ module.exports = {
      *
      * @return {Promise<boolean>}
      */
-    waitForPage: function () {
+    waitForPage: function() {
       const menuButton = this.page.phoenixPage().elements.menuButton
-      return this.api.waitForElementPresent(this.elements.filesListContainer.selector)
+      return this.api
+        .waitForElementPresent(this.elements.filesListContainer.selector)
         .useStrategy(menuButton)
         .assert.elementNotPresent(menuButton)
         .useCss()

--- a/tests/acceptance/pageObjects/publicLinkPasswordPage.js
+++ b/tests/acceptance/pageObjects/publicLinkPasswordPage.js
@@ -1,5 +1,5 @@
 module.exports = {
-  url: function () {
+  url: function() {
     return this.api.launchUrl
   },
   elements: {
@@ -28,14 +28,12 @@ module.exports = {
        *
        * @param {string} password
        */
-      submitPublicLinkPassword: async function (password) {
-        await this
-          .waitForElementVisible('@passwordInput')
+      submitPublicLinkPassword: async function(password) {
+        await this.waitForElementVisible('@passwordInput')
           .setValue('@passwordInput', password)
           .click('@passwordSubmitButton')
 
-        return this
-          .page.FilesPageElement.filesList()
+        return this.page.FilesPageElement.filesList()
           .waitForElementPresent({ selector: '@filesListProgressBar', abortOnFailure: false }) // don't fail if we are too late
           .waitForElementNotPresent('@filesListProgressBar')
       },
@@ -43,9 +41,8 @@ module.exports = {
        * submits the public link password input form
        * this is made for those scenarios where we submit wrong password in previous steps and webUI doesn't navigate to files-page
        */
-      submitLinkPasswordForm: function () {
-        return this
-          .initAjaxCounters()
+      submitLinkPasswordForm: function() {
+        return this.initAjaxCounters()
           .waitForElementVisible('@passwordInput')
           .click('@passwordSubmitButton')
           .waitForOutstandingAjaxCalls()
@@ -55,16 +52,14 @@ module.exports = {
        *
        * @return {Promise<string>}
        */
-      getResourceAccessDeniedMsg: async function () {
+      getResourceAccessDeniedMsg: async function() {
         let message
-        await this
-          .waitForElementVisible('@passwordSubmitButton')
-          .getText(
-            '@resourceProtectedText',
-            (result) => {
-              message = result.value
-            }
-          )
+        await this.waitForElementVisible('@passwordSubmitButton').getText(
+          '@resourceProtectedText',
+          result => {
+            message = result.value
+          }
+        )
         return message
       }
     }

--- a/tests/acceptance/pageObjects/sharedWithMePage.js
+++ b/tests/acceptance/pageObjects/sharedWithMePage.js
@@ -3,7 +3,7 @@ const util = require('util')
 const { join } = require('../helpers/path')
 
 module.exports = {
-  url: function () {
+  url: function() {
     return join(this.api.launchUrl, '/#/files/shared-with-me/')
   },
   commands: {
@@ -11,9 +11,10 @@ module.exports = {
      * like build-in navigate() but also waits till for the progressbar to appear and disappear
      * @returns {*}
      */
-    navigateAndWaitTillLoaded: function () {
+    navigateAndWaitTillLoaded: function() {
       return navigationHelper.navigateAndWaitTillLoaded(
-        this.url(), this.page.FilesPageElement.filesList().elements.filesListProgressBar
+        this.url(),
+        this.page.FilesPageElement.filesList().elements.filesListProgressBar
       )
     },
     /**
@@ -24,23 +25,25 @@ module.exports = {
      *
      * @return {Promise<string>}
      */
-    getShareStatusOfResource: async function (filename, sharer) {
+    getShareStatusOfResource: async function(filename, sharer) {
       let status
-      const requiredXpath = this.api.page.FilesPageElement.filesList().getFileRowSelectorByFileName(filename) +
+      const requiredXpath =
+        this.api.page.FilesPageElement.filesList().getFileRowSelectorByFileName(filename) +
         util.format(this.elements.getSharedFromUserName.selector, sharer) +
         this.elements.shareStatusOnFileRow.selector
-      await this
-        .useXpath()
+      await this.useXpath()
         .waitForAnimationToFinish()
-        .api.getText(requiredXpath,
-          (result) => {
-            if (result.status === 0) {
-              status = result.value === '' ? 'Accepted' : result.value
-            } else {
-              throw new Error(`Expected: share status of the resource but found unexpected response: ${result.value.error}`)
-            }
+        .api.getText(requiredXpath, result => {
+          if (result.status === 0) {
+            status = result.value === '' ? 'Accepted' : result.value
+          } else {
+            throw new Error(
+              `Expected: share status of the resource but found unexpected response: ${
+                result.value.error
+              }`
+            )
           }
-        )
+        })
         .useCss()
       return status
     },
@@ -51,15 +54,15 @@ module.exports = {
      *Performs required action, such as accept and decline, on the file row element of the desired file name
      *  shared by specific user
      */
-    declineAcceptFile: function (action, filename, user) {
+    declineAcceptFile: function(action, filename, user) {
       const actionLocatorButton = {
         locateStrategy: this.elements.shareStatusActionOnFileRow.locateStrategy,
-        selector: this.api.page.FilesPageElement.filesList().getFileRowSelectorByFileName(filename) +
-                  util.format(this.elements.getSharedFromUserName.selector, user) +
-                  util.format(this.elements.shareStatusActionOnFileRow.selector, action)
+        selector:
+          this.api.page.FilesPageElement.filesList().getFileRowSelectorByFileName(filename) +
+          util.format(this.elements.getSharedFromUserName.selector, user) +
+          util.format(this.elements.shareStatusActionOnFileRow.selector, action)
       }
-      return this
-        .initAjaxCounters()
+      return this.initAjaxCounters()
         .waitForElementVisible(actionLocatorButton)
         .click(actionLocatorButton)
         .waitForOutstandingAjaxCalls()
@@ -71,28 +74,25 @@ module.exports = {
      *
      * @return {Promise<string>}
      */
-    getSharedByUser: async function (element) {
+    getSharedByUser: async function(element) {
       let username
-      const requiredXpath = this.api.page.FilesPageElement.filesList().getFileRowSelectorByFileName(element) +
-          this.elements.sharedFrom.selector
+      const requiredXpath =
+        this.api.page.FilesPageElement.filesList().getFileRowSelectorByFileName(element) +
+        this.elements.sharedFrom.selector
       await this.waitForElementVisible({
         locateStrategy: this.elements.sharedFrom.locateStrategy,
         selector: requiredXpath
+      }).api.getText(this.elements.sharedFrom.locateStrategy, requiredXpath, result => {
+        username = result.value
       })
-        .api.getText(
-          this.elements.sharedFrom.locateStrategy,
-          requiredXpath,
-          (result) => {
-            username = result.value
-          }
-        )
       return username
     },
-    isSharePresent: async function (element, sharer) {
-      const requiredXpath = this.api.page.FilesPageElement.filesList().getFileRowSelectorByFileName(element) +
-                          util.format(this.elements.getSharedFromUserName.selector, sharer)
+    isSharePresent: async function(element, sharer) {
+      const requiredXpath =
+        this.api.page.FilesPageElement.filesList().getFileRowSelectorByFileName(element) +
+        util.format(this.elements.getSharedFromUserName.selector, sharer)
       let shareFound = false
-      await this.api.elements('xpath', requiredXpath, function (result) {
+      await this.api.elements('xpath', requiredXpath, function(result) {
         shareFound = result.value.length > 0
       })
       return shareFound
@@ -112,7 +112,8 @@ module.exports = {
       locateStrategy: 'xpath'
     },
     shareStatusActionOnFileRow: {
-      selector: '/../..//*[contains(@class,"file-row-share-status-action")][normalize-space(.)="%s"]',
+      selector:
+        '/../..//*[contains(@class,"file-row-share-status-action")][normalize-space(.)="%s"]',
       locateStrategy: 'xpath'
     }
   }

--- a/tests/acceptance/pageObjects/sharedWithOthersPage.js
+++ b/tests/acceptance/pageObjects/sharedWithOthersPage.js
@@ -2,7 +2,7 @@ const navigationHelper = require('../helpers/navigationHelper')
 const { join } = require('../helpers/path')
 
 module.exports = {
-  url: function () {
+  url: function() {
     return join(this.api.launchUrl, '/#/files/shared-with-others/')
   },
   commands: {
@@ -10,9 +10,10 @@ module.exports = {
      * like build-in navigate() but also waits till for the progressbar to appear and disappear
      * @returns {*}
      */
-    navigateAndWaitTillLoaded: function () {
+    navigateAndWaitTillLoaded: function() {
       return navigationHelper.navigateAndWaitTillLoaded(
-        this.url(), this.page.FilesPageElement.filesList().elements.filesListProgressBar
+        this.url(),
+        this.page.FilesPageElement.filesList().elements.filesListProgressBar
       )
     }
   }

--- a/tests/acceptance/pageObjects/trashbinPage.js
+++ b/tests/acceptance/pageObjects/trashbinPage.js
@@ -2,7 +2,7 @@ const navigationHelper = require('../helpers/navigationHelper')
 const { join } = require('../helpers/path')
 
 module.exports = {
-  url: function () {
+  url: function() {
     return join(this.api.launchUrl, '/#/files/trash-bin/')
   },
   commands: {
@@ -10,14 +10,14 @@ module.exports = {
      * like build-in navigate() but also waits till for the progressbar to appear and disappear
      * @returns {*}
      */
-    navigateAndWaitTillLoaded: function () {
+    navigateAndWaitTillLoaded: function() {
       return navigationHelper.navigateAndWaitTillLoaded(
-        this.url(), this.page.FilesPageElement.filesList().elements.filesListProgressBar
+        this.url(),
+        this.page.FilesPageElement.filesList().elements.filesListProgressBar
       )
     },
-    clearTrashbin: function () {
-      return this
-        .waitForElementVisible('@clearTrashbin')
+    clearTrashbin: function() {
+      return this.waitForElementVisible('@clearTrashbin')
         .initAjaxCounters()
         .click('@clearTrashbin')
         .waitForOutstandingAjaxCalls()

--- a/tests/acceptance/setup.js
+++ b/tests/acceptance/setup.js
@@ -25,25 +25,25 @@ defineParameterType({
   transformer: s => codify.replaceInlineCode(s)
 })
 
-Before(function startDriverOnLocal () {
+Before(function startDriverOnLocal() {
   return RUNNING_ON_CI || startWebDriver({ env })
 })
 
-Before(function createSessionForEnv () {
+Before(function createSessionForEnv() {
   return createSession({ env })
 })
 
-Before(function logSessionInfoOnSauceLabs () {
+Before(function logSessionInfoOnSauceLabs() {
   if (process.env.SAUCE_USERNAME) {
     return client
-      .session(function (session) {
+      .session(function(session) {
         console.log('  Link to saucelabs job: https://app.saucelabs.com/tests/' + session.sessionId)
       })
       .timeoutsAsyncScript(SAUCELABS_ASYNC_SCRIPT_TIMEOUT)
   }
 })
 
-Before(function createLdapClient () {
+Before(function createLdapClient() {
   if (client.globals.ocis) {
     return ldap.createClient().then(ldapClient => {
       client.globals.ldapClient = ldapClient
@@ -51,31 +51,28 @@ Before(function createLdapClient () {
   }
 })
 
-After(function deleteLdapClient () {
+After(function deleteLdapClient() {
   if (client.globals.ocis && client.globals.ldapClient) {
     return ldap.terminate(client.globals.ldapClient)
   }
 })
 
-async function cacheAndSetConfigs (server) {
+async function cacheAndSetConfigs(server) {
   if (client.globals.ocis) {
     return
   }
   await cacheConfigs(server)
-  return setConfigs(
-    server,
-    client.globals.backend_admin_username
-  )
+  return setConfigs(server, client.globals.backend_admin_username)
 }
 
-Before(function cacheAndSetConfigsOnLocal () {
+Before(function cacheAndSetConfigsOnLocal() {
   if (client.globals.ocis) {
     return
   }
   return cacheAndSetConfigs(client.globals.backend_url)
 })
 
-Before(function cacheAndSetConfigsOnRemoteIfExists () {
+Before(function cacheAndSetConfigsOnRemoteIfExists() {
   if (client.globals.ocis) {
     return
   }
@@ -86,7 +83,7 @@ Before(function cacheAndSetConfigsOnRemoteIfExists () {
 
 // After hooks are run in reverse order in which they are defined
 // https://github.com/cucumber/cucumber-js/blob/master/docs/support_files/hooks.md#hooks
-After(function rollbackConfigsOnRemoteIfExists () {
+After(function rollbackConfigsOnRemoteIfExists() {
   if (client.globals.ocis) {
     return
   }
@@ -95,22 +92,22 @@ After(function rollbackConfigsOnRemoteIfExists () {
   }
 })
 
-After(function rollbackConfigsOnLocal () {
+After(function rollbackConfigsOnLocal() {
   if (client.globals.ocis) {
     return
   }
   return rollbackConfigs(client.globals.backend_url)
 })
 
-After(function stopDriverIfOnLocal () {
+After(function stopDriverIfOnLocal() {
   return RUNNING_ON_CI || stopWebDriver()
 })
 
-After(function closeSessionForEnv () {
+After(function closeSessionForEnv() {
   return closeSession()
 })
 
-After(async function tryToReadBrowserConsoleOnFailure ({ result }) {
+After(async function tryToReadBrowserConsoleOnFailure({ result }) {
   if (client.globals.ocis) {
     return
   }

--- a/tests/acceptance/stepDefinitions/accountContext.js
+++ b/tests/acceptance/stepDefinitions/accountContext.js
@@ -3,13 +3,13 @@ const { When, Then } = require('cucumber')
 const assert = require('assert')
 const _ = require('lodash')
 
-When('the user browses to the account page', function () {
-  return client
-    .page.accountPage()
-    .navigateAndWaitTillLoaded()
+When('the user browses to the account page', function() {
+  return client.page.accountPage().navigateAndWaitTillLoaded()
 })
 
-Then('the user should have following details displayed on the account information', async function (dataTable) {
+Then('the user should have following details displayed on the account information', async function(
+  dataTable
+) {
   const expectedAccInfo = dataTable.rowsHash()
   const actualAccInfo = await client.page.accountPage().getAccountInformation()
   const actualEntries = Object.entries(actualAccInfo)
@@ -18,14 +18,20 @@ Then('the user should have following details displayed on the account informatio
       const actualGroupMembership = value.split(',').map(grp => grp.trim())
       const expectedGroupMembership = expectedAccInfo[key].split(',').map(grp => grp.trim())
       const differenceInGroups = _.difference(actualGroupMembership, expectedGroupMembership)
-      assert.strictEqual(differenceInGroups.length, 0, 'Actual group membership for the user was ' +
-      actualGroupMembership + ' but was expected to be ' + expectedGroupMembership)
+      assert.strictEqual(
+        differenceInGroups.length,
+        0,
+        'Actual group membership for the user was ' +
+          actualGroupMembership +
+          ' but was expected to be ' +
+          expectedGroupMembership
+      )
     } else {
       assert.strictEqual(value, expectedAccInfo[key])
     }
   }
 })
 
-When('the user logs out using the webUI', function () {
+When('the user logs out using the webUI', function() {
   return client.page.accountPage().logout()
 })

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -16,171 +16,148 @@ Before(() => {
   deletedElements = []
 })
 
-When('the user browses to the files page',
-  () => {
-    return client
-      .page.filesPage()
-      .navigateAndWaitTillLoaded()
-  })
-
-When('the user browses to the favorites page', function () {
-  return client
-    .page.favoritesPage()
-    .navigateAndWaitTillLoaded()
+When('the user browses to the files page', () => {
+  return client.page.filesPage().navigateAndWaitTillLoaded()
 })
 
-Given('the user has browsed to the favorites page', function () {
-  return client
-    .page.favoritesPage()
-    .navigateAndWaitTillLoaded()
+When('the user browses to the favorites page', function() {
+  return client.page.favoritesPage().navigateAndWaitTillLoaded()
 })
 
-When('the user browses to the shared-with-me page', function () {
-  return client
-    .page.sharedWithMePage()
-    .navigateAndWaitTillLoaded()
+Given('the user has browsed to the favorites page', function() {
+  return client.page.favoritesPage().navigateAndWaitTillLoaded()
 })
 
-Given('the user has browsed to the shared-with-me page', function () {
-  return client
-    .page.sharedWithMePage()
-    .navigateAndWaitTillLoaded()
+When('the user browses to the shared-with-me page', function() {
+  return client.page.sharedWithMePage().navigateAndWaitTillLoaded()
 })
 
-Given('the user has browsed to the shared-with-others page', function () {
-  return client
-    .page.sharedWithOthersPage()
-    .navigateAndWaitTillLoaded()
+Given('the user has browsed to the shared-with-me page', function() {
+  return client.page.sharedWithMePage().navigateAndWaitTillLoaded()
 })
 
-When('the user browses to the shared-with-me page using the webUI', function () {
-  return client
-    .page.phoenixPage()
-    .navigateToUsingMenu('Shared with me')
+Given('the user has browsed to the shared-with-others page', function() {
+  return client.page.sharedWithOthersPage().navigateAndWaitTillLoaded()
 })
 
-When('the user browses to the shared-with-others page', function () {
-  return client
-    .page.sharedWithOthersPage()
-    .navigateAndWaitTillLoaded()
+When('the user browses to the shared-with-me page using the webUI', function() {
+  return client.page.phoenixPage().navigateToUsingMenu('Shared with me')
 })
 
-When('the user browses to the shared-with-others page using the webUI', function () {
-  return client
-    .page.phoenixPage()
-    .navigateToUsingMenu('Shared with others')
+When('the user browses to the shared-with-others page', function() {
+  return client.page.sharedWithOthersPage().navigateAndWaitTillLoaded()
 })
 
-Given('the user has browsed to the trashbin page', function () {
-  return client
-    .page.trashbinPage()
-    .navigateAndWaitTillLoaded()
+When('the user browses to the shared-with-others page using the webUI', function() {
+  return client.page.phoenixPage().navigateToUsingMenu('Shared with others')
 })
 
-When('the user browses to the trashbin page', function () {
-  return client
-    .page.trashbinPage()
-    .navigateAndWaitTillLoaded()
+Given('the user has browsed to the trashbin page', function() {
+  return client.page.trashbinPage().navigateAndWaitTillLoaded()
 })
 
-Given('the user has browsed to the favorites page using the webUI', function () {
-  return client
-    .page.phoenixPage()
-    .navigateToUsingMenu('Favorites')
+When('the user browses to the trashbin page', function() {
+  return client.page.trashbinPage().navigateAndWaitTillLoaded()
 })
 
-When('the user browses to the favorites page using the webUI', function () {
-  return client
-    .page.phoenixPage()
-    .navigateToUsingMenu('Favorites')
+Given('the user has browsed to the favorites page using the webUI', function() {
+  return client.page.phoenixPage().navigateToUsingMenu('Favorites')
 })
 
-When('the user browses to the files page using the webUI', function () {
-  return client
-    .page.phoenixPage()
-    .navigateToUsingMenu('All files')
+When('the user browses to the favorites page using the webUI', function() {
+  return client.page.phoenixPage().navigateToUsingMenu('Favorites')
 })
 
-Then('the files table should be displayed',
-  () => {
-    return client.page.FilesPageElement.filesList()
-      .waitForElementVisible('@filesTable')
-  })
+When('the user browses to the files page using the webUI', function() {
+  return client.page.phoenixPage().navigateToUsingMenu('All files')
+})
 
-Given('the user has browsed to the files page', async function () {
-  await client
-    .page.filesPage()
-    .navigateAndWaitTillLoaded()
+Then('the files table should be displayed', () => {
+  return client.page.FilesPageElement.filesList().waitForElementVisible('@filesTable')
+})
+
+Given('the user has browsed to the files page', async function() {
+  await client.page.filesPage().navigateAndWaitTillLoaded()
   await client.page.FilesPageElement.filesList().waitForAllThumbnailsLoaded()
 })
 
-When('the user opens folder {string} directly on the webUI', async function (folder) {
+When('the user opens folder {string} directly on the webUI', async function(folder) {
   folder = encodeURIComponent(path.normalize(folder))
   await client.page.filesPage().navigateAndWaitTillLoaded(folder)
   await client.page.FilesPageElement.filesList().waitForAllThumbnailsLoaded()
 })
 
-Given('user {string} has uploaded file with content {string} to {string}', async function (user, content, filename) {
+Given('user {string} has uploaded file with content {string} to {string}', async function(
+  user,
+  content,
+  filename
+) {
   await waitBetweenFileUploadOperations()
   await webdav.uploadFileWithContent(user, content, filename)
 })
 
-When('the user browses to display the {string} details of file {string}', async function (versions, filename) {
+When('the user browses to display the {string} details of file {string}', async function(
+  versions,
+  filename
+) {
   const api = client.page.FilesPageElement
-  await api
-    .filesList()
-    .clickRow(filename)
-  api.appSideBar()
-    .openVersionsTab()
+  await api.filesList().clickRow(filename)
+  api.appSideBar().openVersionsTab()
   return client
 })
 
-Given('user {string} has moved file/folder {string} to {string}', function (user, fromName, toName) {
+Given('user {string} has moved file/folder {string} to {string}', function(user, fromName, toName) {
   return move(user, fromName, toName)
 })
 
-When('the user creates a folder with the name {string} using the webUI', function (folderName) {
+When('the user creates a folder with the name {string} using the webUI', function(folderName) {
   return client.page.filesPage().createFolder(folderName)
 })
 
-When('the user creates a file with the name {string} using the webUI', function (fileName) {
+When('the user creates a file with the name {string} using the webUI', function(fileName) {
   return client.page.filesPage().createFile(fileName)
 })
 
-When('the user creates a folder with default name using the webUI', function () {
+When('the user creates a folder with default name using the webUI', function() {
   return client.page.filesPage().createFolder(null, false)
 })
 
-When('the user creates a folder without name using the webUI', function () {
+When('the user creates a folder without name using the webUI', function() {
   return client.page.filesPage().createFolder('', false)
 })
 
-When('the user creates a folder with the invalid name {string} using the webUI', function (folderName) {
+When('the user creates a folder with the invalid name {string} using the webUI', function(
+  folderName
+) {
   return client.page.filesPage().createFolder(folderName, false)
 })
 
-Given('the user has opened folder {string}', (folder) => client.page.FilesPageElement.filesList().navigateToFolder(folder))
-When('the user opens folder {string} using the webUI', (folder) => client.page.FilesPageElement.filesList().navigateToFolder(folder))
+Given('the user has opened folder {string}', folder =>
+  client.page.FilesPageElement.filesList().navigateToFolder(folder)
+)
+When('the user opens folder {string} using the webUI', folder =>
+  client.page.FilesPageElement.filesList().navigateToFolder(folder)
+)
 
-Given('the user has opened the share dialog for file/folder {string}', function (fileName) {
-  return client.page.FilesPageElement
-    .appSideBar()
+Given('the user has opened the share dialog for file/folder {string}', function(fileName) {
+  return client.page.FilesPageElement.appSideBar()
     .closeSidebar(100)
     .openSharingDialog(fileName)
 })
 
-When('the user browses to folder {string} using the breadcrumb on the webUI', (resource) =>
-  client.page.filesPage().navigateToBreadcrumb(resource))
+When('the user browses to folder {string} using the breadcrumb on the webUI', resource =>
+  client.page.filesPage().navigateToBreadcrumb(resource)
+)
 
-When('the user deletes file/folder {string} using the webUI', function (element) {
+When('the user deletes file/folder {string} using the webUI', function(element) {
   return client.page.FilesPageElement.filesList().deleteFile(element)
 })
 
-Given('the user has deleted file/folder/resource {string} using the webUI', function (element) {
+Given('the user has deleted file/folder/resource {string} using the webUI', function(element) {
   return client.page.FilesPageElement.filesList().deleteFile(element)
 })
 
-When('the user deletes the following elements using the webUI', async function (table) {
+When('the user deletes the following elements using the webUI', async function(table) {
   for (const line of table.rows()) {
     await client.page.FilesPageElement.filesList().deleteFile(line[0])
     deletedElements.push(line[0])
@@ -188,11 +165,11 @@ When('the user deletes the following elements using the webUI', async function (
   return client.page.filesPage()
 })
 
-Then('there should be no breadcrumb displayed on the webUI', function () {
+Then('there should be no breadcrumb displayed on the webUI', function() {
   return assertBreadCrumbIsNotDisplayed()
 })
 
-Then('breadcrumb for folder {string} should be displayed on the webUI', function (resource) {
+Then('breadcrumb for folder {string} should be displayed on the webUI', function(resource) {
   return assertBreadcrumbIsDisplayedFor(resource)
 })
 
@@ -200,7 +177,7 @@ Then('breadcrumb for folder {string} should be displayed on the webUI', function
  * makes sure delete operations are carried out maximum once a second to avoid trashbin issues
  * see https://github.com/owncloud/core/issues/23151
  */
-const waitBetweenDeleteOperations = async function () {
+const waitBetweenDeleteOperations = async function() {
   const timeSinceLastDelete = Date.now() - timeOfLastDeleteOperation
   if (timeSinceLastDelete <= 1000) {
     await client.pause(1000 - timeSinceLastDelete + 1)
@@ -212,7 +189,7 @@ const waitBetweenDeleteOperations = async function () {
  * makes sure upload operations are carried out maximum once a second to avoid version issues
  * see https://github.com/owncloud/core/issues/23151
  */
-const waitBetweenFileUploadOperations = async function () {
+const waitBetweenFileUploadOperations = async function() {
   const timeSinceLastFileUpload = Date.now() - timeOfLastUploadOperation
   if (timeSinceLastFileUpload <= 1001) {
     await client.pause(1001 - timeSinceLastFileUpload)
@@ -220,7 +197,10 @@ const waitBetweenFileUploadOperations = async function () {
   timeOfLastUploadOperation = Date.now()
 }
 
-Given('the following files/folders/resources have been deleted by user {string}', async function (user, table) {
+Given('the following files/folders/resources have been deleted by user {string}', async function(
+  user,
+  table
+) {
   const filesToDelete = table.hashes()
   for (const entry of filesToDelete) {
     await waitBetweenDeleteOperations()
@@ -229,28 +209,29 @@ Given('the following files/folders/resources have been deleted by user {string}'
   return client
 })
 
-When('the user uploads file {string} using the webUI', function (element) {
+When('the user uploads file {string} using the webUI', function(element) {
   const uploadPath = path.join(client.globals.mountedUploadDir, element)
   return client.page.filesPage().uploadFile(uploadPath)
 })
 
-When('the user uploads a created file {string} using the webUI', function (element) {
+When('the user uploads a created file {string} using the webUI', function(element) {
   const filePath = path.join(client.globals.filesForUpload, element)
-  return client.uploadRemote(filePath, function (uploadPath) {
+  return client.uploadRemote(filePath, function(uploadPath) {
     client.page.filesPage().uploadFile(uploadPath)
   })
 })
 
-When('the public uploads file {string} in files-drop page', function (element) {
+When('the public uploads file {string} in files-drop page', function(element) {
   const rootUploadDir = client.globals.mountedUploadDir
   const filePath = path.join(rootUploadDir, element)
-  return client.page.filesDropPage()
+  return client.page
+    .filesDropPage()
     .initAjaxCounters()
     .uploadFile(filePath)
     .waitForOutstandingAjaxCalls()
 })
 
-Then('the following files should be listed on the files-drop page:', async function (filesToCheck) {
+Then('the following files should be listed on the files-drop page:', async function(filesToCheck) {
   filesToCheck = filesToCheck.raw().map(([file]) => file)
 
   const actualFiles = await client.page.filesDropPage().getUploadedFiles()
@@ -262,203 +243,196 @@ Then('the following files should be listed on the files-drop page:', async funct
   )
 })
 
-When('the user unshares file/folder {string} using the webUI', function (element) {
+When('the user unshares file/folder {string} using the webUI', function(element) {
   return client.page.FilesPageElement.filesList().deleteFile(element)
 })
 
-When('the user uploads folder {string} using the webUI', function (element) {
+When('the user uploads folder {string} using the webUI', function(element) {
   const rootUploadDir = client.globals.mountedUploadDir
   const name = path.join(rootUploadDir, element)
   return client.page.filesPage().uploadFolder(name)
 })
 
-When('the user uploads a folder containing the following files in separate sub-folders using the webUI:', async function (files) {
-  files = files.raw().map(item => item[0])
+When(
+  'the user uploads a folder containing the following files in separate sub-folders using the webUI:',
+  async function(files) {
+    files = files.raw().map(item => item[0])
 
-  if ((new Set(files)).size !== files.length) {
-    throw new Error(
-      `Allowing upload of multiple files in the same folder would complicate
+    if (new Set(files).size !== files.length) {
+      throw new Error(
+        `Allowing upload of multiple files in the same folder would complicate
       other step-definitions. Please remove duplicated files and retry.`
-    )
-  }
+      )
+    }
 
-  if (files.length === 1) {
-    throw new Error('Please try uploading more than one file. Uploading only one file is not supported.')
-  }
+    if (files.length === 1) {
+      throw new Error(
+        'Please try uploading more than one file. Uploading only one file is not supported.'
+      )
+    }
 
-  for (const file of files) {
-    const filePath = path.join(client.globals.filesForUpload, file)
-    await client.uploadRemote(filePath)
+    for (const file of files) {
+      const filePath = path.join(client.globals.filesForUpload, file)
+      await client.uploadRemote(filePath)
+    }
+    return client.page.filesPage().uploadSessionFolder()
   }
-  return client.page.filesPage().uploadSessionFolder()
-})
+)
 
-Then('it should not be possible to create files using the webUI', function () {
-  return client.page.filesPage().canCreateFiles((isDisabled) => {
+Then('it should not be possible to create files using the webUI', function() {
+  return client.page.filesPage().canCreateFiles(isDisabled => {
     client.assert.strictEqual(isDisabled, true, 'Create action must not be enabled')
   })
 })
 
-When('the user renames file/folder {string} to {string} using the webUI', function (fromName, toName) {
+When('the user renames file/folder {string} to {string} using the webUI', function(
+  fromName,
+  toName
+) {
   return client.page.FilesPageElement.filesList().renameFile(fromName, toName)
 })
 
-When('the user renames file/folder {string} to an invalid name {string} using the webUI', function (fromName, toName) {
+When('the user renames file/folder {string} to an invalid name {string} using the webUI', function(
+  fromName,
+  toName
+) {
   return client.page.FilesPageElement.filesList().renameFile(fromName, toName, false)
 })
 
-When('the user renames the following file/folder using the webUI', async function (dataTable) {
+When('the user renames the following file/folder using the webUI', async function(dataTable) {
   for (const { fromName, toName } of dataTable.hashes()) {
-    await client
-      .page.FilesPageElement.filesList().renameFile(
-        fromName,
-        toName
-      )
+    await client.page.FilesPageElement.filesList().renameFile(fromName, toName)
   }
   return client
 })
 
-Given('the user has marked file/folder {string} as favorite using the webUI', function (path) {
+Given('the user has marked file/folder {string} as favorite using the webUI', function(path) {
   return client.page.FilesPageElement.filesRow().markAsFavorite(path)
 })
 
-When('the user marks file/folder {string} as favorite using the webUI', function (path) {
+When('the user marks file/folder {string} as favorite using the webUI', function(path) {
   return client.page.FilesPageElement.filesRow().markAsFavorite(path)
 })
 
-When('the user unmarks the favorited file/folder {string} using the webUI', function (path) {
+When('the user unmarks the favorited file/folder {string} using the webUI', function(path) {
   return client.page.FilesPageElement.filesRow().unmarkFavorite(path)
 })
 
-Then('there should be no files/folders/resources listed on the webUI', async function () {
+Then('there should be no files/folders/resources listed on the webUI', async function() {
   let currentUrl = null
-  await client.url((result) => {
+  await client.url(result => {
     currentUrl = result.value
   })
 
   // only check empty message in regular file lists, not files drop page
   if (currentUrl.indexOf('/files-drop/') === -1) {
-    const noContentMessageVisible = await client
-      .page
-      .FilesPageElement.filesList()
-      .isNoContentMessageVisible()
+    const noContentMessageVisible = await client.page.FilesPageElement.filesList().isNoContentMessageVisible()
     assert.ok(noContentMessageVisible, 'Empty message must be visible')
   }
 
   const allRowsResult = await client.page.FilesPageElement.filesList().allFileRows()
 
-  assert.ok(allRowsResult.value.length === 0, `No resources are listed, ${allRowsResult.length} found`)
+  assert.ok(
+    allRowsResult.value.length === 0,
+    `No resources are listed, ${allRowsResult.length} found`
+  )
 })
 
-Then('file {string} should be listed on the webUI', function (folder) {
-  return client
-    .page
-    .FilesPageElement.filesList()
-    .waitForFileVisible(folder, 'file')
+Then('file {string} should be listed on the webUI', function(folder) {
+  return client.page.FilesPageElement.filesList().waitForFileVisible(folder, 'file')
 })
 
-Then('folder {string} should be listed on the webUI', (folder) => {
-  return client
-    .page
-    .FilesPageElement.filesList()
-    .waitForFileVisible(folder, 'folder')
+Then('folder {string} should be listed on the webUI', folder => {
+  return client.page.FilesPageElement.filesList().waitForFileVisible(folder, 'folder')
 })
 
-Then('file/folder with path {string} should be listed in the favorites page on the webUI', function (path) {
-  return client
-    .page
-    .FilesPageElement.filesList()
-    .waitForFileWithPathVisible(path)
+Then('file/folder with path {string} should be listed in the favorites page on the webUI', function(
+  path
+) {
+  return client.page.FilesPageElement.filesList().waitForFileWithPathVisible(path)
 })
 
-Then('the last uploaded folder should be listed on the webUI', async function () {
+Then('the last uploaded folder should be listed on the webUI', async function() {
   const folder = client.sessionId
-  await client
-    .page
-    .FilesPageElement.filesList()
-    .waitForFileVisible(folder)
+  await client.page.FilesPageElement.filesList().waitForFileVisible(folder)
 
   return client
 })
 
-Then('file {string} should not be listed on the webUI', async function (folder) {
+Then('file {string} should not be listed on the webUI', async function(folder) {
   const state = await client.page.FilesPageElement.filesList().isElementListed(folder, 'file')
-  return client.assert.ok(
-    !state, `Error: Resource ${folder} is listed on the filesList`
-  )
+  return client.assert.ok(!state, `Error: Resource ${folder} is listed on the filesList`)
 })
 
-Then('folder {string} should not be listed on the webUI', async (folder) => {
+Then('folder {string} should not be listed on the webUI', async folder => {
   const state = await client.page.FilesPageElement.filesList().isElementListed(folder, 'folder')
-  return client.assert.ok(
-    !state, `Error: Resource ${folder} is listed on the filesList`
-  )
+  return client.assert.ok(!state, `Error: Resource ${folder} is listed on the filesList`)
 })
 
-Then('the deleted elements should not be listed on the webUI', function () {
+Then('the deleted elements should not be listed on the webUI', function() {
   return assertDeletedElementsAreNotListed()
 })
 
-Then('the deleted elements should not be listed on the webUI after a page reload', function () {
+Then('the deleted elements should not be listed on the webUI after a page reload', function() {
   client.refresh()
   return assertDeletedElementsAreNotListed()
 })
 
-Then('the versions list should contain {int} entries', async function (expectedNumber) {
+Then('the versions list should contain {int} entries', async function(expectedNumber) {
   const count = await client.page.FilesPageElement.versionsDialog().getVersionsCount()
-  return assert.strictEqual(
-    expectedNumber, count
-  )
+  return assert.strictEqual(expectedNumber, count)
 })
 
-Then('the versions list for resource {string} should contain {int} entry/entries', async function (resourceName, expectedNumber) {
+Then('the versions list for resource {string} should contain {int} entry/entries', async function(
+  resourceName,
+  expectedNumber
+) {
   const api = client.page.FilesPageElement
-  await api
-    .filesList()
-    .clickRow(resourceName)
-  api.appSideBar()
-    .openVersionsTab()
+  await api.filesList().clickRow(resourceName)
+  api.appSideBar().openVersionsTab()
   const count = await api.versionsDialog().getVersionsCount()
 
-  assert.strictEqual(
-    expectedNumber, count
-  )
+  assert.strictEqual(expectedNumber, count)
 
   client.page.FilesPageElement.appSideBar().closeSidebar(100)
 
   return this
 })
 
-Then('the content of file {string} for user {string} should be {string}', async function (file, user, content) {
+Then('the content of file {string} for user {string} should be {string}', async function(
+  file,
+  user,
+  content
+) {
   const remote = await download(user, file)
   return client.assert.strictEqual(
-    remote, content,
+    remote,
+    content,
     `Failed asserting remote file ${file} is same as content ${content} for user${user}`
   )
 })
 
-When('the user restores the file to last version using the webUI', function () {
+When('the user restores the file to last version using the webUI', function() {
   return client.page.FilesPageElement.versionsDialog().restoreToPreviousVersion()
-}
-)
+})
 
-When('the user reloads the current page of the webUI', function () {
+When('the user reloads the current page of the webUI', function() {
   return client.refresh()
 })
 
-Given('the user has reloaded the current page of the webUI', function () {
+Given('the user has reloaded the current page of the webUI', function() {
   return client.refresh()
 })
 
-When('the user marks all files for batch action using the webUI', function () {
+When('the user marks all files for batch action using the webUI', function() {
   return client.page.FilesPageElement.filesList().checkAllFiles()
 })
 
-When('the user batch deletes the marked files using the webUI', function () {
+When('the user batch deletes the marked files using the webUI', function() {
   return client.page.filesPage().deleteAllCheckedFiles()
 })
 
-When('the user batch deletes these files using the webUI', async function (fileOrFolders) {
+When('the user batch deletes these files using the webUI', async function(fileOrFolders) {
   for (const item of fileOrFolders.rows()) {
     await client.page.FilesPageElement.filesList().toggleFileOrFolderCheckbox('enable', item[0])
     deletedElements.push(item[0])
@@ -467,45 +441,47 @@ When('the user batch deletes these files using the webUI', async function (fileO
   return client.page.filesPage().deleteAllCheckedFiles()
 })
 
-When('the user unmarks these files for batch action using the webUI', async function (fileOrFolders) {
+When('the user unmarks these files for batch action using the webUI', async function(
+  fileOrFolders
+) {
   for (const item of fileOrFolders.rows()) {
     await client.page.FilesPageElement.filesList().toggleFileOrFolderCheckbox('disable', item[0])
   }
 })
 
-When('the user marks these files for batch action using the webUI', async function (fileOrFolders) {
+When('the user marks these files for batch action using the webUI', async function(fileOrFolders) {
   for (const item of fileOrFolders.rows()) {
     await client.page.FilesPageElement.filesList().toggleFileOrFolderCheckbox('enable', item[0])
   }
 })
 
-When('the user clears the trashbin', function () {
+When('the user clears the trashbin', function() {
   return client.page.trashbinPage().clearTrashbin()
 })
 
-When('the user batch restores the marked files using the webUI', function () {
+When('the user batch restores the marked files using the webUI', function() {
   return client.page.FilesPageElement.filesList().restoreSelected()
 })
 
-When('the user picks the row of file/folder {string} in the webUI', function (item) {
+When('the user picks the row of file/folder {string} in the webUI', function(item) {
   return client.page.FilesPageElement.filesList().clickRow(item)
 })
 
-When('the user switches to {string} tab in details panel using the webUI', function (tab) {
+When('the user switches to {string} tab in details panel using the webUI', function(tab) {
   return client.page.filesPage().selectTabInSidePanel(tab)
 })
 
-Then('the folder should be empty on the webUI', async function () {
+Then('the folder should be empty on the webUI', async function() {
   const allFileRows = await client.page.FilesPageElement.filesList().allFileRows()
   return client.assert.equal(allFileRows.value.length, 0)
 })
 
-Then('the trashbin should be empty on the webUI', async function () {
+Then('the trashbin should be empty on the webUI', async function() {
   const allFileRows = await client.page.FilesPageElement.filesList().allFileRows()
   return client.assert.strictEqual(allFileRows.value.length, 0)
 })
 
-const theseResourcesShouldNotBeListed = async function (table) {
+const theseResourcesShouldNotBeListed = async function(table) {
   for (const entry of table.rows()) {
     const state = await client.page.FilesPageElement.filesList().isElementListed(entry[0])
     assert.ok(!state, `Expected resource '${entry[0]}' to be 'not present' but found 'present'`)
@@ -515,14 +491,17 @@ const theseResourcesShouldNotBeListed = async function (table) {
 /**
  * needs a heading line in the table
  */
-Then('these folders/files/resources should not be listed on the webUI', function (table) {
+Then('these folders/files/resources should not be listed on the webUI', function(table) {
   return theseResourcesShouldNotBeListed(table)
 })
 
 /**
  * needs a heading line in the table
  */
-Then('as {string} these folders/files/resources should not be listed on the webUI', async function (user, entryList) {
+Then('as {string} these folders/files/resources should not be listed on the webUI', async function(
+  user,
+  entryList
+) {
   if (user !== client.globals.currentUser) {
     await loginHelper.reLoginAsUser(user)
   }
@@ -534,29 +513,35 @@ Then('as {string} these folders/files/resources should not be listed on the webU
  *
  * needs a heading line in the table
  */
-Then('these folders/files/resources should not be listed in the folder {string} on the webUI', async function (folder, entryList) {
-  await client.page.filesPage().navigateAndWaitTillLoaded(folder)
-  return theseResourcesShouldNotBeListed(entryList)
-})
+Then(
+  'these folders/files/resources should not be listed in the folder {string} on the webUI',
+  async function(folder, entryList) {
+    await client.page.filesPage().navigateAndWaitTillLoaded(folder)
+    return theseResourcesShouldNotBeListed(entryList)
+  }
+)
 
 /**
  * currently this only works with the files page, on other pages the user cannot navigate into subfolders
  *
  * needs a heading line in the table
  */
-Then('as {string} these folders/files/resources should not be listed in the folder {string} on the webUI', async function (user, folder, entryList) {
-  if (user !== client.globals.currentUser) {
-    await loginHelper.reLoginAsUser(user)
+Then(
+  'as {string} these folders/files/resources should not be listed in the folder {string} on the webUI',
+  async function(user, folder, entryList) {
+    if (user !== client.globals.currentUser) {
+      await loginHelper.reLoginAsUser(user)
+    }
+    await client.page.filesPage().navigateAndWaitTillLoaded(folder)
+    return theseResourcesShouldNotBeListed(entryList)
   }
-  await client.page.filesPage().navigateAndWaitTillLoaded(folder)
-  return theseResourcesShouldNotBeListed(entryList)
-})
+)
 
 /**
  *
  * @param {DataTable} entryList the list needs a heading line
  */
-const theseResourcesShouldBeListed = async function (entryList) {
+const theseResourcesShouldBeListed = async function(entryList) {
   if (entryList.rows().length <= 0) {
     throw Error('Gerkin entry list is empty. Missing heading?')
   }
@@ -568,7 +553,7 @@ const theseResourcesShouldBeListed = async function (entryList) {
   return client
 }
 
-const assertBreadCrumbIsNotDisplayed = function () {
+const assertBreadCrumbIsNotDisplayed = function() {
   const breadcrumbXpath = client.page.filesPage().elements.breadcrumb.selector
   return client.expect.element(breadcrumbXpath).to.not.be.present
 }
@@ -577,20 +562,21 @@ const assertBreadCrumbIsNotDisplayed = function () {
  *
  * @param {string} resource
  */
-const assertBreadcrumbIsDisplayedFor = function (resource) {
+const assertBreadcrumbIsDisplayedFor = function(resource) {
   const breadcrumbElement = client.page.filesPage().elements.resourceBreadcrumb
   const resourceBreadcrumbXpath = util.format(breadcrumbElement.selector, resource)
   return client
     .useStrategy(breadcrumbElement)
-    .assert
-    .visible(resourceBreadcrumbXpath,
-      `Resource ${resourceBreadcrumbXpath} expected to be visible but is not visible .`)
+    .assert.visible(
+      resourceBreadcrumbXpath,
+      `Resource ${resourceBreadcrumbXpath} expected to be visible but is not visible .`
+    )
 }
 
 /**
  * needs a heading line in the table
  */
-Then('these files/folders/resources should be listed on the webUI', function (entryList) {
+Then('these files/folders/resources should be listed on the webUI', function(entryList) {
   return theseResourcesShouldBeListed(entryList)
 })
 
@@ -599,15 +585,21 @@ Then('these files/folders/resources should be listed on the webUI', function (en
  *
  * needs a heading line in the table
  */
-Then('these files/folders/resources should be listed in the folder {string} on the webUI', async function (folder, entryList) {
-  await client.page.filesPage().navigateAndWaitTillLoaded(folder)
-  return theseResourcesShouldBeListed(entryList)
-})
+Then(
+  'these files/folders/resources should be listed in the folder {string} on the webUI',
+  async function(folder, entryList) {
+    await client.page.filesPage().navigateAndWaitTillLoaded(folder)
+    return theseResourcesShouldBeListed(entryList)
+  }
+)
 
 /**
  * needs a heading line in the table
  */
-Then('as {string} these files/folders/resources should be listed on the webUI', async function (user, entryList) {
+Then('as {string} these files/folders/resources should be listed on the webUI', async function(
+  user,
+  entryList
+) {
   if (user !== client.globals.currentUser) {
     await loginHelper.reLoginAsUser(user)
   }
@@ -619,52 +611,57 @@ Then('as {string} these files/folders/resources should be listed on the webUI', 
  *
  * needs a heading line in the table
  */
-Then('as {string} these files/folders/resources should be listed in the folder {string} on the webUI', async function (user, folder, entryList) {
-  if (user !== client.globals.currentUser) {
-    await loginHelper.reLoginAsUser(user)
+Then(
+  'as {string} these files/folders/resources should be listed in the folder {string} on the webUI',
+  async function(user, folder, entryList) {
+    if (user !== client.globals.currentUser) {
+      await loginHelper.reLoginAsUser(user)
+    }
+    await client.page.filesPage().navigateAndWaitTillLoaded(folder)
+    return theseResourcesShouldBeListed(entryList)
   }
-  await client.page.filesPage().navigateAndWaitTillLoaded(folder)
-  return theseResourcesShouldBeListed(entryList)
-})
+)
 
-Then('file/folder {string} should be marked as favorite on the webUI', function (path) {
-  return client.page.FilesPageElement.filesRow().isMarkedFavorite(path)
+Then('file/folder {string} should be marked as favorite on the webUI', function(path) {
+  return client.page.FilesPageElement.filesRow()
+    .isMarkedFavorite(path)
     .then(result => {
       assert.strictEqual(result, true, `${path} expected to be favorite but was not`)
     })
 })
 
-Then('file/folder {string} should not be marked as favorite on the webUI', function (path) {
-  return client.page.FilesPageElement.filesRow().isMarkedFavorite(path)
+Then('file/folder {string} should not be marked as favorite on the webUI', function(path) {
+  return client.page.FilesPageElement.filesRow()
+    .isMarkedFavorite(path)
     .then(result => {
       assert.strictEqual(result, false, `not expected ${path} to be favorite but was`)
     })
 })
 
-Then(/there should be (\d+) files\/folders listed on the webUI/, async function (noOfItems) {
+Then(/there should be (\d+) files\/folders listed on the webUI/, async function(noOfItems) {
   const itemsCount = await client.page.FilesPageElement.filesList().countFilesAndFolders()
   return client.assert.equal(itemsCount, noOfItems)
 })
 
-Then('the folder should be empty on the webUI after a page reload', async function () {
+Then('the folder should be empty on the webUI after a page reload', async function() {
   await client.refresh()
   const allFileRows = await client.page.FilesPageElement.filesList().allFileRows()
   return client.assert.equal(allFileRows.value.length, 0)
 })
 
-Then('the app-sidebar should be visible', function () {
-  return client.page.filesPage().isSidebarVisible((value) => {
+Then('the app-sidebar should be visible', function() {
+  return client.page.filesPage().isSidebarVisible(value => {
     assert.strictEqual(value, true, 'side-bar should be visible, but is not')
   })
 })
 
-Then('the {string} details panel should be visible', function (panel) {
-  return client.page.filesPage().isPanelVisible(panel, (value) => {
+Then('the {string} details panel should be visible', function(panel) {
+  return client.page.filesPage().isPanelVisible(panel, value => {
     assert.strictEqual(value, true, `'${panel}-panel' should be visible, but is not`)
   })
 })
 
-Then('the following tabs should be visible in the details dialog', async function (table) {
+Then('the following tabs should be visible in the details dialog', async function(table) {
   const visibleTabs = await client.page.filesPage().getVisibleTabs()
   const expectedVisibleTabs = table.rows()
   const difference = _.difference(expectedVisibleTabs.flat(), visibleTabs)
@@ -673,54 +670,54 @@ Then('the following tabs should be visible in the details dialog', async functio
   }
 })
 
-Then('no {string} tab should be available in the details panel', function (tab) {
+Then('no {string} tab should be available in the details panel', function(tab) {
   const tabSelector = client.page.filesPage().getXpathOfLinkToTabInSidePanel()
-  return client.page.filesPage()
+  return client.page
+    .filesPage()
     .useXpath()
     .waitForElementNotPresent(tabSelector)
 })
 
-const assertElementsAreListed = async function (elements) {
+const assertElementsAreListed = async function(elements) {
   for (const element of elements) {
     const state = await client.page.FilesPageElement.filesList().isElementListed(element)
-    assert.ok(
-      state, `Expected resource '${element}' to be 'present' but found 'not present'`
-    )
+    assert.ok(state, `Expected resource '${element}' to be 'present' but found 'not present'`)
   }
   return client
 }
 
-const assertElementsAreNotListed = async function (elements) {
+const assertElementsAreNotListed = async function(elements) {
   for (const element of elements) {
     const state = await client.page.FilesPageElement.filesList().isElementListed(element)
-    assert.ok(
-      !state, `Expected resource '${element}' to be 'not present' but found 'present'`
-    )
+    assert.ok(!state, `Expected resource '${element}' to be 'not present' but found 'present'`)
   }
   return client
 }
 
-const assertDeletedElementsAreNotListed = function () {
+const assertDeletedElementsAreNotListed = function() {
   return assertElementsAreNotListed(deletedElements)
 }
 
-const assertDeletedElementsAreListed = function () {
+const assertDeletedElementsAreListed = function() {
   return assertElementsAreListed(deletedElements)
 }
 
-When(/^the user restores (file|folder) "([^"]*)" from the trashbin using the webUI$/, function (elementType, element) {
+When(/^the user restores (file|folder) "([^"]*)" from the trashbin using the webUI$/, function(
+  elementType,
+  element
+) {
   return client.page.FilesPageElement.filesList().restoreFile(element, elementType)
 })
 
-Then('the following files/folders/resources should be listed on the webUI', function (table) {
+Then('the following files/folders/resources should be listed on the webUI', function(table) {
   return assertElementsAreListed([].concat.apply([], table.rows()))
 })
 
-Then('file/folder {string} should be listed in the folder {string} on the webUI', async function (file, folder) {
-  const api = client
-    .page
-    .FilesPageElement
-    .filesList()
+Then('file/folder {string} should be listed in the folder {string} on the webUI', async function(
+  file,
+  folder
+) {
+  const api = client.page.FilesPageElement.filesList()
 
   await api.navigateToFolder(folder)
 
@@ -729,216 +726,278 @@ Then('file/folder {string} should be listed in the folder {string} on the webUI'
   return client
 })
 
-Then('the deleted elements should be listed on the webUI', function () {
+Then('the deleted elements should be listed on the webUI', function() {
   return assertDeletedElementsAreListed()
 })
 
-Given('the user has renamed the following files', function (table) {
-  return Promise.all(table.hashes().map((row) => {
-    return webdav.move(client.globals.currentUser, row['from-name-parts'], row['to-name-parts'])
-  }))
+Given('the user has renamed the following files', function(table) {
+  return Promise.all(
+    table.hashes().map(row => {
+      return webdav.move(client.globals.currentUser, row['from-name-parts'], row['to-name-parts'])
+    })
+  )
 })
 
 Given('user {string} has renamed file/folder {string} to {string}', webdav.move)
 
-Given('the user has created folder {string}', function (fileName) {
+Given('the user has created folder {string}', function(fileName) {
   return webdav.createFolder(client.globals.currentUser, fileName)
 })
 Given('user {string} has created folder {string}', webdav.createFolder)
 
-Then('file/folder {string} should not be listed in shared-with-others page on the webUI', async function (filename) {
-  await client.page.sharedWithOthersPage().navigateAndWaitTillLoaded()
-  const state = await client.page.FilesPageElement.filesList().isElementListed(filename)
-  assert.ok(
-    !state, `Error: Resource ${filename} is present on the shared-with-others page on the webUI`
-  )
-})
+Then(
+  'file/folder {string} should not be listed in shared-with-others page on the webUI',
+  async function(filename) {
+    await client.page.sharedWithOthersPage().navigateAndWaitTillLoaded()
+    const state = await client.page.FilesPageElement.filesList().isElementListed(filename)
+    assert.ok(
+      !state,
+      `Error: Resource ${filename} is present on the shared-with-others page on the webUI`
+    )
+  }
+)
 
-Then('file/folder {string} should be listed in shared-with-others page on the webUI', async function (filename) {
-  await client.page.sharedWithOthersPage().navigateAndWaitTillLoaded()
-  await client.page.FilesPageElement.filesList().waitForFileVisible(filename)
+Then(
+  'file/folder {string} should be listed in shared-with-others page on the webUI',
+  async function(filename) {
+    await client.page.sharedWithOthersPage().navigateAndWaitTillLoaded()
+    await client.page.FilesPageElement.filesList().waitForFileVisible(filename)
 
-  return client
-})
+    return client
+  }
+)
 
-Given('the user has created file {string}', function (fileName) {
+Given('the user has created file {string}', function(fileName) {
   return webdav.createFile(client.globals.currentUser, fileName, '')
 })
 
-Given('user {string} has created file {string}', function (userId, fileName) {
+Given('user {string} has created file {string}', function(userId, fileName) {
   return webdav.createFile(userId, fileName, '')
 })
 
-Given('the user has created the following folders', function (entryList) {
+Given('the user has created the following folders', function(entryList) {
   entryList.rows().forEach(entry => {
     webdav.createFolder(client.globals.currentUser, entry[0])
   })
   return client
 })
-Given('the user has created the following files', function (entryList) {
+Given('the user has created the following files', function(entryList) {
   entryList.rows().forEach(entry => {
     webdav.createFile(client.globals.currentUser, entry[0])
   })
   return client
 })
 
-When('the user browses to the folder {string} on the files page', (folderName) => {
+When('the user browses to the folder {string} on the files page', folderName => {
   const targetFolder = folderName === '/' ? '' : folderName
-  return client
-    .page.filesPage()
-    .navigateAndWaitTillLoaded(targetFolder)
+  return client.page.filesPage().navigateAndWaitTillLoaded(targetFolder)
 })
-When('the user copies the permalink of the file/folder/resource {string} using the webUI', async function (file) {
-  await client.page.FilesPageElement
-    .appSideBar()
-    .closeSidebar(100)
-    .openPublicLinkDialog(file)
-  await client.page.filesPage().copyPermalinkFromFilesAppBar()
-  return client
-})
-Then('the clipboard content should match permalink of resource {string}', async function (folderName) {
-  const folderData = await webdav.getProperties(folderName, client.globals.currentUser, ['oc:privatelink'])
-  return client.getClipBoardContent(function (value) {
+When(
+  'the user copies the permalink of the file/folder/resource {string} using the webUI',
+  async function(file) {
+    await client.page.FilesPageElement.appSideBar()
+      .closeSidebar(100)
+      .openPublicLinkDialog(file)
+    await client.page.filesPage().copyPermalinkFromFilesAppBar()
+    return client
+  }
+)
+Then('the clipboard content should match permalink of resource {string}', async function(
+  folderName
+) {
+  const folderData = await webdav.getProperties(folderName, client.globals.currentUser, [
+    'oc:privatelink'
+  ])
+  return client.getClipBoardContent(function(value) {
     assert.strictEqual(folderData['oc:privatelink'], value)
   })
 })
 
 Then('the app-sidebar for file/folder {string} should be visible on the webUI', resource => {
-  return client.page.filesPage()
+  return client.page
+    .filesPage()
     .isSidebarVisible(value => {
       assert.strictEqual(value, true, 'sidebar should be visible, but is not')
     })
     .checkSidebarItem(resource)
 })
 
-Then('the thumbnail should be visible in the app-sidebar', function () {
+Then('the thumbnail should be visible in the app-sidebar', function() {
   return client.page.FilesPageElement.appSideBar().isThumbnailVisible()
 })
 
-When('the user deletes the file {string} from the deleted files list', function (element) {
+When('the user deletes the file {string} from the deleted files list', function(element) {
   return client.page.FilesPageElement.filesList().deleteImmediately(element)
 })
 
-Then('it should not be possible to delete file/folder {string} using the webUI', async function (resource) {
-  const state = await client.page.FilesPageElement
-    .filesList()
-    .isActionAttributeDisabled('delete', resource)
+Then('it should not be possible to delete file/folder {string} using the webUI', async function(
+  resource
+) {
+  const state = await client.page.FilesPageElement.filesList().isActionAttributeDisabled(
+    'delete',
+    resource
+  )
   assert.ok(state, `expected property disabled of ${resource} to be 'true' but found ${state}`)
 })
 
-Then('it should not be possible to rename file/folder {string} using the webUI', async function (resource) {
-  const state = await client.page.FilesPageElement
-    .filesList()
-    .isActionAttributeDisabled('rename', resource)
+Then('it should not be possible to rename file/folder {string} using the webUI', async function(
+  resource
+) {
+  const state = await client.page.FilesPageElement.filesList().isActionAttributeDisabled(
+    'rename',
+    resource
+  )
   assert.ok(state, `expected property disabled of ${resource} to be 'true' but found ${state}`)
 })
 
-When('the user uploads overwriting file {string} using the webUI', function (file) {
+When('the user uploads overwriting file {string} using the webUI', function(file) {
   const uploadPath = path.join(client.globals.mountedUploadDir, file)
-  return client.page.filesPage().selectFileForUpload(uploadPath)
+  return client.page
+    .filesPage()
+    .selectFileForUpload(uploadPath)
     .then(() => client.page.filesPage().confirmFileOverwrite())
 })
 
-When('the user tries to create a file with already existing name {string} using the webUI', function (fileName) {
-  return client.page.filesPage().triesToCreateExistingFile(fileName)
-})
+When(
+  'the user tries to create a file with already existing name {string} using the webUI',
+  function(fileName) {
+    return client.page.filesPage().triesToCreateExistingFile(fileName)
+  }
+)
 
-Then('the create file button should be disabled', function () {
+Then('the create file button should be disabled', function() {
   return client.page.filesPage().checkForButtonDisabled()
 })
 
-When('user {string} has renamed the following file', function (user, table) {
-  const fromName = table.hashes().map(data => data['from-name-parts']).join('')
-  const toName = table.hashes().map(data => data['to-name-parts']).join('')
+When('user {string} has renamed the following file', function(user, table) {
+  const fromName = table
+    .hashes()
+    .map(data => data['from-name-parts'])
+    .join('')
+  const toName = table
+    .hashes()
+    .map(data => data['to-name-parts'])
+    .join('')
   return webdav.move(user, fromName, toName)
 })
 
-Then('the following file should be listed on the webUI', async function (table) {
-  const name = table.hashes().map(data => data['name-parts']).join('')
+Then('the following file should be listed on the webUI', async function(table) {
+  const name = table
+    .hashes()
+    .map(data => data['name-parts'])
+    .join('')
   const state = await client.page.FilesPageElement.filesList().isElementListed(name)
-  return assert.strictEqual(
-    state, true, `Element ${name} is not present on the filesList!`
-  )
+  return assert.strictEqual(state, true, `Element ${name} is not present on the filesList!`)
 })
 
-Then('the following file should not be listed on the webUI', async function (table) {
-  const name = table.hashes().map(data => data['name-parts']).join('')
+Then('the following file should not be listed on the webUI', async function(table) {
+  const name = table
+    .hashes()
+    .map(data => data['name-parts'])
+    .join('')
   const state = await client.page.FilesPageElement.filesList().isElementListed(name)
-  return assert.ok(
-    !state, `Element ${name} is present on the filesList!`
-  )
+  return assert.ok(!state, `Element ${name} is present on the filesList!`)
 })
 
-Then('the user deletes the following file using the webUI', function (table) {
-  const name = table.hashes().map(data => data['name-parts']).join('')
+Then('the user deletes the following file using the webUI', function(table) {
+  const name = table
+    .hashes()
+    .map(data => data['name-parts'])
+    .join('')
   return client.page.FilesPageElement.filesList().deleteFile(name)
 })
 
-Then('the user should be redirected to the files-drop page', function () {
+Then('the user should be redirected to the files-drop page', function() {
   return client.page.filesDropPage().waitForPage()
 })
 
-Then('the user should be redirected to the public links page', function () {
+Then('the user should be redirected to the public links page', function() {
   return client.page.publicLinkFilesPage().waitForPage()
 })
 
-Then('file/folder {string} shared by {string} should not be listed in the webUI', async function (element, sharer) {
+Then('file/folder {string} shared by {string} should not be listed in the webUI', async function(
+  element,
+  sharer
+) {
   const found = await client.page.sharedWithMePage().isSharePresent(element, sharer)
-  assert.ok(!found, element + ' shared by ' + sharer + ' was present but was not expected to be present')
+  assert.ok(
+    !found,
+    element + ' shared by ' + sharer + ' was present but was not expected to be present'
+  )
 })
 
-Then('the page should be empty', async function () {
+Then('the page should be empty', async function() {
   const isVisible = await client.page.phoenixPage().isPageVisible()
   assert.ok(!isVisible, 'The phoenix page should be empty but is not')
 })
 
-When('the user downloads file/folder {string} using the webUI', function (file) {
+When('the user downloads file/folder {string} using the webUI', function(file) {
   return client.page.FilesPageElement.filesList().downloadFile(file)
 })
 
-Then('the following resources should have share indicators on the webUI', async function (dataTable) {
+Then('the following resources should have share indicators on the webUI', async function(
+  dataTable
+) {
   for (const { fileName, expectedIndicators } of dataTable.hashes()) {
-    const indicatorsArray = await client
-      .page.FilesPageElement.filesList().getShareIndicatorsForResource(fileName)
+    const indicatorsArray = await client.page.FilesPageElement.filesList().getShareIndicatorsForResource(
+      fileName
+    )
 
     const expectedIndicatorsArray = expectedIndicators.split(',').map(s => s.trim())
     assert.ok(
-      _.intersection(indicatorsArray, expectedIndicatorsArray).length === expectedIndicatorsArray.length,
-      `Expected share indicators to be the same for "${fileName}": expected [` + expectedIndicatorsArray.join(', ') + '] got [' + indicatorsArray.join(', ') + ']'
+      _.intersection(indicatorsArray, expectedIndicatorsArray).length ===
+        expectedIndicatorsArray.length,
+      `Expected share indicators to be the same for "${fileName}": expected [` +
+        expectedIndicatorsArray.join(', ') +
+        '] got [' +
+        indicatorsArray.join(', ') +
+        ']'
     )
   }
 })
 
-Then('the following resources should not have share indicators on the webUI', async function (dataTable) {
+Then('the following resources should not have share indicators on the webUI', async function(
+  dataTable
+) {
   for (const [fileName] of dataTable.raw()) {
-    const indicatorsArray = await client
-      .page.FilesPageElement.filesList().getShareIndicatorsForResource(fileName)
+    const indicatorsArray = await client.page.FilesPageElement.filesList().getShareIndicatorsForResource(
+      fileName
+    )
 
     assert.ok(!indicatorsArray.length, `Expected no share indicators present for "${fileName}"`)
   }
 })
 
-async function _setFilesTableSort (column, isDesc) {
+async function _setFilesTableSort(column, isDesc) {
   await client.page.FilesPageElement.filesList().setSort(column, isDesc)
 }
 
-When('the user has set the sort order of the {string} column to descending order', async function (column) {
+When('the user has set the sort order of the {string} column to descending order', async function(
+  column
+) {
   await _setFilesTableSort(column, true)
 })
-When('the user has set the sort order of the {string} column to ascending order', async function (column) {
+When('the user has set the sort order of the {string} column to ascending order', async function(
+  column
+) {
   await _setFilesTableSort(column, false)
 })
-Then('the file {string} should have a thumbnail displayed on the webUI', async function (resource) {
-  const iconUrl = await client
-    .page
-    .FilesPageElement.filesList()
-    .getResourceThumbnail(resource, 'file')
-  assert.ok(iconUrl && iconUrl.startsWith('blob:'), 'Icon URL expected to be set when thumbnail is displayed')
+Then('the file {string} should have a thumbnail displayed on the webUI', async function(resource) {
+  const iconUrl = await client.page.FilesPageElement.filesList().getResourceThumbnail(
+    resource,
+    'file'
+  )
+  assert.ok(
+    iconUrl && iconUrl.startsWith('blob:'),
+    'Icon URL expected to be set when thumbnail is displayed'
+  )
 })
-Then('the file {string} should have a file type icon displayed on the webUI', async function (resource) {
-  const iconUrl = await client
-    .page
-    .FilesPageElement.filesList()
-    .getResourceThumbnail(resource, 'file')
+Then('the file {string} should have a file type icon displayed on the webUI', async function(
+  resource
+) {
+  const iconUrl = await client.page.FilesPageElement.filesList().getResourceThumbnail(
+    resource,
+    'file'
+  )
   assert.strictEqual(null, iconUrl, 'No icon URL expected when file type icon is displayed')
 })

--- a/tests/acceptance/stepDefinitions/generalContext.js
+++ b/tests/acceptance/stepDefinitions/generalContext.js
@@ -9,165 +9,199 @@ const occHelper = require('../helpers/occHelper')
 let initialConfigJsonSettings
 let createdFiles = []
 
-Given('a file with the size of {string} bytes and the name {string} has been created locally', function (size, name) {
-  const fullPathOfLocalFile = client.globals.filesForUpload + name
-  const fh = fs.openSync(fullPathOfLocalFile, 'w')
-  fs.writeSync(fh, 'A', Math.max(0, size - 1))
-  fs.closeSync(fh)
-  createdFiles.push(fullPathOfLocalFile)
-})
+Given(
+  'a file with the size of {string} bytes and the name {string} has been created locally',
+  function(size, name) {
+    const fullPathOfLocalFile = client.globals.filesForUpload + name
+    const fh = fs.openSync(fullPathOfLocalFile, 'w')
+    fs.writeSync(fh, 'A', Math.max(0, size - 1))
+    fs.closeSync(fh)
+    createdFiles.push(fullPathOfLocalFile)
+  }
+)
 
-const getConfigJsonContent = function (fullPathOfConfigFile) {
+const getConfigJsonContent = function(fullPathOfConfigFile) {
   const rawdata = fs.readFileSync(fullPathOfConfigFile)
   return JSON.parse(rawdata)
 }
 
-Given('the property {string} has been set to {string} in phoenix config file', function (key, value) {
+Given('the property {string} has been set to {string} in phoenix config file', function(
+  key,
+  value
+) {
   const data = getConfigJsonContent(this.fullPathOfConfigFile)
   data[key] = value
   return fs.writeFileSync(this.fullPathOfConfigFile, JSON.stringify(data, null, 4))
 })
 
-Given('the property {string} has been deleted in phoenix config file', function (key) {
+Given('the property {string} has been deleted in phoenix config file', function(key) {
   const data = getConfigJsonContent(this.fullPathOfConfigFile)
   delete data[key]
   return fs.writeFileSync(this.fullPathOfConfigFile, JSON.stringify(data, null, 4))
 })
 
-Then('the success/error message with header {string} should be displayed on the webUI', function (message) {
-  return client
-    .page.phoenixPage()
+Then('the success/error message with header {string} should be displayed on the webUI', function(
+  message
+) {
+  return client.page
+    .phoenixPage()
     .waitForElementVisible('@message')
-    .expect.element('@message').text.to.equal(message)
+    .expect.element('@message')
+    .text.to.equal(message)
 })
 
-Then('the following success/error message should be displayed on the webUI', function (message) {
-  return client
-    .page.phoenixPage()
+Then('the following success/error message should be displayed on the webUI', function(message) {
+  return client.page
+    .phoenixPage()
     .waitForElementVisible('@messages')
-    .expect.element('@messages').text.to.equal(message)
+    .expect.element('@messages')
+    .text.to.equal(message)
 })
 
-Then('the error message {string} should be displayed on the webUI dialog prompt', function (message) {
-  return client
-    .page.phoenixPage()
+Then('the error message {string} should be displayed on the webUI dialog prompt', function(
+  message
+) {
+  return client.page
+    .phoenixPage()
     .waitForElementVisible('@ocDialogPromptAlert')
-    .expect.element('@ocDialogPromptAlert').text.to.equal(message)
+    .expect.element('@ocDialogPromptAlert')
+    .text.to.equal(message)
 })
 
-Then('the user should see the following error message on the login card dialog', function (message) {
-  return client
-    .page.publicLinkPasswordPage()
+Then('the user should see the following error message on the login card dialog', function(message) {
+  return client.page
+    .publicLinkPasswordPage()
     .waitForElementVisible('@loginCardDialogBox')
-    .expect.element('@loginCardDialogBox').text.to.equal(message)
+    .expect.element('@loginCardDialogBox')
+    .text.to.equal(message)
 })
 
-When('the user clears all error message from the webUI', function () {
-  return client
-    .page.phoenixPage()
-    .clearAllErrorMessages()
+When('the user clears all error message from the webUI', function() {
+  return client.page.phoenixPage().clearAllErrorMessages()
 })
 
-Then('no message should be displayed on the webUI', function () {
-  return client
-    .page.phoenixPage()
-    .expect.element('@message').to.not.be.present
+Then('no message should be displayed on the webUI', function() {
+  return client.page.phoenixPage().expect.element('@message').to.not.be.present
 })
 
-Then('as {string} the content of {string} should be the same as the local {string}', function (userId, remoteFile, localFile) {
+Then('as {string} the content of {string} should be the same as the local {string}', function(
+  userId,
+  remoteFile,
+  localFile
+) {
   const fullPathOfLocalFile = client.globals.filesForUpload + localFile
   return webdavHelper
     .download(userId, remoteFile)
     .then(body => assertContentOFLocalFileIs(fullPathOfLocalFile, body))
 })
 
-Then('as {string} the content of {string} should not be the same as the local {string}', function (userId, remoteFile, localFile) {
+Then('as {string} the content of {string} should not be the same as the local {string}', function(
+  userId,
+  remoteFile,
+  localFile
+) {
   const fullPathOfLocalFile = client.globals.filesForUpload + localFile
   return webdavHelper
     .download(userId, remoteFile)
     .then(body => assertContentOFLocalFileIsNot(fullPathOfLocalFile, body))
 })
 
-const assertContentOFLocalFileIs = function (fullPathOflocalFile, expectedContent) {
+const assertContentOFLocalFileIs = function(fullPathOflocalFile, expectedContent) {
   const actualContent = fs.readFileSync(fullPathOflocalFile, { encoding: 'utf-8' })
   return client.assert.strictEqual(
-    actualContent, expectedContent, 'asserting content of local file "' + fullPathOflocalFile + '"'
+    actualContent,
+    expectedContent,
+    'asserting content of local file "' + fullPathOflocalFile + '"'
   )
 }
 
-const assertContentOFLocalFileIsNot = function (fullPathOflocalFile, expectedContent) {
+const assertContentOFLocalFileIsNot = function(fullPathOflocalFile, expectedContent) {
   const actualContent = fs.readFileSync(fullPathOflocalFile, { encoding: 'utf-8' })
   return client.assert.notEqual(
-    actualContent, expectedContent, 'asserting content of local file "' + fullPathOflocalFile + '"'
+    actualContent,
+    expectedContent,
+    'asserting content of local file "' + fullPathOflocalFile + '"'
   )
 }
 
-const assertRemoteFileSameAsSkeletonFile = async function (userId, remoteFile, skeletonFile) {
+const assertRemoteFileSameAsSkeletonFile = async function(userId, remoteFile, skeletonFile) {
   const skeleton = await webdavHelper.getSkeletonFile(skeletonFile)
   const remote = await webdavHelper.download(userId, remoteFile)
   return client.assert.strictEqual(
-    skeleton, remote, `Failed asserting remote file ${remoteFile} is same as skeleton file ${skeletonFile} for user${userId}`
+    skeleton,
+    remote,
+    `Failed asserting remote file ${remoteFile} is same as skeleton file ${skeletonFile} for user${userId}`
   )
 }
 
-Then('as {string} the content of {string} should be the same as the original {string}', function (user, remoteFile, skeletonFile) {
+Then('as {string} the content of {string} should be the same as the original {string}', function(
+  user,
+  remoteFile,
+  skeletonFile
+) {
   return assertRemoteFileSameAsSkeletonFile(user, remoteFile, skeletonFile)
 })
 
-Given('the setting {string} of app {string} has been set to {string}', function (setting, app, value) {
-  return occHelper.runOcc(
-    [
-      'config:app:set', app, setting, '--value=' + value
-    ])
+Given('the setting {string} of app {string} has been set to {string}', function(
+  setting,
+  app,
+  value
+) {
+  return occHelper.runOcc(['config:app:set', app, setting, '--value=' + value])
 })
 
-Given('the setting {string} of app {string} has been set to {string} on remote server', function (setting, app, value) {
+Given('the setting {string} of app {string} has been set to {string} on remote server', function(
+  setting,
+  app,
+  value
+) {
   return backendHelper.runOnRemoteBackend(occHelper.runOcc, [
-    'config:app:set', app, setting, '--value=' + value
+    'config:app:set',
+    app,
+    setting,
+    '--value=' + value
   ])
 })
 
-Given('the administrator has cleared the versions for user {string}', function (userId) {
-  return occHelper.runOcc(
-    [
-      'versions:cleanup', userId
-    ])
+Given('the administrator has cleared the versions for user {string}', function(userId) {
+  return occHelper.runOcc(['versions:cleanup', userId])
 })
 
-Given('the administrator has cleared the versions for all users', function () {
-  return occHelper.runOcc(
-    [
-      'versions:cleanup'
-    ])
+Given('the administrator has cleared the versions for all users', function() {
+  return occHelper.runOcc(['versions:cleanup'])
 })
 
-const setTrustedServer = function (url) {
+const setTrustedServer = function(url) {
   const body = new URLSearchParams()
   body.append('url', url)
   const postUrl = 'apps/testing/api/v1/trustedservers'
-  return httpHelper.postOCS(postUrl, 'admin', body)
-    .then(res => {
-      return httpHelper.checkStatus(res)
-    })
+  return httpHelper.postOCS(postUrl, 'admin', body).then(res => {
+    return httpHelper.checkStatus(res)
+  })
 }
 
-Given('server {code} has been added as trusted server', function (server) {
+Given('server {code} has been added as trusted server', function(server) {
   return setTrustedServer(server)
 })
 
-Given('server {code} has been added as trusted server on remote server', function (url) {
+Given('server {code} has been added as trusted server on remote server', function(url) {
   return backendHelper.runOnRemoteBackend(setTrustedServer, url)
 })
 
-Before(function (testCase) {
+Before(function(testCase) {
   createdFiles = []
-  if (typeof process.env.SCREEN_RESOLUTION !== 'undefined' && process.env.SCREEN_RESOLUTION.trim() !== '') {
+  if (
+    typeof process.env.SCREEN_RESOLUTION !== 'undefined' &&
+    process.env.SCREEN_RESOLUTION.trim() !== ''
+  ) {
     const resolution = process.env.SCREEN_RESOLUTION.split('x')
     resolution[0] = parseInt(resolution[0])
     resolution[1] = parseInt(resolution[1])
     if (resolution[0] > 1 && resolution[1] > 1) {
       client.resizeWindow(resolution[0], resolution[1])
-      console.log('\nINFO: setting screen resolution to ' + resolution[0] + 'x' + resolution[1] + '\n')
+      console.log(
+        '\nINFO: setting screen resolution to ' + resolution[0] + 'x' + resolution[1] + '\n'
+      )
     } else {
       console.warn('\nWARNING: invalid resolution given, running tests in full resolution!\n')
       client.maximizeWindow()
@@ -178,7 +212,7 @@ Before(function (testCase) {
   console.log('  ' + testCase.sourceLocation.uri + ':' + testCase.sourceLocation.line + '\n')
 })
 
-After(async function (testCase) {
+After(async function(testCase) {
   if (client.globals.ocis) {
     return
   }
@@ -193,32 +227,24 @@ After(async function (testCase) {
   await httpHelper.deleteOCS(url, 'admin', body)
 })
 
-Before(function () {
+Before(function() {
   this.fullPathOfConfigFile = client.globals.phoenix_config
   initialConfigJsonSettings = getConfigJsonContent(client.globals.phoenix_config)
 })
 
-After(function () {
+After(function() {
   if (client.globals.ocis || client.globals.openid_login) {
     return
   }
-  fs.writeFileSync(this.fullPathOfConfigFile,
-    JSON.stringify(initialConfigJsonSettings, null, 4))
+  fs.writeFileSync(this.fullPathOfConfigFile, JSON.stringify(initialConfigJsonSettings, null, 4))
 })
 
-Given('the app {string} has been disabled', function (app) {
-  return occHelper.runOcc(
-    [
-      'app:disable', app
-    ])
+Given('the app {string} has been disabled', function(app) {
+  return occHelper.runOcc(['app:disable', app])
 })
 
-Given('default expiration date for users is set to {int} day/days', function (days) {
-  occHelper.runOcc(
-    [
-      `config:app:set --value ${days} core shareapi_expire_after_n_days_user_share`
-    ]
-  )
+Given('default expiration date for users is set to {int} day/days', function(days) {
+  occHelper.runOcc([`config:app:set --value ${days} core shareapi_expire_after_n_days_user_share`])
 
   return this
 })

--- a/tests/acceptance/stepDefinitions/loginContext.js
+++ b/tests/acceptance/stepDefinitions/loginContext.js
@@ -3,19 +3,16 @@ const { Given, Then, When } = require('cucumber')
 const loginHelper = require('../helpers/loginHelper')
 const assert = require('assert')
 
-Given(/^the user has browsed to the login page$/,
-  () => {
-    return client
-      .page
-      .loginPage()
-      .navigate()
-  })
+Given(/^the user has browsed to the login page$/, () => {
+  return client.page.loginPage().navigate()
+})
 
 Given('the user has clicked the authenticate button', () => client.page.loginPage().authenticate())
 
 When('the user clicks the authenticate button', () => client.page.loginPage().authenticate())
 
-When('the user logs in with username {string} and password {string} using the webUI',
+When(
+  'the user logs in with username {string} and password {string} using the webUI',
   (username, password) => {
     if (client.globals.openid_login) {
       return client.page.ocisLoginPage().login(username, password)
@@ -24,7 +21,8 @@ When('the user logs in with username {string} and password {string} using the we
   }
 )
 
-When('the user tries to log in with username {string} and password {string} using the webUI',
+When(
+  'the user tries to log in with username {string} and password {string} using the webUI',
   (username, password) => {
     if (client.globals.openid_login) {
       return client.page.ocisLoginPage().login(username, password)
@@ -33,41 +31,36 @@ When('the user tries to log in with username {string} and password {string} usin
   }
 )
 
-When('user {string} logs in using the webUI',
-  (username) => loginHelper.loginAsUser(username)
-)
+When('user {string} logs in using the webUI', username => loginHelper.loginAsUser(username))
 
-When('the user authorizes access to phoenix',
-  () => {
-    return client
-      .page.ownCloudAuthorizePage()
-      .authorize()
-  })
+When('the user authorizes access to phoenix', () => {
+  return client.page.ownCloudAuthorizePage().authorize()
+})
 
-Then('the files table should not be empty',
-  () => {
-    return client.page.FilesPageElement.filesList()
+Then('the files table should not be empty', () => {
+  return (
+    client.page.FilesPageElement.filesList()
       // even the loading indicator is gone the table might not be rendered yet
       .waitForElementVisible('@fileRows')
-  })
-
-Then('the warning {string} should be displayed on the login page', async function (expectedMessage) {
-  const actualMessage = await client.page.ownCloudLoginPage().getLoginErrorMessage()
-  return assert.strictEqual(
-    actualMessage, expectedMessage, `Error message miss-match, Expected: '${expectedMessage}', Found: '${actualMessage}'`
   )
 })
 
-Then('the authentication page should be visible',
-  () => {
-    const loginPage = client
-      .page.loginPage()
-    return loginPage
-      .waitForElementPresent('@authenticateButton')
-  })
+Then('the warning {string} should be displayed on the login page', async function(expectedMessage) {
+  const actualMessage = await client.page.ownCloudLoginPage().getLoginErrorMessage()
+  return assert.strictEqual(
+    actualMessage,
+    expectedMessage,
+    `Error message miss-match, Expected: '${expectedMessage}', Found: '${actualMessage}'`
+  )
+})
+
+Then('the authentication page should be visible', () => {
+  const loginPage = client.page.loginPage()
+  return loginPage.waitForElementPresent('@authenticateButton')
+})
 
 // combined step
-Given('user {string} has logged in using the webUI', (user) => {
+Given('user {string} has logged in using the webUI', user => {
   return loginHelper.loginAsUser(user)
 })
 
@@ -75,28 +68,28 @@ When('the user logs out of the webUI', () => {
   return loginHelper.logout()
 })
 
-When('the user re-logs in as {string} using the webUI', (user) => {
+When('the user re-logs in as {string} using the webUI', user => {
   return loginHelper.reLoginAsUser(user)
 })
 
-Then('the user profile should be visible in the webUI', function () {
+Then('the user profile should be visible in the webUI', function() {
   return client.page.phoenixPage().waitForElementVisible('@userMenuButton')
 })
 
-When('the user opens the user profile', function () {
+When('the user opens the user profile', function() {
   return client.page.phoenixPage().browseToUserProfile()
 })
 
-Then('username {string} should be visible in the webUI', async function (username) {
+Then('username {string} should be visible in the webUI', async function(username) {
   const profileUserName = await client.page.profilePage().getUserProfileName()
   assert.strictEqual(profileUserName, username)
 })
 
-When('the user browses to manage the account', function () {
+When('the user browses to manage the account', function() {
   return client.page.profilePage().browseToManageAccount()
 })
 
-Then('the accounts page should be visible in the webUI', async function () {
+Then('the accounts page should be visible in the webUI', async function() {
   const isPageVisible = await client.page.accountPage().isPageVisible()
   return assert.ok(isPageVisible)
 })

--- a/tests/acceptance/stepDefinitions/messagesContext.js
+++ b/tests/acceptance/stepDefinitions/messagesContext.js
@@ -1,6 +1,6 @@
 const { client } = require('nightwatch-api')
 const { When } = require('cucumber')
 
-When('the user closes the message', function () {
+When('the user closes the message', function() {
   return client.page.phoenixPage().closeMessage()
 })

--- a/tests/acceptance/stepDefinitions/notificationsContext.js
+++ b/tests/acceptance/stepDefinitions/notificationsContext.js
@@ -5,28 +5,29 @@ const codify = require('../helpers/codify')
 const assert = require('assert')
 const util = require('util')
 
-When('user {string} is sent a notification', function (user) {
+When('user {string} is sent a notification', function(user) {
   const body = new URLSearchParams()
   body.append('user', user)
   const apiURL = 'apps/testing/api/v1/notifications'
 
-  return httpHelper.postOCS(apiURL, 'admin', body)
+  return httpHelper
+    .postOCS(apiURL, 'admin', body)
     .then(res => httpHelper.checkStatus(res, 'Could not generate notification.'))
 })
 
-When('the user marks the notification as read', function () {
+When('the user marks the notification as read', function() {
   return client.page.phoenixPage().markNotificationAsRead()
 })
 
-When('the user accepts all shares displayed in the notifications on the webUI', function () {
+When('the user accepts all shares displayed in the notifications on the webUI', function() {
   return client.page.phoenixPage().acceptAllSharesInNotification()
 })
 
-When('the user declines all shares displayed in the notifications on the webUI', function () {
+When('the user declines all shares displayed in the notifications on the webUI', function() {
   return client.page.phoenixPage().declineAllSharesInNotification()
 })
 
-Given('app {string} has been {}', async function (app, action) {
+Given('app {string} has been {}', async function(app, action) {
   assert.ok(
     action === 'enabled' || action === 'disabled',
     "only supported either 'enabled' or 'disabled'. Passed: " + action
@@ -37,47 +38,49 @@ Given('app {string} has been {}', async function (app, action) {
     action === 'enabled' ? 'enable' : 'disable'
   )
   const apiURL = `cloud/apps/${app}`
-  const response = await action === 'enabled' ? httpHelper.postOCS(apiURL) : httpHelper.deleteOCS(apiURL)
-  response.then(res => {
-    httpHelper.checkStatus(res, errorMessage)
-    return res.json()
-  }).then(data => {
-    httpHelper.checkOCSStatus(data, errorMessage)
-  })
+  const response =
+    (await action) === 'enabled' ? httpHelper.postOCS(apiURL) : httpHelper.deleteOCS(apiURL)
+  response
+    .then(res => {
+      httpHelper.checkStatus(res, errorMessage)
+      return res.json()
+    })
+    .then(data => {
+      httpHelper.checkOCSStatus(data, errorMessage)
+    })
 })
 
-Then('the user should see the notification bell on the webUI', function () {
+Then('the user should see the notification bell on the webUI', function() {
   return client.page.phoenixPage().waitForElementVisible('@notificationBell')
 })
 
-Then('the user should see the notification bell on the webUI after a page reload', function () {
+Then('the user should see the notification bell on the webUI after a page reload', function() {
   client.refresh()
   return client.page.phoenixPage().waitForElementVisible('@notificationBell')
 })
 
-Then('the notification bell should disappear on the webUI', function () {
+Then('the notification bell should disappear on the webUI', function() {
   return client.page.phoenixPage().waitForElementNotPresent('@notificationBell')
 })
 
-Then('the user should see {int} notifications on the webUI with these details',
-  async function (numberOfNotifications, dataTable) {
-    codify.replaceInlineTable(dataTable)
-    const expectedNotifications = dataTable.hashes()
-    const notifications = await client.page.phoenixPage().getNotifications()
-    assert.strictEqual(
-      notifications.length,
-      numberOfNotifications,
-      'Notification count miss-match!'
+Then('the user should see {int} notifications on the webUI with these details', async function(
+  numberOfNotifications,
+  dataTable
+) {
+  codify.replaceInlineTable(dataTable)
+  const expectedNotifications = dataTable.hashes()
+  const notifications = await client.page.phoenixPage().getNotifications()
+  assert.strictEqual(notifications.length, numberOfNotifications, 'Notification count miss-match!')
+  for (const element of expectedNotifications) {
+    const isPresent = notifications.includes(element.title)
+    assert.ok(
+      isPresent,
+      `Expected: '${element.title}' to be present but found: not present in ${notifications}`
     )
-    for (const element of expectedNotifications) {
-      const isPresent = notifications.includes(element.title)
-      assert.ok(
-        isPresent,
-        `Expected: '${element.title}' to be present but found: not present in ${notifications}`)
-    }
-  })
+  }
+})
 
-Then('the user should have no notifications', async function () {
+Then('the user should have no notifications', async function() {
   const status = await client.page.phoenixPage().isNotificationBellVisible()
   assert.ok(!status, 'Expected: notification bell to be absent but found: visible')
 })

--- a/tests/acceptance/stepDefinitions/privateLinksContext.js
+++ b/tests/acceptance/stepDefinitions/privateLinksContext.js
@@ -2,26 +2,32 @@ const { client } = require('nightwatch-api')
 const { When } = require('cucumber')
 const webdav = require('../helpers/webdavHelper')
 
-When('the user copies the private link of the file/folder {string} using the webUI', async function (resource) {
+When('the user copies the private link of the file/folder {string} using the webUI', async function(
+  resource
+) {
   const api = client.page.FilesPageElement
   await api.filesList().clickRow(resource)
 
   return api.publicLinksDialog().copyPrivateLink()
 })
 
-When('the user navigates to the copied private/public link using the webUI', function () {
-  return client.getClipBoardContent(function (url) {
+When('the user navigates to the copied private/public link using the webUI', function() {
+  return client.getClipBoardContent(function(url) {
     // If the redirect happens immediately we receive an error
     // Cannot read property 'parentNode' of null
-    setTimeout(function () {
+    setTimeout(function() {
       client.url(url)
     }, 0)
   })
 })
 
-When('the user navigates to the private link created by user {string} for file/folder {string}', async function (user, resource) {
-  const item = await webdav.getProperties(resource, user, ['oc:privatelink'])
-  return client
-    .url(item['oc:privatelink'])
-    .page.phoenixPage().waitForElementVisible('@phoenixContainer')
-})
+When(
+  'the user navigates to the private link created by user {string} for file/folder {string}',
+  async function(user, resource) {
+    const item = await webdav.getProperties(resource, user, ['oc:privatelink'])
+    return client
+      .url(item['oc:privatelink'])
+      .page.phoenixPage()
+      .waitForElementVisible('@phoenixContainer')
+  }
+)

--- a/tests/acceptance/stepDefinitions/provisioningContext.js
+++ b/tests/acceptance/stepDefinitions/provisioningContext.js
@@ -10,7 +10,7 @@ const { join } = require('../helpers/path')
 
 const ldap = require('../helpers/ldapHelper')
 
-function createDefaultUser (userId) {
+function createDefaultUser(userId) {
   const password = userSettings.getPasswordForUser(userId)
   const displayname = userSettings.getDisplayNameOfDefaultUser(userId)
   const email = userSettings.getEmailAddressOfDefaultUser(userId)
@@ -20,7 +20,7 @@ function createDefaultUser (userId) {
   return createUser(userId, password, displayname, email)
 }
 
-function createUser (userId, password, displayName = false, email = false) {
+function createUser(userId, password, displayName = false, email = false) {
   const body = new URLSearchParams()
   body.append('userid', userId)
   body.append('password', password)
@@ -28,39 +28,42 @@ function createUser (userId, password, displayName = false, email = false) {
 
   userSettings.addUserToCreatedUsersList(userId, password, displayName, email)
   const url = 'cloud/users'
-  return httpHelper.postOCS(url, 'admin', body)
+  return httpHelper
+    .postOCS(url, 'admin', body)
     .then(() => {
       if (displayName !== false) {
-        promiseList.push(new Promise((resolve, reject) => {
-          const body = new URLSearchParams()
-          body.append('key', 'display')
-          body.append('value', displayName)
-          const url = `cloud/users/${encodeURIComponent(userId)}`
-          httpHelper.putOCS(url, 'admin', body)
-            .then(res => {
+        promiseList.push(
+          new Promise((resolve, reject) => {
+            const body = new URLSearchParams()
+            body.append('key', 'display')
+            body.append('value', displayName)
+            const url = `cloud/users/${encodeURIComponent(userId)}`
+            httpHelper.putOCS(url, 'admin', body).then(res => {
               if (res.status !== 200) {
                 reject(new Error('Could not set display name of user'))
               }
               resolve(res)
             })
-        }))
+          })
+        )
       }
     })
     .then(() => {
       if (email !== false) {
-        promiseList.push(new Promise((resolve, reject) => {
-          const body = new URLSearchParams()
-          body.append('key', 'email')
-          body.append('value', email)
-          const url = `cloud/users/${encodeURIComponent(userId)}`
-          httpHelper.putOCS(url, 'admin', body)
-            .then(res => {
+        promiseList.push(
+          new Promise((resolve, reject) => {
+            const body = new URLSearchParams()
+            body.append('key', 'email')
+            body.append('value', email)
+            const url = `cloud/users/${encodeURIComponent(userId)}`
+            httpHelper.putOCS(url, 'admin', body).then(res => {
               if (res.status !== 200) {
                 reject(new Error('Could not set email of user'))
               }
               resolve()
             })
-        }))
+          })
+        )
       }
     })
     .then(() => {
@@ -68,13 +71,13 @@ function createUser (userId, password, displayName = false, email = false) {
     })
 }
 
-function deleteUser (userId) {
+function deleteUser(userId) {
   userSettings.deleteUserFromCreatedUsersList(userId)
   const url = `cloud/users/${userId}`
   return httpHelper.deleteOCS(url)
 }
 
-function initUser (userId) {
+function initUser(userId) {
   const url = `cloud/users/${userId}`
   return httpHelper.getOCS(url, userId)
 }
@@ -84,14 +87,13 @@ function initUser (userId) {
  * @param {string} groupId
  * @returns {*|Promise}
  */
-function createGroup (groupId) {
+function createGroup(groupId) {
   if (client.globals.ocis) {
-    return ldap.createGroup(client.globals.ldapClient, groupId)
-      .then((err) => {
-        if (!err) {
-          userSettings.addGroupToCreatedGroupsList(groupId)
-        }
-      })
+    return ldap.createGroup(client.globals.ldapClient, groupId).then(err => {
+      if (!err) {
+        userSettings.addGroupToCreatedGroupsList(groupId)
+      }
+    })
   }
   const body = new URLSearchParams()
   body.append('groupid', groupId)
@@ -105,13 +107,13 @@ function createGroup (groupId) {
  * @param {string} groupId
  * @returns {*|Promise}
  */
-function deleteGroup (groupId) {
+function deleteGroup(groupId) {
   userSettings.deleteGroupFromCreatedGroupsList(groupId)
   const url = `cloud/groups/${groupId}`
   return httpHelper.deleteOCS(url)
 }
 
-function addToGroup (userId, groupId) {
+function addToGroup(userId, groupId) {
   if (client.globals.ocis) {
     return ldap.addUserToGroup(client.globals.ldapClient, userId, groupId)
   }
@@ -121,112 +123,111 @@ function addToGroup (userId, groupId) {
   return httpHelper.postOCS(url, 'admin', body)
 }
 
-Given('user {string} has been created with default attributes', async function (userId) {
+Given('user {string} has been created with default attributes', async function(userId) {
   await deleteUser(userId)
   await createDefaultUser(userId)
   await initUser(userId)
 })
 
-Given('user {string} has been created with default attributes on remote server', function (userId) {
-  return backendHelper.runOnRemoteBackend(
-    async function () {
-      await deleteUser()
-        .then(() => createDefaultUser(userId))
-        .then(() => initUser(userId))
-    })
+Given('user {string} has been created with default attributes on remote server', function(userId) {
+  return backendHelper.runOnRemoteBackend(async function() {
+    await deleteUser()
+      .then(() => createDefaultUser(userId))
+      .then(() => initUser(userId))
+  })
 })
 
-Given('the quota of user {string} has been set to {string}', function (userId, quota) {
+Given('the quota of user {string} has been set to {string}', function(userId, quota) {
   const body = new URLSearchParams()
   body.append('key', 'quota')
   body.append('value', quota)
   const url = `cloud/users/${userId}`
-  return httpHelper.putOCS(url, 'admin', body)
+  return httpHelper
+    .putOCS(url, 'admin', body)
     .then(res => httpHelper.checkStatus(res, 'Could not set quota.'))
 })
 
-Given('these users have been created with default attributes but not initialized:', function (dataTable) {
-  return Promise.all(dataTable.rows().map((userId) => {
-    return deleteUser(userId)
-      .then(() => createDefaultUser(userId))
-  }))
+Given('these users have been created with default attributes but not initialized:', function(
+  dataTable
+) {
+  return Promise.all(
+    dataTable.rows().map(userId => {
+      return deleteUser(userId).then(() => createDefaultUser(userId))
+    })
+  )
 })
 
-Given('these users have been created but not initialized:', function (dataTable) {
+Given('these users have been created but not initialized:', function(dataTable) {
   codify.replaceInlineTable(dataTable)
-  return Promise.all(dataTable.hashes().map((user) => {
-    const userId = user.username
-    const password = user.password || userSettings.getPasswordForUser(userId)
-    const displayName = user.displayname || false
-    const email = user.email || false
-    return deleteUser(userId)
-      .then(() => createUser(userId, password, displayName, email))
-  }))
+  return Promise.all(
+    dataTable.hashes().map(user => {
+      const userId = user.username
+      const password = user.password || userSettings.getPasswordForUser(userId)
+      const displayName = user.displayname || false
+      const email = user.email || false
+      return deleteUser(userId).then(() => createUser(userId, password, displayName, email))
+    })
+  )
 })
 
-Given('these users have been created with default attributes:', function (dataTable) {
-  return Promise.all(dataTable.rows().map((user) => {
-    const userId = user[0]
-    return deleteUser(userId)
-      .then(() => createDefaultUser(userId))
-      .then(() => initUser(userId))
-  }))
+Given('these users have been created with default attributes:', function(dataTable) {
+  return Promise.all(
+    dataTable.rows().map(user => {
+      const userId = user[0]
+      return deleteUser(userId)
+        .then(() => createDefaultUser(userId))
+        .then(() => initUser(userId))
+    })
+  )
 })
 
-Given('group {string} has been created', function (groupId) {
-  return deleteGroup(groupId.toString())
-    .then(() => createGroup(groupId.toString()))
+Given('group {string} has been created', function(groupId) {
+  return deleteGroup(groupId.toString()).then(() => createGroup(groupId.toString()))
 })
 
-Given('these groups have been created:', function (dataTable) {
-  return Promise.all(dataTable.rows().map((groupId) => {
-    return deleteGroup(groupId.toString())
-      .then(() => createGroup(groupId.toString()))
-  }))
+Given('these groups have been created:', function(dataTable) {
+  return Promise.all(
+    dataTable.rows().map(groupId => {
+      return deleteGroup(groupId.toString()).then(() => createGroup(groupId.toString()))
+    })
+  )
 })
 
-Given('user {string} has been added to group {string}', function (userId, groupId) {
+Given('user {string} has been added to group {string}', function(userId, groupId) {
   return addToGroup(userId, groupId)
 })
 
-After(async function () {
+After(async function() {
   const createdUsers = Object.keys(userSettings.getCreatedUsers('LOCAL'))
   const createdRemoteUsers = Object.keys(userSettings.getCreatedUsers('REMOTE'))
   const createdGroups = userSettings.getCreatedGroups()
 
   if (client.globals.ocis) {
-    const dataDir = (user) => join(client.globals.ocis_data_dir, 'data', user)
-    const deleteUserPromises = createdUsers.map(
-      user => ldap.deleteUser(client.globals.ldapClient, user)
-        .then(() => {
-          console.log('Deleted LDAP User: ', user)
-        })
+    const dataDir = user => join(client.globals.ocis_data_dir, 'data', user)
+    const deleteUserPromises = createdUsers.map(user =>
+      ldap.deleteUser(client.globals.ldapClient, user).then(() => {
+        console.log('Deleted LDAP User: ', user)
+      })
     )
     const deleteUserDirectories = createdUsers.map(user => fs.remove(dataDir(user)))
-    const deleteGroupPromises = createdGroups.map(
-      group => ldap.deleteGroup(client.globals.ldapClient, group)
-        .then(() => {
-          console.log('Deleted LDAP Group: ', group)
-        })
+    const deleteGroupPromises = createdGroups.map(group =>
+      ldap.deleteGroup(client.globals.ldapClient, group).then(() => {
+        console.log('Deleted LDAP Group: ', group)
+      })
     )
     await Promise.all([
       ...deleteUserPromises,
       ...deleteGroupPromises,
       ...deleteUserDirectories
-    ])
-      .then(() => {
-        userSettings.resetCreatedUsers()
-        userSettings.resetCreatedGroups()
-      })
+    ]).then(() => {
+      userSettings.resetCreatedUsers()
+      userSettings.resetCreatedGroups()
+    })
   } else {
-    await Promise.all(
-      [...createdUsers.map(deleteUser), ...createdGroups.map(deleteGroup)]
-    )
+    await Promise.all([...createdUsers.map(deleteUser), ...createdGroups.map(deleteGroup)])
   }
 
   if (client.globals.remote_backend_url) {
-    return backendHelper.runOnRemoteBackend(
-      () => Promise.all(createdRemoteUsers.map(deleteUser))
-    )
+    return backendHelper.runOnRemoteBackend(() => Promise.all(createdRemoteUsers.map(deleteUser)))
   }
 })

--- a/tests/acceptance/stepDefinitions/publicLinkContext.js
+++ b/tests/acceptance/stepDefinitions/publicLinkContext.js
@@ -8,22 +8,19 @@ const path = require('../helpers/path')
 
 When(
   'the user (tries to )create/creates a new public link for file/folder/resource {string} using the webUI',
-  async function (resource) {
-    await client.page.FilesPageElement
-      .appSideBar()
+  async function(resource) {
+    await client.page.FilesPageElement.appSideBar()
       .closeSidebar(100)
       .openPublicLinkDialog(resource)
-    return client.page.FilesPageElement.publicLinksDialog()
-      .addNewLink()
+    return client.page.FilesPageElement.publicLinksDialog().addNewLink()
   }
 )
 
 When(
   'the user (tries to )create/creates a new public link for file/folder/resource {string} using the webUI with',
-  async function (resource, settingsTable) {
+  async function(resource, settingsTable) {
     const settings = settingsTable.rowsHash()
-    await client.page.FilesPageElement
-      .appSideBar()
+    await client.page.FilesPageElement.appSideBar()
       .closeSidebar(100)
       .openPublicLinkDialog(resource)
     return client.page.FilesPageElement.publicLinksDialog().addNewLink(settings)
@@ -32,113 +29,128 @@ When(
 
 When(
   'the user (tries to) create a new public link for file/folder/resource {string} which expires in {string} day/days using the webUI',
-  async function (resource, days) {
-    await client.page.FilesPageElement
-      .appSideBar()
+  async function(resource, days) {
+    await client.page.FilesPageElement.appSideBar()
       .closeSidebar(100)
       .openPublicLinkDialog(resource)
     return client.page.FilesPageElement.publicLinksDialog().setPublicLinkDate(days)
   }
 )
 
-When('the public uses the webUI to access the last public link created by user {string}', async function (linkCreator) {
-  const lastShare = await sharingHelper.fetchLastPublicLinkShare(linkCreator)
-  if (lastShare.permissions === sharingHelper.PERMISSION_TYPES.create) {
-    return client.page.filesDropPage().navigateAndWaitTillLoaded(lastShare.token)
+When(
+  'the public uses the webUI to access the last public link created by user {string}',
+  async function(linkCreator) {
+    const lastShare = await sharingHelper.fetchLastPublicLinkShare(linkCreator)
+    if (lastShare.permissions === sharingHelper.PERMISSION_TYPES.create) {
+      return client.page.filesDropPage().navigateAndWaitTillLoaded(lastShare.token)
+    }
+    return client.page.publicLinkFilesPage().navigateAndWaitTillLoaded(lastShare.token)
   }
-  return client.page.publicLinkFilesPage().navigateAndWaitTillLoaded(lastShare.token)
-})
+)
 
-When('the public (tries to )open/opens the public link page of the last public link created by user {string}', async function (linkCreator) {
-  const lastShare = await sharingHelper.fetchLastPublicLinkShare(linkCreator)
-  return client.page.publicLinkFilesPage().navigateAndWaitTillLoaded(lastShare.token)
-})
+When(
+  'the public (tries to )open/opens the public link page of the last public link created by user {string}',
+  async function(linkCreator) {
+    const lastShare = await sharingHelper.fetchLastPublicLinkShare(linkCreator)
+    return client.page.publicLinkFilesPage().navigateAndWaitTillLoaded(lastShare.token)
+  }
+)
 
-When('the public (tries to )open/opens the public link page of the last public link created by user {string} with password {string}', async function (linkCreator, password) {
-  const lastShare = await sharingHelper.fetchLastPublicLinkShare(linkCreator)
-  await client.page.publicLinkFilesPage().navigateAndWaitForPasswordPage(lastShare.token)
-  return client.page.publicLinkPasswordPage().submitPublicLinkPassword(password)
-})
-
-When('the public uses the webUI to access the last public link created by user {string} with password {string}', async function (linkCreator, password) {
-  const lastShare = await sharingHelper.fetchLastPublicLinkShare(linkCreator)
-  if (lastShare.permissions === sharingHelper.PERMISSION_TYPES.create) {
-    await client.page.filesDropPage().navigateAndWaitForPasswordPage(lastShare.token)
-  } else {
+When(
+  'the public (tries to )open/opens the public link page of the last public link created by user {string} with password {string}',
+  async function(linkCreator, password) {
+    const lastShare = await sharingHelper.fetchLastPublicLinkShare(linkCreator)
     await client.page.publicLinkFilesPage().navigateAndWaitForPasswordPage(lastShare.token)
+    return client.page.publicLinkPasswordPage().submitPublicLinkPassword(password)
   }
-  return client.page.publicLinkPasswordPage().submitPublicLinkPassword(password)
+)
+
+When(
+  'the public uses the webUI to access the last public link created by user {string} with password {string}',
+  async function(linkCreator, password) {
+    const lastShare = await sharingHelper.fetchLastPublicLinkShare(linkCreator)
+    if (lastShare.permissions === sharingHelper.PERMISSION_TYPES.create) {
+      await client.page.filesDropPage().navigateAndWaitForPasswordPage(lastShare.token)
+    } else {
+      await client.page.publicLinkFilesPage().navigateAndWaitForPasswordPage(lastShare.token)
+    }
+    return client.page.publicLinkPasswordPage().submitPublicLinkPassword(password)
+  }
+)
+
+Then('user {string} should not have any public link', async function(sharer) {
+  const resp = await sharingHelper.getAllPublicLinkShares(sharer)
+  assert.strictEqual(resp.length, 0, 'User has shares. Response: ' + resp)
 })
 
-Then('user {string} should not have any public link',
-  async function (sharer) {
-    const resp = await sharingHelper.getAllPublicLinkShares(sharer)
-    assert.strictEqual(
-      resp.length, 0, 'User has shares. Response: ' + resp)
-  })
+Then('the fields of the last public link share response of user {string} should include', function(
+  linkCreator,
+  dataTable
+) {
+  const fieldsData = dataTable.rowsHash()
+  return sharingHelper.assertUserLastPublicShareDetails(linkCreator, fieldsData)
+})
 
-Then('the fields of the last public link share response of user {string} should include',
-  function (linkCreator, dataTable) {
-    const fieldsData = dataTable.rowsHash()
-    return sharingHelper.assertUserLastPublicShareDetails(linkCreator, fieldsData)
-  })
-
-Then('as user {string} the folder {string} should not have any public link', async function (sharer, resource) {
+Then('as user {string} the folder {string} should not have any public link', async function(
+  sharer,
+  resource
+) {
   const publicLinkShares = await sharingHelper.getAllPublicLinkShares(sharer)
   resource = path.resolve(resource)
   for (const share of publicLinkShares) {
     if (share.path === resource && share.share_type === SHARE_TYPES.public_link) {
       assert.fail(
-        'Expected share with user ' + sharer +
-        ' and resource ' + resource + ' is present!\n' + JSON.stringify(publicLinkShares)
+        'Expected share with user ' +
+          sharer +
+          ' and resource ' +
+          resource +
+          ' is present!\n' +
+          JSON.stringify(publicLinkShares)
       )
     }
   }
   return this
 })
 
-Then('the public should not get access to the publicly shared file', async function () {
-  const message = await client
-    .page
+Then('the public should not get access to the publicly shared file', async function() {
+  const message = await client.page
     .publicLinkPasswordPage()
     .submitLinkPasswordForm() // form is submitted as password input is filled in the step before this particular step in 'when' part
     .getResourceAccessDeniedMsg()
   return assert.strictEqual(
     'This resource is password-protected.',
     message,
-    'Resource protected message invalid, Found: ', message
+    'Resource protected message invalid, Found: ',
+    message
   )
 })
 
-When('the user edits the public link named {string} of file/folder/resource {string} changing following but not saving',
-  async function (linkName, resource, dataTable) {
+When(
+  'the user edits the public link named {string} of file/folder/resource {string} changing following but not saving',
+  async function(linkName, resource, dataTable) {
     const editData = dataTable.rowsHash()
-    await client.page.FilesPageElement
-      .appSideBar()
+    await client.page.FilesPageElement.appSideBar()
       .closeSidebar(100)
       .openPublicLinkDialog(resource)
-    return client.page.FilesPageElement
-      .publicLinksDialog()
-      .editPublicLink(linkName, editData)
-  })
+    return client.page.FilesPageElement.publicLinksDialog().editPublicLink(linkName, editData)
+  }
+)
 
-When('the user edits the public link named {string} of file/folder/resource {string} changing following',
-  async function (linkName, resource, dataTable) {
+When(
+  'the user edits the public link named {string} of file/folder/resource {string} changing following',
+  async function(linkName, resource, dataTable) {
     const editData = dataTable.rowsHash()
-    await client.page.FilesPageElement
-      .appSideBar()
+    await client.page.FilesPageElement.appSideBar()
       .closeSidebar(100)
       .openPublicLinkDialog(resource)
-    await client.page.FilesPageElement
-      .publicLinksDialog()
-      .editPublicLink(linkName, editData)
-    return client.page.FilesPageElement
-      .publicLinksDialog()
-      .savePublicLink()
-  })
+    await client.page.FilesPageElement.publicLinksDialog().editPublicLink(linkName, editData)
+    return client.page.FilesPageElement.publicLinksDialog().savePublicLink()
+  }
+)
 
-When('the user tries to edit expiration of the public link named {string} of file {string} to past date {string}',
-  async function (linkName, resource, pastDate) {
+When(
+  'the user tries to edit expiration of the public link named {string} of file {string} to past date {string}',
+  async function(linkName, resource, pastDate) {
     const api = client.page.FilesPageElement
     await api
       .appSideBar()
@@ -151,49 +163,46 @@ When('the user tries to edit expiration of the public link named {string} of fil
       .sharingDialog()
       .openExpirationDatePicker()
       .isExpiryDateDisabled(dateToSet)
-    return assert.ok(
-      isDisabled,
-      'Expected expiration date to be disabled but found not disabled'
-    )
-  })
+    return assert.ok(isDisabled, 'Expected expiration date to be disabled but found not disabled')
+  }
+)
 
-When('the user removes the public link named {string} of file/folder/resource {string} using the webUI',
-  async function (linkName, resource) {
-    await client.page
-      .FilesPageElement
-      .appSideBar()
+When(
+  'the user removes the public link named {string} of file/folder/resource {string} using the webUI',
+  async function(linkName, resource) {
+    await client.page.FilesPageElement.appSideBar()
       .closeSidebar(100)
       .openPublicLinkDialog(resource)
-    return client.page.FilesPageElement.publicLinksDialog()
-      .removePublicLink(linkName)
-  })
+    return client.page.FilesPageElement.publicLinksDialog().removePublicLink(linkName)
+  }
+)
 
-Then('public link named {string} should not be listed on the public links list on the webUI', async function (linkName) {
-  const isPresent = await client.page
-    .FilesPageElement
-    .publicLinksDialog()
-    .isPublicLinkPresent(linkName)
-  return assert.ok(
-    !isPresent,
-    `expected public-link '${linkName}' to be 'not listed' but got found`
-  )
-})
+Then(
+  'public link named {string} should not be listed on the public links list on the webUI',
+  async function(linkName) {
+    const isPresent = await client.page.FilesPageElement.publicLinksDialog().isPublicLinkPresent(
+      linkName
+    )
+    return assert.ok(
+      !isPresent,
+      `expected public-link '${linkName}' to be 'not listed' but got found`
+    )
+  }
+)
 
-async function findMatchingPublicLinkByName (name, role, resource, via = null) {
-  await client.page.FilesPageElement
-    .appSideBar()
+async function findMatchingPublicLinkByName(name, role, resource, via = null) {
+  await client.page.FilesPageElement.appSideBar()
     .closeSidebar(100)
     .openPublicLinkDialog(resource)
 
-  const shares = await client.page.FilesPageElement
-    .publicLinksDialog()
-    .getPublicLinkList()
+  const shares = await client.page.FilesPageElement.publicLinksDialog().getPublicLinkList()
 
   const share = shares.find(link => link.name === name)
 
   if (!share) {
     assert.fail(
-      `Link with name "${name}" was expected to be in share list but was not present. Found links: ` + shares.map(share => share.name)
+      `Link with name "${name}" was expected to be in share list but was not present. Found links: ` +
+        shares.map(share => share.name)
     )
   }
 
@@ -205,43 +214,42 @@ async function findMatchingPublicLinkByName (name, role, resource, via = null) {
 
 Then(
   'a link named {string} should be listed with role {string} in the public link list of file/folder/resource {string} on the webUI',
-  async function (name, role, resource) {
+  async function(name, role, resource) {
     await findMatchingPublicLinkByName(name, role, resource)
   }
 )
 
 Then(
   'a link named {string} should be listed with role {string} in the public link list of file/folder/resource {string} via {string} on the webUI',
-  async function (name, role, resource, via) {
+  async function(name, role, resource, via) {
     await findMatchingPublicLinkByName(name, role, resource, via)
   }
 )
 
-Then('the user should see an error message on the public link share dialog saying {string}', async function (expectedMessage) {
-  const actualMessage = await client.page.FilesPageElement
-    .publicLinksDialog()
-    .getErrorMessage()
-  return client.assert.strictEqual(actualMessage, expectedMessage)
+Then(
+  'the user should see an error message on the public link share dialog saying {string}',
+  async function(expectedMessage) {
+    const actualMessage = await client.page.FilesPageElement.publicLinksDialog().getErrorMessage()
+    return client.assert.strictEqual(actualMessage, expectedMessage)
+  }
+)
+
+When('the user closes the public link details sidebar', function() {
+  return client.page.FilesPageElement.appSideBar().closeSidebar(100)
 })
 
-When('the user closes the public link details sidebar', function () {
-  return client.page.FilesPageElement
-    .appSideBar()
-    .closeSidebar(100)
-})
-
-When('the user copies the url of public link named {string} of file/folder/resource {string} using the webUI',
-  async function (linkName, resource) {
-    await client.page.FilesPageElement
-      .appSideBar()
+When(
+  'the user copies the url of public link named {string} of file/folder/resource {string} using the webUI',
+  async function(linkName, resource) {
+    await client.page.FilesPageElement.appSideBar()
       .closeSidebar(100)
       .openPublicLinkDialog(resource)
-    return client.page.FilesPageElement.publicLinksDialog()
-      .copyPublicLinkURI(linkName)
-  })
+    return client.page.FilesPageElement.publicLinksDialog().copyPublicLinkURI(linkName)
+  }
+)
 
-Then('the tokens should be unique for each public links on the webUI', async function () {
+Then('the tokens should be unique for each public links on the webUI', async function() {
   const publicLinkUrls = await client.page.FilesPageElement.publicLinksDialog().getPublicLinkUrls()
-  const isUnique = publicLinkUrls.length === (new Set(publicLinkUrls).size)
+  const isUnique = publicLinkUrls.length === new Set(publicLinkUrls).size
   return assert.ok(isUnique)
 })

--- a/tests/acceptance/stepDefinitions/searchContext.js
+++ b/tests/acceptance/stepDefinitions/searchContext.js
@@ -1,6 +1,6 @@
 const { client } = require('nightwatch-api')
 const { When } = require('cucumber')
 
-When('the user searches for {string} using the webUI', function (searchTerm) {
+When('the user searches for {string} using the webUI', function(searchTerm) {
   return client.page.phoenixPage().search(searchTerm)
 })

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -22,11 +22,15 @@ const { COLLABORATOR_PERMISSION_ARRAY, calculateDate } = require('../helpers/sha
  * @param {string} role
  * @param {string} permissions
  */
-const userSharesFileOrFolderWithUserOrGroup = async function (
-  file, sharee, shareWithGroup, role, permissions = undefined, remote = false
+const userSharesFileOrFolderWithUserOrGroup = async function(
+  file,
+  sharee,
+  shareWithGroup,
+  role,
+  permissions = undefined,
+  remote = false
 ) {
-  const api = client.page
-    .FilesPageElement
+  const api = client.page.FilesPageElement
 
   await api
     .appSideBar()
@@ -42,7 +46,7 @@ const userSharesFileOrFolderWithUserOrGroup = async function (
  * @param {string} sharee
  * @param {string} role
  */
-const userSharesFileOrFolderWithUser = function (file, sharee, role) {
+const userSharesFileOrFolderWithUser = function(file, sharee, role) {
   return userSharesFileOrFolderWithUserOrGroup(file, sharee, false, role)
 }
 
@@ -52,7 +56,7 @@ const userSharesFileOrFolderWithUser = function (file, sharee, role) {
  * @param {string} sharee
  * @param {string} role
  */
-const userSharesFileOrFolderWithRemoteUser = function (file, sharee, role) {
+const userSharesFileOrFolderWithRemoteUser = function(file, sharee, role) {
   return userSharesFileOrFolderWithUserOrGroup(file, sharee, false, role, undefined, true)
 }
 /**
@@ -61,23 +65,38 @@ const userSharesFileOrFolderWithRemoteUser = function (file, sharee, role) {
  * @param {string} sharee
  * @param {string} role
  */
-const userSharesFileOrFolderWithGroup = function (file, sharee, role) {
+const userSharesFileOrFolderWithGroup = function(file, sharee, role) {
   return userSharesFileOrFolderWithUserOrGroup(file, sharee, true, role)
 }
 
-Given('user {string} from remote server has shared {string} with user {string} from local server', function (sharer, file, receiver) {
-  receiver = util.format('%s@%s', receiver, client.globals.backend_url)
-  return backendHelper.runOnRemoteBackend(
-    shareFileFolder, file, sharer, receiver, SHARE_TYPES.federated_cloud_share
-  )
-})
+Given(
+  'user {string} from remote server has shared {string} with user {string} from local server',
+  function(sharer, file, receiver) {
+    receiver = util.format('%s@%s', receiver, client.globals.backend_url)
+    return backendHelper.runOnRemoteBackend(
+      shareFileFolder,
+      file,
+      sharer,
+      receiver,
+      SHARE_TYPES.federated_cloud_share
+    )
+  }
+)
 
-Given('user {string} from remote server has shared {string} with user {string} from local server with {string} permissions', function (sharer, file, receiver, permission) {
-  receiver = util.format('%s@%s', receiver, client.globals.backend_url)
-  return backendHelper.runOnRemoteBackend(
-    shareFileFolder, file, sharer, receiver, SHARE_TYPES.federated_cloud_share, permission
-  )
-})
+Given(
+  'user {string} from remote server has shared {string} with user {string} from local server with {string} permissions',
+  function(sharer, file, receiver, permission) {
+    receiver = util.format('%s@%s', receiver, client.globals.backend_url)
+    return backendHelper.runOnRemoteBackend(
+      shareFileFolder,
+      file,
+      sharer,
+      receiver,
+      SHARE_TYPES.federated_cloud_share,
+      permission
+    )
+  }
+)
 
 /**
  * creates a new share
@@ -92,9 +111,14 @@ Given('user {string} from remote server has shared {string} with user {string} f
  * @param {string} extraParams.password Password of the share (public links)
  * @param {string} extraParams.expireDate Expiry date of the share
  */
-const shareFileFolder = function (
-  elementToShare, sharer, receiver = null, shareType = SHARE_TYPES.user,
-  permissionString = 'all', name = null, extraParams = {}
+const shareFileFolder = function(
+  elementToShare,
+  sharer,
+  receiver = null,
+  shareType = SHARE_TYPES.user,
+  permissionString = 'all',
+  name = null,
+  extraParams = {}
 ) {
   const params = new URLSearchParams()
   elementToShare = path.resolve(elementToShare)
@@ -114,9 +138,10 @@ const shareFileFolder = function (
     }
   }
   const url = 'apps/files_sharing/api/v1/shares'
-  return httpHelper.postOCS(url, sharer, params)
+  return httpHelper
+    .postOCS(url, sharer, params)
     .then(res => res.json())
-    .then(function (json) {
+    .then(function(json) {
       httpHelper.checkOCSStatus(json, 'Could not create share. Message: ' + json.ocs.meta.message)
     })
 }
@@ -129,34 +154,34 @@ const shareFileFolder = function (
  *
  * @return void
  */
-Given('user {string} has created a new share with following settings',
-  function (sharer, dataTable) {
-    const settings = dataTable.rowsHash()
-    const expireDate = settings.expireDate
-    let dateToSet = ''
-    if (typeof expireDate !== 'undefined') {
-      dateToSet = sharingHelper.calculateDate(expireDate)
+Given('user {string} has created a new share with following settings', function(sharer, dataTable) {
+  const settings = dataTable.rowsHash()
+  const expireDate = settings.expireDate
+  let dateToSet = ''
+  if (typeof expireDate !== 'undefined') {
+    dateToSet = sharingHelper.calculateDate(expireDate)
+  }
+  let targetShareType = null
+  if (settings.shareTypeString) {
+    targetShareType = sharingHelper.humanReadableShareTypeToNumber(settings.shareTypeString)
+  }
+  return shareFileFolder(
+    settings.path,
+    sharer,
+    settings.shareWith,
+    targetShareType,
+    settings.permissionString,
+    settings.name,
+    {
+      expireDate: dateToSet,
+      password: settings.password
     }
-    let targetShareType = null
-    if (settings.shareTypeString) {
-      targetShareType = sharingHelper.humanReadableShareTypeToNumber(settings.shareTypeString)
-    }
-    return shareFileFolder(
-      settings.path,
-      sharer,
-      settings.shareWith,
-      targetShareType,
-      settings.permissionString,
-      settings.name,
-      {
-        expireDate: dateToSet,
-        password: settings.password
-      }
-    )
-  })
+  )
+})
 
-When('the user tries to edit the collaborator {string} of file/folder/resource {string} changing following',
-  async function (collaborator, resource, dataTable) {
+When(
+  'the user tries to edit the collaborator {string} of file/folder/resource {string} changing following',
+  async function(collaborator, resource, dataTable) {
     const settings = dataTable.rowsHash()
     const api = client.page.FilesPageElement
     await api
@@ -164,14 +189,16 @@ When('the user tries to edit the collaborator {string} of file/folder/resource {
       .closeSidebar(100)
       .openSharingDialog(resource)
     return api.sharingDialog().changeCollaboratorSettings(collaborator, settings)
-  })
+  }
+)
 
-Then('the user should see an error message on the collaborator share dialog saying {string}', async function (expectedMessage) {
-  const actualMessage = await client.page.FilesPageElement
-    .sharingDialog()
-    .getErrorMessage()
-  return client.assert.strictEqual(actualMessage, expectedMessage)
-})
+Then(
+  'the user should see an error message on the collaborator share dialog saying {string}',
+  async function(expectedMessage) {
+    const actualMessage = await client.page.FilesPageElement.sharingDialog().getErrorMessage()
+    return client.assert.strictEqual(actualMessage, expectedMessage)
+  }
+)
 
 /**
  * sets up data into a standard format for creating new public link share
@@ -186,25 +213,17 @@ Then('the user should see an error message on the collaborator share dialog sayi
  * @param {string} data.permissions Allowed permissions on the share
  * @param {string} data.expireDate Expiry date of the share
  */
-const createPublicLink = function (sharer, data) {
+const createPublicLink = function(sharer, data) {
   let { path, permissions = 'read', name, password, expireDate } = data
 
   if (typeof expireDate !== 'undefined') {
     expireDate = sharingHelper.calculateDate(expireDate)
   }
 
-  return shareFileFolder(
-    path,
-    sharer,
-    null,
-    SHARE_TYPES.public_link,
-    permissions,
-    name,
-    {
-      password,
-      expireDate
-    }
-  )
+  return shareFileFolder(path, sharer, null, SHARE_TYPES.public_link, permissions, name, {
+    password,
+    expireDate
+  })
 }
 /**
  *
@@ -213,20 +232,26 @@ const createPublicLink = function (sharer, data) {
  * @param {string} role
  * @returns {Promise}
  */
-const assertCollaboratorslistContains = function (type, name, { role = null, via = null, resharedThrough = null, additionalInfo = null }) {
+const assertCollaboratorslistContains = function(
+  type,
+  name,
+  { role = null, via = null, resharedThrough = null, additionalInfo = null }
+) {
   if (type !== 'user' && type !== 'group' && type !== 'remote user') {
     throw new Error(`illegal type "${type}"`)
   }
 
-  return client.page.FilesPageElement.SharingDialog.collaboratorsDialog().getCollaboratorsList(null, name)
+  return client.page.FilesPageElement.SharingDialog.collaboratorsDialog()
+    .getCollaboratorsList(null, name)
     .then(shares => {
       const share = shares.find(share => {
-        return (name === share.displayName && type === share.shareType.toLowerCase())
+        return name === share.displayName && type === share.shareType.toLowerCase()
       })
 
       if (!share) {
         assert.fail(
-          `"${name}" with type "${type}" was expected to be in share list but was not present. Found collaborators: ` + shares.map(share => `name=${share.displayName} type=${share.shareType}`)
+          `"${name}" with type "${type}" was expected to be in share list but was not present. Found collaborators: ` +
+            shares.map(share => `name=${share.displayName} type=${share.shareType}`)
         )
       }
 
@@ -251,24 +276,27 @@ const assertCollaboratorslistContains = function (type, name, { role = null, via
  * @param {string} name
  * @returns {Promise}
  */
-const assertCollaboratorslistDoesNotContain = function (type, name) {
+const assertCollaboratorslistDoesNotContain = function(type, name) {
   if (type !== 'user' && type !== 'group') {
     throw new Error('illegal type')
   }
   const collaboratorsDialog = client.page.FilesPageElement.SharingDialog.collaboratorsDialog()
-  return collaboratorsDialog.getCollaboratorsList({
-    displayName: collaboratorsDialog.elements.collaboratorInformationSubName
-  }, name).then(shares => {
-    const share = shares.find(share => {
-      return (name === share.displayName && type === share.shareType.toLowerCase())
-    })
+  return collaboratorsDialog
+    .getCollaboratorsList(
+      {
+        displayName: collaboratorsDialog.elements.collaboratorInformationSubName
+      },
+      name
+    )
+    .then(shares => {
+      const share = shares.find(share => {
+        return name === share.displayName && type === share.shareType.toLowerCase()
+      })
 
-    if (share) {
-      assert.fail(
-        `"${name}" was expected to not be in share list but was present.`
-      )
-    }
-  })
+      if (share) {
+        assert.fail(`"${name}" was expected to not be in share list but was present.`)
+      }
+    })
 }
 
 /**
@@ -278,17 +306,15 @@ const assertCollaboratorslistDoesNotContain = function (type, name) {
  * @param {string} pattern
  * @return {string[]} groupMatchingPattern
  */
-const getUsersMatchingPattern = function (pattern) {
+const getUsersMatchingPattern = function(pattern) {
   // check if all created users that contain the pattern either in the display name or the username
   // are listed in the autocomplete list
   // in both cases the display name should be listed
   const users = userSettings.getCreatedUsers()
   const usersID = Object.keys(users)
-  return usersID.filter(
-    id => users[id].displayname.toLowerCase().includes(pattern) || id.includes(pattern)
-  ).map(
-    id => users[id].displayname
-  )
+  return usersID
+    .filter(id => users[id].displayname.toLowerCase().includes(pattern) || id.includes(pattern))
+    .map(id => users[id].displayname)
 }
 
 /**
@@ -297,7 +323,7 @@ const getUsersMatchingPattern = function (pattern) {
  * @param {string} pattern
  * @return {string[]} groupMatchingPattern
  */
-const getGroupsMatchingPattern = function (pattern) {
+const getGroupsMatchingPattern = function(pattern) {
   const groups = userSettings.getCreatedGroups()
   const groupMatchingPattern = groups.filter(group => group.toLowerCase().includes(pattern))
   return groupMatchingPattern
@@ -311,15 +337,19 @@ const getGroupsMatchingPattern = function (pattern) {
  * @param {string} alreadySharedUserOrGroup
  * @param {string} userOrGroup
  */
-const assertUsersGroupsWithPatternInAutocompleteListExcluding = async function (pattern, alreadySharedUserOrGroup, userOrGroup) {
+const assertUsersGroupsWithPatternInAutocompleteListExcluding = async function(
+  pattern,
+  alreadySharedUserOrGroup,
+  userOrGroup
+) {
   const sharingDialog = client.page.FilesPageElement.sharingDialog()
   const currentUserDisplayName = userSettings.getDisplayNameForUser(client.globals.currentUser)
-  const usersMatchingPattern = getUsersMatchingPattern(pattern).filter(
-    displayName => {
-      return displayName !== currentUserDisplayName && displayName !== alreadySharedUserOrGroup
-    }
+  const usersMatchingPattern = getUsersMatchingPattern(pattern).filter(displayName => {
+    return displayName !== currentUserDisplayName && displayName !== alreadySharedUserOrGroup
+  })
+  const groupMatchingPattern = getGroupsMatchingPattern(pattern).filter(
+    group => group !== alreadySharedUserOrGroup
   )
-  const groupMatchingPattern = getGroupsMatchingPattern(pattern).filter(group => group !== alreadySharedUserOrGroup)
 
   if (usersMatchingPattern.length + groupMatchingPattern.length > 5) {
     await sharingDialog.displayAllCollaboratorsAutocompleteResults()
@@ -340,18 +370,23 @@ const assertUsersGroupsWithPatternInAutocompleteListExcluding = async function (
  * @param {boolean} remote
  * @param {boolean} expectToSucceed
  */
-const userSharesFileOrFolderWithUserOrGroupWithExpirationDate = async function ({
-  resource, sharee, days, shareWithGroup = false, remote = false
+const userSharesFileOrFolderWithUserOrGroupWithExpirationDate = async function({
+  resource,
+  sharee,
+  days,
+  shareWithGroup = false,
+  remote = false
 }) {
-  const api = client.page
-    .FilesPageElement
+  const api = client.page.FilesPageElement
 
   await api
     .appSideBar()
     .closeSidebar(100)
     .openSharingDialog(resource)
 
-  return api.sharingDialog().shareWithUserOrGroup(sharee, shareWithGroup, 'Viewer', undefined, remote, days)
+  return api
+    .sharingDialog()
+    .shareWithUserOrGroup(sharee, shareWithGroup, 'Viewer', undefined, remote, days)
 }
 
 /**
@@ -359,9 +394,8 @@ const userSharesFileOrFolderWithUserOrGroupWithExpirationDate = async function (
  * @param {string} resource
  * @param {string} value
  */
-const checkCollaboratorsExpirationDate = async function (collaborator, resource, value) {
-  const api = client.page
-    .FilesPageElement
+const checkCollaboratorsExpirationDate = async function(collaborator, resource, value) {
+  const api = client.page.FilesPageElement
 
   await api
     .appSideBar()
@@ -371,11 +405,12 @@ const checkCollaboratorsExpirationDate = async function (collaborator, resource,
   return api.sharingDialog().checkExpirationDate(collaborator, value)
 }
 
-const checkReceivedSharesExpirationDate = function (user, target, days) {
+const checkReceivedSharesExpirationDate = function(user, target, days) {
   const apiURL = 'apps/files_sharing/api/v1/shares?shared_with_me=true'
-  return httpHelper.getOCS(apiURL, user)
+  return httpHelper
+    .getOCS(apiURL, user)
     .then(res => res.json())
-    .then(function (result) {
+    .then(function(result) {
       httpHelper.checkOCSStatus(result, 'Could not get shares. Message: ' + result.ocs.meta.message)
       const shares = result.ocs.data
       const currentDate = new Date()
@@ -386,7 +421,10 @@ const checkReceivedSharesExpirationDate = function (user, target, days) {
       const foundDates = []
 
       for (const share of shares) {
-        if (share.file_target === `/${target}` && expectedExpirationDate.getTime() === new Date(share.expiration).getTime()) {
+        if (
+          share.file_target === `/${target}` &&
+          expectedExpirationDate.getTime() === new Date(share.expiration).getTime()
+        ) {
           found = true
           break
         }
@@ -406,40 +444,54 @@ const checkReceivedSharesExpirationDate = function (user, target, days) {
     })
 }
 
-Given('user {string} has shared file/folder {string} with user {string}', function (sharer, elementToShare, receiver) {
+Given('user {string} has shared file/folder {string} with user {string}', function(
+  sharer,
+  elementToShare,
+  receiver
+) {
   return shareFileFolder(elementToShare, sharer, receiver)
 })
 
-Given('the user has shared file/folder {string} with user {string}', function (elementToShare, receiver) {
+Given('the user has shared file/folder {string} with user {string}', function(
+  elementToShare,
+  receiver
+) {
   return shareFileFolder(elementToShare, client.globals.currentUser, receiver)
 })
 
 Given(
   'user {string} has shared file/folder {string} with user {string} with {string} permission/permissions',
-  function (sharer, elementToShare, receiver, permissions) {
+  function(sharer, elementToShare, receiver, permissions) {
     return shareFileFolder(elementToShare, sharer, receiver, SHARE_TYPES.user, permissions)
   }
 )
 
-Given('user {string} has shared file/folder {string} with group {string}', function (sharer, elementToShare, receiver) {
+Given('user {string} has shared file/folder {string} with group {string}', function(
+  sharer,
+  elementToShare,
+  receiver
+) {
   return shareFileFolder(elementToShare, sharer, receiver, SHARE_TYPES.group)
 })
 
-Given('user {string} has shared file/folder {string} with group {string} with {string} permission/permissions',
-  function (sharer, elementToShare, receiver, permissions) {
-    return shareFileFolder(elementToShare, sharer, receiver, SHARE_TYPES.group, permissions)
-  })
-
 Given(
-  'user {string} has shared file/folder {string} with link with {string} permissions',
-  function (sharer, elementToShare, permissions) {
-    return shareFileFolder(elementToShare, sharer, null, SHARE_TYPES.public_link, permissions)
+  'user {string} has shared file/folder {string} with group {string} with {string} permission/permissions',
+  function(sharer, elementToShare, receiver, permissions) {
+    return shareFileFolder(elementToShare, sharer, receiver, SHARE_TYPES.group, permissions)
   }
 )
 
+Given('user {string} has shared file/folder {string} with link with {string} permissions', function(
+  sharer,
+  elementToShare,
+  permissions
+) {
+  return shareFileFolder(elementToShare, sharer, null, SHARE_TYPES.public_link, permissions)
+})
+
 Given(
   'user {string} has shared file/folder {string} with link with {string} permissions and password {string}',
-  function (sharer, elementToShare, permissions, password) {
+  function(sharer, elementToShare, permissions, password) {
     return shareFileFolder(
       elementToShare,
       sharer,
@@ -452,85 +504,80 @@ Given(
   }
 )
 
-Given('the administrator has enabled exclude groups from sharing', function () {
-  return runOcc(
-    [
-      'config:app:set core shareapi_exclude_groups --value=yes'
-    ]
-  )
+Given('the administrator has enabled exclude groups from sharing', function() {
+  return runOcc(['config:app:set core shareapi_exclude_groups --value=yes'])
 })
 
-Given('the administrator has excluded group {string} from sharing', async function (group) {
-  const configList = await runOcc([
-    'config:list'
-  ])
+Given('the administrator has excluded group {string} from sharing', async function(group) {
+  const configList = await runOcc(['config:list'])
   const config = _.get(configList, 'ocs.data.stdOut')
   const configParsed = JSON.parse(config)
-  const initialExcludedGroup = JSON.parse(_.get(configParsed, 'apps.core.shareapi_exclude_groups_list') || '[]')
+  const initialExcludedGroup = JSON.parse(
+    _.get(configParsed, 'apps.core.shareapi_exclude_groups_list') || '[]'
+  )
   if (!initialExcludedGroup.includes(group)) {
     initialExcludedGroup.push(group)
-    const resultGroupList = initialExcludedGroup.map((res) => '"' + res + '"')
+    const resultGroupList = initialExcludedGroup.map(res => '"' + res + '"')
     const resultToString = resultGroupList.join(',')
-    return runOcc(
-      [
-        'config:app:set',
-        'core',
-        'shareapi_exclude_groups_list',
-        '--value=[' + resultToString + ']'
-      ]
-    )
+    return runOcc([
+      'config:app:set',
+      'core',
+      'shareapi_exclude_groups_list',
+      '--value=[' + resultToString + ']'
+    ])
   }
 })
 
-Given('the administrator has set the minimum characters for sharing autocomplete to {string}', function (value) {
-  return runOcc(
-    ['config:system:set user.search_min_length --value=' + value]
-  )
+Given(
+  'the administrator has set the minimum characters for sharing autocomplete to {string}',
+  function(value) {
+    return runOcc(['config:system:set user.search_min_length --value=' + value])
+  }
+)
+
+Given('user {string} has created a public link with following settings', function(
+  sharer,
+  dataTable
+) {
+  return createPublicLink(sharer, dataTable.rowsHash())
 })
 
-Given('user {string} has created a public link with following settings',
-  function (sharer, dataTable) {
-    return createPublicLink(sharer, dataTable.rowsHash())
-  })
-
-Given('the administrator has excluded group {string} from receiving shares', async function (group) {
-  const configList = await runOcc([
-    'config:list'
-  ])
+Given('the administrator has excluded group {string} from receiving shares', async function(group) {
+  const configList = await runOcc(['config:list'])
   const config = _.get(configList, 'ocs.data.stdOut')
   const configParsed = JSON.parse(config)
-  const initialExcludedGroup = JSON.parse(_.get(configParsed, 'apps.files_sharing.blacklisted_receiver_groups') || '[]')
+  const initialExcludedGroup = JSON.parse(
+    _.get(configParsed, 'apps.files_sharing.blacklisted_receiver_groups') || '[]'
+  )
   if (!initialExcludedGroup.includes(group)) {
     initialExcludedGroup.push(group)
-    let excludedGroups = initialExcludedGroup.map((res) => `"${res}"`)
+    let excludedGroups = initialExcludedGroup.map(res => `"${res}"`)
     excludedGroups = excludedGroups.join(',')
-    return runOcc(
-      [
-        'config:app:set',
-        'files_sharing',
-        'blacklisted_receiver_groups',
-        '--value=[' + excludedGroups + ']'
-      ]
-    )
+    return runOcc([
+      'config:app:set',
+      'files_sharing',
+      'blacklisted_receiver_groups',
+      '--value=[' + excludedGroups + ']'
+    ])
   }
 })
 
-When('the user opens the share creation dialog in the webUI', function () {
+When('the user opens the share creation dialog in the webUI', function() {
   return client.page.FilesPageElement.SharingDialog.collaboratorsDialog().clickCreateShare()
 })
 
-When('the user cancels the share creation dialog in the webUI', function () {
+When('the user cancels the share creation dialog in the webUI', function() {
   return client.page.FilesPageElement.sharingDialog().clickCancel()
 })
 
-When('the user types {string} in the share-with-field', function (input) {
+When('the user types {string} in the share-with-field', function(input) {
   return client.page.FilesPageElement.sharingDialog().enterAutoComplete(input)
 })
 
-When('the user sets custom permission for current role of collaborator {string} for folder/file {string} to {string} using the webUI',
-  async function (user, resource, permissions) {
-    const api = client.page
-      .FilesPageElement
+When(
+  'the user sets custom permission for current role of collaborator {string} for folder/file {string} to {string} using the webUI',
+  async function(user, resource, permissions) {
+    const api = client.page.FilesPageElement
 
     await api
       .appSideBar()
@@ -538,31 +585,40 @@ When('the user sets custom permission for current role of collaborator {string} 
       .openSharingDialog(resource)
 
     return api.sharingDialog().changeCustomPermissionsTo(user, permissions)
-  })
+  }
+)
 
-When('the user disables all the custom permissions of collaborator {string} for file/folder {string} using the webUI',
-  async function (collaborator, resource) {
-    const api = client.page
-      .FilesPageElement
+When(
+  'the user disables all the custom permissions of collaborator {string} for file/folder {string} using the webUI',
+  async function(collaborator, resource) {
+    const api = client.page.FilesPageElement
 
-    await api.appSideBar()
+    await api
+      .appSideBar()
       .closeSidebar(100)
       .openSharingDialog(resource)
 
     return api.sharingDialog().disableAllCustomPermissions(collaborator)
-  })
+  }
+)
 
-const assertSharePermissions = async function (currentSharePermissions, permissions = undefined) {
+const assertSharePermissions = async function(currentSharePermissions, permissions = undefined) {
   let expectedPermissionArray
   if (permissions !== undefined) {
-    expectedPermissionArray = await client.page.FilesPageElement.sharingDialog().getArrayFromPermissionString(permissions)
+    expectedPermissionArray = await client.page.FilesPageElement.sharingDialog().getArrayFromPermissionString(
+      permissions
+    )
   }
   for (let i = 0; i < COLLABORATOR_PERMISSION_ARRAY.length; i++) {
     const permissionName = COLLABORATOR_PERMISSION_ARRAY[i]
     if (permissions !== undefined) {
       // check all the required permissions are set
       if (expectedPermissionArray.includes(permissionName)) {
-        assert.strictEqual(currentSharePermissions[permissionName], true, `Permission ${permissionName} is not set`)
+        assert.strictEqual(
+          currentSharePermissions[permissionName],
+          true,
+          `Permission ${permissionName} is not set`
+        )
       } else {
         // check unexpected permissions are not set or absent from the array
         assert.ok(!currentSharePermissions[permissionName], `Permission ${permissionName} is set`)
@@ -574,49 +630,54 @@ const assertSharePermissions = async function (currentSharePermissions, permissi
   }
 }
 
-Then('custom permission/permissions {string} should be set for user {string} for file/folder {string} on the webUI',
-  async function (permissions, user, resource) {
-    await client.page
-      .FilesPageElement
-      .appSideBar()
+Then(
+  'custom permission/permissions {string} should be set for user {string} for file/folder {string} on the webUI',
+  async function(permissions, user, resource) {
+    await client.page.FilesPageElement.appSideBar()
       .closeSidebar(100)
       .openSharingDialog(resource)
-    const currentSharePermissions = await client.page.FilesPageElement.sharingDialog()
-      .getDisplayedPermission(user)
+    const currentSharePermissions = await client.page.FilesPageElement.sharingDialog().getDisplayedPermission(
+      user
+    )
 
     return assertSharePermissions(currentSharePermissions, permissions)
-  })
+  }
+)
 
-Then('no custom permissions should be set for collaborator {string} for file/folder {string} on the webUI', async function (user, resource) {
-  await client.page
-    .FilesPageElement
-    .appSideBar()
-    .closeSidebar(100)
-    .openSharingDialog(resource)
-  const currentSharePermissions = await client.page.FilesPageElement.sharingDialog()
-    .getDisplayedPermission(user)
-  return assertSharePermissions(currentSharePermissions)
-})
+Then(
+  'no custom permissions should be set for collaborator {string} for file/folder {string} on the webUI',
+  async function(user, resource) {
+    await client.page.FilesPageElement.appSideBar()
+      .closeSidebar(100)
+      .openSharingDialog(resource)
+    const currentSharePermissions = await client.page.FilesPageElement.sharingDialog().getDisplayedPermission(
+      user
+    )
+    return assertSharePermissions(currentSharePermissions)
+  }
+)
 
-When('the user shares file/folder/resource {string} with group {string} as {string} using the webUI', userSharesFileOrFolderWithGroup)
+When(
+  'the user shares file/folder/resource {string} with group {string} as {string} using the webUI',
+  userSharesFileOrFolderWithGroup
+)
 
-When('the user shares file/folder/resource {string} with remote user {string} as {string} using the webUI', userSharesFileOrFolderWithRemoteUser)
+When(
+  'the user shares file/folder/resource {string} with remote user {string} as {string} using the webUI',
+  userSharesFileOrFolderWithRemoteUser
+)
 
-Then('it should not be possible to share file/folder {string} using the webUI', async function (resource) {
+Then('it should not be possible to share file/folder {string} using the webUI', async function(
+  resource
+) {
   const appSideBar = client.page.FilesPageElement.appSideBar()
   const filesList = client.page.FilesPageElement.filesList()
   // assumes current webUI state as no sidebar open for any resource
   const state = await filesList.isSharingButtonPresent(resource)
-  assert.ok(
-    !state,
-    `Error: Sharing button for resource ${resource} is not in disabled state`
-  )
+  assert.ok(!state, `Error: Sharing button for resource ${resource} is not in disabled state`)
   await filesList.openSideBar(resource)
   const sidebarLinkTabState = await appSideBar.isLinksTabPresentOnCurrentSidebar()
-  assert.ok(
-    !sidebarLinkTabState,
-    `Error: Sidebar 'Links' tab for resource ${resource} is present`
-  )
+  assert.ok(!sidebarLinkTabState, `Error: Sidebar 'Links' tab for resource ${resource} is present`)
   const sidebarCollaboratorsTabState = await appSideBar.isCollaboratorsTabPresentOnCurrentSidebar()
   assert.ok(
     !sidebarCollaboratorsTabState,
@@ -624,96 +685,131 @@ Then('it should not be possible to share file/folder {string} using the webUI', 
   )
 })
 
-When('the user shares file/folder/resource {string} with user {string} as {string} using the webUI', userSharesFileOrFolderWithUser)
+When(
+  'the user shares file/folder/resource {string} with user {string} as {string} using the webUI',
+  userSharesFileOrFolderWithUser
+)
 
-When('the user shares file/folder/resource {string} with user {string} as {string} with permission/permissions {string} using the webUI', function (resource, shareWithUser, role, permissions) {
-  return userSharesFileOrFolderWithUserOrGroup(resource, shareWithUser, false, role, permissions)
-})
-
-When('the user selects the following collaborators for the share as {string} with {string} permissions:', async function (role, permissions, usersTable) {
-  const users = usersTable.hashes()
-  const dialog = client.page.FilesPageElement.sharingDialog()
-
-  for (const { collaborator, type } of users) {
-    await dialog.selectCollaboratorForShare(collaborator, type === 'group')
+When(
+  'the user shares file/folder/resource {string} with user {string} as {string} with permission/permissions {string} using the webUI',
+  function(resource, shareWithUser, role, permissions) {
+    return userSharesFileOrFolderWithUserOrGroup(resource, shareWithUser, false, role, permissions)
   }
+)
 
-  await dialog.selectRoleForNewCollaborator(role)
-  await dialog.selectPermissionsOnPendingShare(permissions)
-})
+When(
+  'the user selects the following collaborators for the share as {string} with {string} permissions:',
+  async function(role, permissions, usersTable) {
+    const users = usersTable.hashes()
+    const dialog = client.page.FilesPageElement.sharingDialog()
 
-When('the user removes {string} as a collaborator from the share', function (user) {
+    for (const { collaborator, type } of users) {
+      await dialog.selectCollaboratorForShare(collaborator, type === 'group')
+    }
+
+    await dialog.selectRoleForNewCollaborator(role)
+    await dialog.selectPermissionsOnPendingShare(permissions)
+  }
+)
+
+When('the user removes {string} as a collaborator from the share', function(user) {
   return client.page.FilesPageElement.sharingDialog().removePendingCollaboratorForShare(user)
 })
 
-When('the user shares with the selected collaborators', function () {
+When('the user shares with the selected collaborators', function() {
   return client.page.FilesPageElement.sharingDialog()
     .confirmShare()
     .waitForOutstandingAjaxCalls()
 })
 
-Then('all users and groups that contain the string {string} in their name should be listed in the autocomplete list on the webUI', async function (pattern) {
-  const sharingDialog = client.page.FilesPageElement.sharingDialog()
-  const currentUserDisplayName = userSettings.getDisplayNameForUser(client.globals.currentUser)
+Then(
+  'all users and groups that contain the string {string} in their name should be listed in the autocomplete list on the webUI',
+  async function(pattern) {
+    const sharingDialog = client.page.FilesPageElement.sharingDialog()
+    const currentUserDisplayName = userSettings.getDisplayNameForUser(client.globals.currentUser)
 
-  // check if all created users that contain the pattern either in the display name or the username
-  // are listed in the autocomplete list
-  // in both cases the display name should be listed
-  const usersMatchingPattern = getUsersMatchingPattern(pattern).filter(
-    displayName => {
+    // check if all created users that contain the pattern either in the display name or the username
+    // are listed in the autocomplete list
+    // in both cases the display name should be listed
+    const usersMatchingPattern = getUsersMatchingPattern(pattern).filter(displayName => {
       return displayName !== currentUserDisplayName
-    }
-  )
-
-  // check if every created group that contains the pattern is listed in the autocomplete list
-  const groupMatchingPattern = getGroupsMatchingPattern(pattern)
-
-  if (usersMatchingPattern.length + groupMatchingPattern.length > 5) {
-    await sharingDialog.displayAllCollaboratorsAutocompleteResults()
-  }
-
-  return sharingDialog.assertUsersInAutocompleteList(usersMatchingPattern).assertGroupsInAutocompleteList(groupMatchingPattern)
-})
-
-Then('all users and groups that contain the string {string} in their name should be listed in the autocomplete list on the webUI except user {string}', function (pattern, alreadySharedUser) {
-  return assertUsersGroupsWithPatternInAutocompleteListExcluding(pattern, alreadySharedUser, 'user')
-})
-
-Then('all users and groups that contain the string {string} in their name should be listed in the autocomplete list on the webUI except group {string}', function (pattern, alreadySharedGroup) {
-  return assertUsersGroupsWithPatternInAutocompleteListExcluding(pattern, alreadySharedGroup, 'group')
-})
-
-Then('only users and groups that contain the string {string} in their name or displayname should be listed in the autocomplete list on the webUI', function (pattern) {
-  return client.page.FilesPageElement.sharingDialog().getShareAutocompleteItemsList()
-    .then(itemsList => {
-      itemsList.forEach(item => {
-        const displayedName = item.split('\n')[0]
-        var found = false
-        for (var userId in userSettings.getCreatedUsers()) {
-          const userDisplayName = userSettings.getDisplayNameForUser(userId)
-          if (userDisplayName === displayedName &&
-            (userDisplayName.toLowerCase().includes(pattern) || userId.toLowerCase().includes(pattern))
-          ) {
-            found = true
-          }
-        }
-        userSettings.getCreatedGroups().forEach(function (groupId) {
-          if (displayedName === groupId && groupId.toLowerCase().includes(pattern)) {
-            found = true
-          }
-        })
-        assert.strictEqual(
-          found,
-          true,
-          `"${displayedName}" was listed in autocomplete list, but should not have been. ` +
-          '(check if that is a manually added user/group)'
-        )
-      })
     })
-})
 
-Then('every item listed in the autocomplete list on the webUI should contain {string}', function (pattern) {
-  return client.page.FilesPageElement.sharingDialog().getShareAutocompleteItemsList()
+    // check if every created group that contains the pattern is listed in the autocomplete list
+    const groupMatchingPattern = getGroupsMatchingPattern(pattern)
+
+    if (usersMatchingPattern.length + groupMatchingPattern.length > 5) {
+      await sharingDialog.displayAllCollaboratorsAutocompleteResults()
+    }
+
+    return sharingDialog
+      .assertUsersInAutocompleteList(usersMatchingPattern)
+      .assertGroupsInAutocompleteList(groupMatchingPattern)
+  }
+)
+
+Then(
+  'all users and groups that contain the string {string} in their name should be listed in the autocomplete list on the webUI except user {string}',
+  function(pattern, alreadySharedUser) {
+    return assertUsersGroupsWithPatternInAutocompleteListExcluding(
+      pattern,
+      alreadySharedUser,
+      'user'
+    )
+  }
+)
+
+Then(
+  'all users and groups that contain the string {string} in their name should be listed in the autocomplete list on the webUI except group {string}',
+  function(pattern, alreadySharedGroup) {
+    return assertUsersGroupsWithPatternInAutocompleteListExcluding(
+      pattern,
+      alreadySharedGroup,
+      'group'
+    )
+  }
+)
+
+Then(
+  'only users and groups that contain the string {string} in their name or displayname should be listed in the autocomplete list on the webUI',
+  function(pattern) {
+    return client.page.FilesPageElement.sharingDialog()
+      .getShareAutocompleteItemsList()
+      .then(itemsList => {
+        itemsList.forEach(item => {
+          const displayedName = item.split('\n')[0]
+          var found = false
+          for (var userId in userSettings.getCreatedUsers()) {
+            const userDisplayName = userSettings.getDisplayNameForUser(userId)
+            if (
+              userDisplayName === displayedName &&
+              (userDisplayName.toLowerCase().includes(pattern) ||
+                userId.toLowerCase().includes(pattern))
+            ) {
+              found = true
+            }
+          }
+          userSettings.getCreatedGroups().forEach(function(groupId) {
+            if (displayedName === groupId && groupId.toLowerCase().includes(pattern)) {
+              found = true
+            }
+          })
+          assert.strictEqual(
+            found,
+            true,
+            `"${displayedName}" was listed in autocomplete list, but should not have been. ` +
+              '(check if that is a manually added user/group)'
+          )
+        })
+      })
+  }
+)
+
+Then('every item listed in the autocomplete list on the webUI should contain {string}', function(
+  pattern
+) {
+  return client.page.FilesPageElement.sharingDialog()
+    .getShareAutocompleteItemsList()
     .then(itemsList => {
       itemsList.forEach(item => {
         if (!item.toLowerCase().includes(pattern)) {
@@ -723,17 +819,18 @@ Then('every item listed in the autocomplete list on the webUI should contain {st
     })
 })
 
-When('the user selects role {string}', function (role) {
+When('the user selects role {string}', function(role) {
   return client.page.FilesPageElement.sharingDialog().selectRoleForNewCollaborator(role)
 })
 
-When('the user confirms the share', function () {
+When('the user confirms the share', function() {
   return client.page.FilesPageElement.sharingDialog().confirmShare()
 })
 
-Then('the users own name should not be listed in the autocomplete list on the webUI', function () {
+Then('the users own name should not be listed in the autocomplete list on the webUI', function() {
   const currentUserDisplayName = userSettings.getDisplayNameForUser(client.globals.currentUser)
-  return client.page.FilesPageElement.sharingDialog().getShareAutocompleteItemsList()
+  return client.page.FilesPageElement.sharingDialog()
+    .getShareAutocompleteItemsList()
     .then(itemsList => {
       itemsList.forEach(item => {
         const displayedName = item.split('\n')[0]
@@ -746,34 +843,62 @@ Then('the users own name should not be listed in the autocomplete list on the we
     })
 })
 
-Then('{string} {string} should not be listed in the autocomplete list on the webUI', function (type, displayName) {
-  return client.page.FilesPageElement.sharingDialog().assertCollaboratorsInAutocompleteList(displayName, type, false)
+Then('{string} {string} should not be listed in the autocomplete list on the webUI', function(
+  type,
+  displayName
+) {
+  return client.page.FilesPageElement.sharingDialog().assertCollaboratorsInAutocompleteList(
+    displayName,
+    type,
+    false
+  )
 })
 
-Then('{string} {string} should be listed in the autocomplete list on the webUI', function (type, displayName) {
-  return client.page.FilesPageElement.sharingDialog().assertCollaboratorsInAutocompleteList(displayName, type)
+Then('{string} {string} should be listed in the autocomplete list on the webUI', function(
+  type,
+  displayName
+) {
+  return client.page.FilesPageElement.sharingDialog().assertCollaboratorsInAutocompleteList(
+    displayName,
+    type
+  )
 })
 
-When('the user opens the share dialog for file/folder/resource {string} using the webUI', function (file) {
+When('the user opens the share dialog for file/folder/resource {string} using the webUI', function(
+  file
+) {
   return client.page.FilesPageElement.filesList().openSharingDialog(file)
 })
 
-When('the user opens the link share dialog for file/folder/resource {string} using the webUI', function (file) {
-  return client.page.FilesPageElement.filesList().openPublicLinkDialog(file)
-})
+When(
+  'the user opens the link share dialog for file/folder/resource {string} using the webUI',
+  function(file) {
+    return client.page.FilesPageElement.filesList().openPublicLinkDialog(file)
+  }
+)
 
-When('the user deletes {string} as collaborator for the current file/folder using the webUI', function (user) {
-  return client.page.FilesPageElement.SharingDialog.collaboratorsDialog().deleteShareWithUserGroup(user)
-})
+When(
+  'the user deletes {string} as collaborator for the current file/folder using the webUI',
+  function(user) {
+    return client.page.FilesPageElement.SharingDialog.collaboratorsDialog().deleteShareWithUserGroup(
+      user
+    )
+  }
+)
 
-When('the user deletes {string} as remote collaborator for the current file/folder using the webUI', function (user) {
-  user = util.format('%s@%s', user, client.globals.remote_backend_url)
-  return client.page.FilesPageElement.SharingDialog.collaboratorsDialog().deleteShareWithUserGroup(user)
-})
+When(
+  'the user deletes {string} as remote collaborator for the current file/folder using the webUI',
+  function(user) {
+    user = util.format('%s@%s', user, client.globals.remote_backend_url)
+    return client.page.FilesPageElement.SharingDialog.collaboratorsDialog().deleteShareWithUserGroup(
+      user
+    )
+  }
+)
 
 When(
   'the user changes the collaborator role of {string} for file/folder {string} to {string} using the webUI',
-  async function (collaborator, resource, newRole) {
+  async function(collaborator, resource, newRole) {
     const api = client.page.FilesPageElement
     await api
       .appSideBar()
@@ -784,299 +909,432 @@ When(
   }
 )
 
-When('the user (tries to )edit/edits the collaborator expiry date of {string} of file/folder/resource {string} to {string} days/day using the webUI',
-  async function (collaborator, resource, days) {
+When(
+  'the user (tries to )edit/edits the collaborator expiry date of {string} of file/folder/resource {string} to {string} days/day using the webUI',
+  async function(collaborator, resource, days) {
     const api = client.page.FilesPageElement
     await api
       .appSideBar()
       .closeSidebar(100)
       .openSharingDialog(resource)
     return api.sharingDialog().changeCollaboratorExpiryDate(collaborator, days)
-  })
+  }
+)
 
-Then('user {string} should be listed as {string} in the collaborators list on the webUI', function (user, role) {
+Then('user {string} should be listed as {string} in the collaborators list on the webUI', function(
+  user,
+  role
+) {
   return assertCollaboratorslistContains('user', user, { role })
 })
 
-Then('the share {string} shared with user {string} should have no expiration information displayed on the WebUI', async function (item, user) {
-  await client.page.FilesPageElement.filesList().clickRow(item)
-  await client.page.filesPage().selectTabInSidePanel('collaborators')
-  const elementID = await client.page.FilesPageElement.SharingDialog.collaboratorsDialog().getCollaboratorExpirationInfo(user)
-  return assert.strictEqual(elementID, undefined, 'The expiration information was present unexpectedly')
-})
-
-Then('the expiration information displayed on the WebUI of share {string} shared with user {string} should be {string} or {string}', async function (item, user, information1, information2) {
-  await client.page.FilesPageElement.filesList().clickRow(item)
-  await client.page.filesPage().selectTabInSidePanel('collaborators')
-  const actualInfo = await client.page.FilesPageElement.SharingDialog.collaboratorsDialog().getCollaboratorExpirationInfo(user)
-  if (actualInfo === information1) {
-    return true
-  } else {
-    return assert.strictEqual(actualInfo, information2,
-      `The expected expiration information was either '${information1}' or '${information2}', but got '${actualInfo}'`)
+Then(
+  'the share {string} shared with user {string} should have no expiration information displayed on the WebUI',
+  async function(item, user) {
+    await client.page.FilesPageElement.filesList().clickRow(item)
+    await client.page.filesPage().selectTabInSidePanel('collaborators')
+    const elementID = await client.page.FilesPageElement.SharingDialog.collaboratorsDialog().getCollaboratorExpirationInfo(
+      user
+    )
+    return assert.strictEqual(
+      elementID,
+      undefined,
+      'The expiration information was present unexpectedly'
+    )
   }
-})
+)
 
-Then('remote user {string} should be listed as {string} via {string} in the collaborators list on the webUI', function (user, role, via) {
-  user = util.format('%s@%s', user, client.globals.remote_backend_url)
-  return assertCollaboratorslistContains('remote user', user, { role, via })
-})
+Then(
+  'the expiration information displayed on the WebUI of share {string} shared with user {string} should be {string} or {string}',
+  async function(item, user, information1, information2) {
+    await client.page.FilesPageElement.filesList().clickRow(item)
+    await client.page.filesPage().selectTabInSidePanel('collaborators')
+    const actualInfo = await client.page.FilesPageElement.SharingDialog.collaboratorsDialog().getCollaboratorExpirationInfo(
+      user
+    )
+    if (actualInfo === information1) {
+      return true
+    } else {
+      return assert.strictEqual(
+        actualInfo,
+        information2,
+        `The expected expiration information was either '${information1}' or '${information2}', but got '${actualInfo}'`
+      )
+    }
+  }
+)
 
-Then('user {string} should be listed as {string} via {string} in the collaborators list on the webUI', function (user, role, via) {
-  return assertCollaboratorslistContains('user', user, { role, via })
-})
+Then(
+  'remote user {string} should be listed as {string} via {string} in the collaborators list on the webUI',
+  function(user, role, via) {
+    user = util.format('%s@%s', user, client.globals.remote_backend_url)
+    return assertCollaboratorslistContains('remote user', user, { role, via })
+  }
+)
 
-Then('user {string} should be listed as {string} reshared through {string} in the collaborators list on the webUI', function (user, role, resharedThrough) {
-  return assertCollaboratorslistContains('user', user, { role, resharedThrough })
-})
+Then(
+  'user {string} should be listed as {string} via {string} in the collaborators list on the webUI',
+  function(user, role, via) {
+    return assertCollaboratorslistContains('user', user, { role, via })
+  }
+)
 
-Then('user {string} should be listed as {string} reshared through {string} via {string} in the collaborators list on the webUI', function (user, role, resharedThrough, via) {
-  return assertCollaboratorslistContains('user', user, { role, resharedThrough, via })
-})
+Then(
+  'user {string} should be listed as {string} reshared through {string} in the collaborators list on the webUI',
+  function(user, role, resharedThrough) {
+    return assertCollaboratorslistContains('user', user, { role, resharedThrough })
+  }
+)
 
-Then('user {string} should be listed with additional info {string} in the collaborators list on the webUI', function (user, additionalInfo) {
-  return assertCollaboratorslistContains('user', user, { additionalInfo })
-})
+Then(
+  'user {string} should be listed as {string} reshared through {string} via {string} in the collaborators list on the webUI',
+  function(user, role, resharedThrough, via) {
+    return assertCollaboratorslistContains('user', user, { role, resharedThrough, via })
+  }
+)
 
-Then('user {string} should be listed without additional info in the collaborators list on the webUI', function (user) {
-  return assertCollaboratorslistContains('user', user, { additionalInfo: false })
-})
+Then(
+  'user {string} should be listed with additional info {string} in the collaborators list on the webUI',
+  function(user, additionalInfo) {
+    return assertCollaboratorslistContains('user', user, { additionalInfo })
+  }
+)
 
-Then('user {string} should be listed as {string} in the collaborators list for file/folder/resource {string} on the webUI',
-  async function (user, role, resource) {
-    await client.page
-      .FilesPageElement
-      .appSideBar()
+Then(
+  'user {string} should be listed without additional info in the collaborators list on the webUI',
+  function(user) {
+    return assertCollaboratorslistContains('user', user, { additionalInfo: false })
+  }
+)
+
+Then(
+  'user {string} should be listed as {string} in the collaborators list for file/folder/resource {string} on the webUI',
+  async function(user, role, resource) {
+    await client.page.FilesPageElement.appSideBar()
       .closeSidebar(100)
       .openSharingDialog(resource)
 
     return assertCollaboratorslistContains('user', user, { role })
-  })
+  }
+)
 
-Then('group {string} should be listed as {string} in the collaborators list on the webUI', function (group, role) {
+Then('group {string} should be listed as {string} in the collaborators list on the webUI', function(
+  group,
+  role
+) {
   return assertCollaboratorslistContains('group', group, { role })
 })
 
-Then('group {string} should be listed as {string} via {string} in the collaborators list on the webUI', function (group, role, via) {
-  return assertCollaboratorslistContains('group', group, { role, via })
-})
+Then(
+  'group {string} should be listed as {string} via {string} in the collaborators list on the webUI',
+  function(group, role, via) {
+    return assertCollaboratorslistContains('group', group, { role, via })
+  }
+)
 
-Then('group {string} should be listed as {string} in the collaborators list for file/folder/resource {string} on the webUI',
-  async function (group, role, resource) {
-    await client.page
-      .FilesPageElement
-      .appSideBar()
+Then(
+  'group {string} should be listed as {string} in the collaborators list for file/folder/resource {string} on the webUI',
+  async function(group, role, resource) {
+    await client.page.FilesPageElement.appSideBar()
       .closeSidebar(100)
       .openSharingDialog(resource)
     return assertCollaboratorslistContains('group', group, { role })
-  })
+  }
+)
 
-Then('user {string} should not be listed in the collaborators list on the webUI', function (user) {
+Then('user {string} should not be listed in the collaborators list on the webUI', function(user) {
   return assertCollaboratorslistDoesNotContain('user', user)
 })
 
-Then('group {string} should not be listed in the collaborators list on the webUI', function (group) {
+Then('group {string} should not be listed in the collaborators list on the webUI', function(group) {
   return assertCollaboratorslistDoesNotContain('group', group)
 })
 
-Then('user {string} should have received a share with these details:', function (user, expectedDetailsTable) {
-  return sharingHelper.assertUserHasShareWithDetails(user, expectedDetailsTable, { shared_with_me: true })
+Then('user {string} should have received a share with these details:', function(
+  user,
+  expectedDetailsTable
+) {
+  return sharingHelper.assertUserHasShareWithDetails(user, expectedDetailsTable, {
+    shared_with_me: true
+  })
 })
 
-Given('user {string} has created a new public link for resource {string}', function (user, resource) {
+Given('user {string} has created a new public link for resource {string}', function(
+  user,
+  resource
+) {
   return shareFileFolder(resource, user, '', SHARE_TYPES.public_link)
 })
 
-Then('user {string} should have shared a file/folder with these details:', function (user, expectedDetailsTable) {
-  return sharingHelper.assertUserHasShareWithDetails(user, expectedDetailsTable, { shared_with_me: false })
+Then('user {string} should have shared a file/folder with these details:', function(
+  user,
+  expectedDetailsTable
+) {
+  return sharingHelper.assertUserHasShareWithDetails(user, expectedDetailsTable, {
+    shared_with_me: false
+  })
 })
 
-Then('user {string} should have shared a file/folder {string} with these details:', function (user, path, expectedDetailsTable) {
-  return sharingHelper.assertUserHasShareWithDetails(user, expectedDetailsTable, { shared_with_me: false, path })
+Then('user {string} should have shared a file/folder {string} with these details:', function(
+  user,
+  path,
+  expectedDetailsTable
+) {
+  return sharingHelper.assertUserHasShareWithDetails(user, expectedDetailsTable, {
+    shared_with_me: false,
+    path
+  })
 })
 
-Then('user {string} should have a share with these details:', function (user, expectedDetailsTable) {
+Then('user {string} should have a share with these details:', function(user, expectedDetailsTable) {
   return sharingHelper.assertUserHasShareWithDetails(user, expectedDetailsTable)
 })
 
-Then('the user should not be able to share file/folder/resource {string} using the webUI', async function (resource) {
+Then(
+  'the user should not be able to share file/folder/resource {string} using the webUI',
+  async function(resource) {
+    const api = client.page.FilesPageElement
+    await api
+      .appSideBar()
+      .closeSidebar(100)
+      .openSharingDialog(resource)
+    const shareResponse = await api.sharingDialog().getSharingPermissionMsg()
+    const noSharePermissionsMsgFormat = "You don't have permission to share this %s."
+    const noSharePermissionsFileMsg = util.format(noSharePermissionsMsgFormat, 'file')
+    const noSharePermissionsFolderMsg = util.format(noSharePermissionsMsgFormat, 'folder')
+    return assert.ok(
+      noSharePermissionsFileMsg === shareResponse || noSharePermissionsFolderMsg === shareResponse,
+      `Expected: no permission to share resource '${resource}' but found: '${shareResponse}'`
+    )
+  }
+)
+
+Then('the collaborators list for file/folder/resource {string} should be empty', async function(
+  resource
+) {
   const api = client.page.FilesPageElement
   await api
     .appSideBar()
     .closeSidebar(100)
     .openSharingDialog(resource)
-  const shareResponse = await api
-    .sharingDialog()
-    .getSharingPermissionMsg()
-  const noSharePermissionsMsgFormat = "You don't have permission to share this %s."
-  const noSharePermissionsFileMsg = util.format(noSharePermissionsMsgFormat, 'file')
-  const noSharePermissionsFolderMsg = util.format(noSharePermissionsMsgFormat, 'folder')
-  return assert.ok(
-    noSharePermissionsFileMsg === shareResponse ||
-    noSharePermissionsFolderMsg === shareResponse,
-    `Expected: no permission to share resource '${resource}' but found: '${shareResponse}'`
+
+  const count = (await api.SharingDialog.collaboratorsDialog().getCollaboratorsList({})).length
+  assert.strictEqual(
+    count,
+    0,
+    `Expected to have no collaborators for '${resource}', Found: ${count}`
   )
 })
 
-Then('the collaborators list for file/folder/resource {string} should be empty', async function (resource) {
-  const api = client.page.FilesPageElement
-  await api
-    .appSideBar()
-    .closeSidebar(100)
-    .openSharingDialog(resource)
-
-  const count = (await api
-    .SharingDialog.collaboratorsDialog()
-    .getCollaboratorsList({})
-  ).length
-  assert.strictEqual(count, 0, `Expected to have no collaborators for '${resource}', Found: ${count}`)
+Then('the expiration date field should be marked as required on the WebUI', async function() {
+  await client.page.FilesPageElement.sharingDialog().waitForElementVisible(
+    '@requiredLabelInCollaboratorsExpirationDate'
+  )
 })
 
-Then('the expiration date field should be marked as required on the WebUI', async function () {
-  await client.page.FilesPageElement.sharingDialog().waitForElementVisible('@requiredLabelInCollaboratorsExpirationDate')
-})
-
-Then('the expiration date for {string} should be disabled on the WebUI', async function (expiration) {
+Then('the expiration date for {string} should be disabled on the WebUI', async function(
+  expiration
+) {
   const dateToSet = calculateDate(expiration)
   const isEnabled = await client.page.FilesPageElement.sharingDialog()
     .openExpirationDatePicker()
     .setExpirationDate(dateToSet)
   return assert.strictEqual(
-    isEnabled, false,
-    `The expiration date for ${expiration} was expected to be disabled, but is found enabled`)
+    isEnabled,
+    false,
+    `The expiration date for ${expiration} was expected to be disabled, but is found enabled`
+  )
 })
 
-Then('the current collaborators list should have order {string}', async function (expectedNames) {
-  const actualNames = (await client.page.FilesPageElement.SharingDialog.collaboratorsDialog().getCollaboratorsListNames()).join(',')
-  assert.strictEqual(actualNames, expectedNames, `Expected to have collaborators in order '${expectedNames}', Found: ${actualNames}`)
+Then('the current collaborators list should have order {string}', async function(expectedNames) {
+  const actualNames = (await client.page.FilesPageElement.SharingDialog.collaboratorsDialog().getCollaboratorsListNames()).join(
+    ','
+  )
+  assert.strictEqual(
+    actualNames,
+    expectedNames,
+    `Expected to have collaborators in order '${expectedNames}', Found: ${actualNames}`
+  )
 })
 
-Then('file/folder {string} shared by {string} should be in {string} state on the webUI',
-  async function (resource, sharer, expectedStatus) {
-    const currentStatus = await client.page.sharedWithMePage().getShareStatusOfResource(resource, sharer)
+Then(
+  'file/folder {string} shared by {string} should be in {string} state on the webUI',
+  async function(resource, sharer, expectedStatus) {
+    const currentStatus = await client.page
+      .sharedWithMePage()
+      .getShareStatusOfResource(resource, sharer)
     return assert.strictEqual(
       currentStatus,
       expectedStatus,
       `Expected resource '${resource}' shared by '${sharer}' to be
       in state '${expectedStatus}' but it is in state: '${currentStatus}'!`
     )
-  })
+  }
+)
 
-When('the user declines share {string} offered by user {string} using the webUI', function (filename, user) {
+When('the user declines share {string} offered by user {string} using the webUI', function(
+  filename,
+  user
+) {
   return client.page.sharedWithMePage().declineAcceptFile('Decline', filename, user)
 })
 
-When('the user accepts share {string} offered by user {string} using the webUI', function (filename, user) {
+When('the user accepts share {string} offered by user {string} using the webUI', function(
+  filename,
+  user
+) {
   return client.page.sharedWithMePage().declineAcceptFile('Accept', filename, user)
 })
 
-Then('the file {string} shared by {string} should be in {string} state on the webUI after a page reload',
-  async function (filename, sharer, expectedStatus) {
+Then(
+  'the file {string} shared by {string} should be in {string} state on the webUI after a page reload',
+  async function(filename, sharer, expectedStatus) {
     await client.refresh()
-    const currentStatus = await client.page.sharedWithMePage().getShareStatusOfResource(filename, sharer)
+    const currentStatus = await client.page
+      .sharedWithMePage()
+      .getShareStatusOfResource(filename, sharer)
     return assert.strictEqual(
       currentStatus,
       expectedStatus,
       `Expected resource '${filename}'  shared by '${sharer}' to
        be in state '${expectedStatus}' but it is in state: '${currentStatus}'!`
     )
-  })
+  }
+)
 
-Then('the autocomplete list should not be displayed on the webUI', async function () {
+Then('the autocomplete list should not be displayed on the webUI', async function() {
   const isVisible = await client.page.FilesPageElement.sharingDialog().isAutocompleteListVisible()
   return assert.ok(!isVisible, 'Expected: autocomplete list "not visible" but found "visible"')
 })
 
-Given('user {string} has declined the share {string} offered by user {string}', function (user, filename, sharer) {
+Given('user {string} has declined the share {string} offered by user {string}', function(
+  user,
+  filename,
+  sharer
+) {
   return sharingHelper.declineShare(filename, user, sharer)
 })
 
-Given('user {string} has accepted the share {string} offered by user {code}', function (user, filename, sharer) {
+Given('user {string} has accepted the share {string} offered by user {code}', function(
+  user,
+  filename,
+  sharer
+) {
   return sharingHelper.acceptShare(filename, user, sharer)
 })
 
-Then('the file {string} shared by {string} should not be in {string} state',
-  async function (filename, sharer, expectedStatus) {
-    const currentStatus = await client.page.sharedWithMePage().getShareStatusOfResource(filename, sharer)
-    return assert.notStrictEqual(
-      currentStatus,
-      expectedStatus,
-      `Expected resource '${filename}' shared by '${sharer}' not to be
+Then('the file {string} shared by {string} should not be in {string} state', async function(
+  filename,
+  sharer,
+  expectedStatus
+) {
+  const currentStatus = await client.page
+    .sharedWithMePage()
+    .getShareStatusOfResource(filename, sharer)
+  return assert.notStrictEqual(
+    currentStatus,
+    expectedStatus,
+    `Expected resource '${filename}' shared by '${sharer}' not to be
       present with status '${expectedStatus}' but got found: '${currentStatus}'!`
-    )
-  })
+  )
+})
 
-Then('file/folder {string} should be marked as shared by {string} on the webUI',
-  async function (element, sharer) {
-    const username = await client.page.sharedWithMePage().getSharedByUser(element)
-    return assert.strictEqual(
-      username,
-      sharer,
-      `Expected username: '${sharer}', but found '${username}'`
-    )
-  })
+Then('file/folder {string} should be marked as shared by {string} on the webUI', async function(
+  element,
+  sharer
+) {
+  const username = await client.page.sharedWithMePage().getSharedByUser(element)
+  return assert.strictEqual(
+    username,
+    sharer,
+    `Expected username: '${sharer}', but found '${username}'`
+  )
+})
 
-Then('user {string} should not have created any shares', async function (user) {
+Then('user {string} should not have created any shares', async function(user) {
   const shares = await sharingHelper.getAllSharesSharedByUser(user)
   assert.strictEqual(shares.length, 0, 'There should not be any share, but there are')
 })
 
-Then('the following resources should have the following collaborators', async function (dataTable) {
+Then('the following resources should have the following collaborators', async function(dataTable) {
   for (const { fileName, expectedCollaborators } of dataTable.hashes()) {
-    const collaboratorsArray = await client
-      .page.FilesPageElement.filesList().getCollaboratorsForResource(fileName)
+    const collaboratorsArray = await client.page.FilesPageElement.filesList().getCollaboratorsForResource(
+      fileName
+    )
 
     const expectedCollaboratorsArray = expectedCollaborators.split(',').map(s => s.trim())
     assert.ok(
-      _.intersection(collaboratorsArray, expectedCollaboratorsArray).length === expectedCollaboratorsArray.length,
-      `Expected collaborators to be the same for "${fileName}": expected [` + expectedCollaboratorsArray.join(', ') + '] got [' + collaboratorsArray.join(', ') + ']'
+      _.intersection(collaboratorsArray, expectedCollaboratorsArray).length ===
+        expectedCollaboratorsArray.length,
+      `Expected collaborators to be the same for "${fileName}": expected [` +
+        expectedCollaboratorsArray.join(', ') +
+        '] got [' +
+        collaboratorsArray.join(', ') +
+        ']'
     )
   }
 })
 
-When('the user (tries to )share/shares file/folder/resource {string} with user {string} which expires in {string} day/days using the webUI',
-  function (resource, sharee, days) {
+When(
+  'the user (tries to )share/shares file/folder/resource {string} with user {string} which expires in {string} day/days using the webUI',
+  function(resource, sharee, days) {
     return userSharesFileOrFolderWithUserOrGroupWithExpirationDate({ resource, sharee, days })
-  })
+  }
+)
 
-When('the user (tries to )share/shares file/folder/resource {string} with group {string} which expires in {string} day/days using the webUI',
-  function (resource, sharee, days) {
-    return userSharesFileOrFolderWithUserOrGroupWithExpirationDate({ resource, sharee, days, shareWithGroup: true })
-  })
+When(
+  'the user (tries to )share/shares file/folder/resource {string} with group {string} which expires in {string} day/days using the webUI',
+  function(resource, sharee, days) {
+    return userSharesFileOrFolderWithUserOrGroupWithExpirationDate({
+      resource,
+      sharee,
+      days,
+      shareWithGroup: true
+    })
+  }
+)
 
-When('the user shares file/folder/resource {string} with user {string} using the webUI', function (resource, user) {
+When('the user shares file/folder/resource {string} with user {string} using the webUI', function(
+  resource,
+  user
+) {
   return userSharesFileOrFolderWithUser(resource, user, 'Viewer')
 })
 
-Then('the fields of the {string} collaborator for file/folder/resource {string} should contain expiration date with value {string} on the webUI', function (collaborator, resource, value) {
-  return checkCollaboratorsExpirationDate(collaborator, resource, value)
-})
+Then(
+  'the fields of the {string} collaborator for file/folder/resource {string} should contain expiration date with value {string} on the webUI',
+  function(collaborator, resource, value) {
+    return checkCollaboratorsExpirationDate(collaborator, resource, value)
+  }
+)
 
-Then('user {string} should have received a share with target {string} and expiration date in {int} day/days', function (user, target, days) {
-  return checkReceivedSharesExpirationDate(user, target, days)
-})
+Then(
+  'user {string} should have received a share with target {string} and expiration date in {int} day/days',
+  function(user, target, days) {
+    return checkReceivedSharesExpirationDate(user, target, days)
+  }
+)
 
-Then('the expiration date shown on the webUI should be {string} days',
-  async function (expectedDays) {
-    let expectedDate = sharingHelper.calculateDate(expectedDays)
-    expectedDate = new Date((Date.parse(expectedDate)))
-    const expectedDateString = expectedDate.toLocaleString('en-GB', { month: 'short' }) + ' ' +
-      (expectedDate.getDate()).toString() + ', ' + expectedDate.getFullYear()
-    const dateStringFromInputField = await client.page.FilesPageElement
-      .sharingDialog()
-      .getExpirationDateFromInputField()
-    assert.strictEqual(
-      dateStringFromInputField,
-      expectedDateString,
-      `Expected: Expiration date field with ${expectedDateString}, but found ${dateStringFromInputField}`
-    )
-  })
-
-Then('it should not be possible to save the pending share on the webUI', async function () {
-  const state = await client.page.FilesPageElement.sharingDialog().getDisabledAttributeOfSaveShareButton()
+Then('the expiration date shown on the webUI should be {string} days', async function(
+  expectedDays
+) {
+  let expectedDate = sharingHelper.calculateDate(expectedDays)
+  expectedDate = new Date(Date.parse(expectedDate))
+  const expectedDateString =
+    expectedDate.toLocaleString('en-GB', { month: 'short' }) +
+    ' ' +
+    expectedDate.getDate().toString() +
+    ', ' +
+    expectedDate.getFullYear()
+  const dateStringFromInputField = await client.page.FilesPageElement.sharingDialog().getExpirationDateFromInputField()
   assert.strictEqual(
-    'true',
-    state,
-    'Expected: save share button to be disabled but got enabled'
+    dateStringFromInputField,
+    expectedDateString,
+    `Expected: Expiration date field with ${expectedDateString}, but found ${dateStringFromInputField}`
   )
+})
+
+Then('it should not be possible to save the pending share on the webUI', async function() {
+  const state = await client.page.FilesPageElement.sharingDialog().getDisabledAttributeOfSaveShareButton()
+  assert.strictEqual('true', state, 'Expected: save share button to be disabled but got enabled')
 })

--- a/tests/acceptance/stepDefinitions/webdavContext.js
+++ b/tests/acceptance/stepDefinitions/webdavContext.js
@@ -15,59 +15,61 @@ const path = require('../helpers/path')
  * @param {string} element - path
  * @returns {Promise<Response|Error>}
  */
-function fileExists (userId, element) {
+function fileExists(userId, element) {
   const davPath = webdavHelper.createDavPath(userId, element)
   return httpHelper.get(davPath, userId)
 }
 
-const fileShouldExist = function (userId, element) {
-  return fileExists(userId, element).then(function (res) {
+const fileShouldExist = function(userId, element) {
+  return fileExists(userId, element).then(function(res) {
     assert.strictEqual(res.status, 200, 'File should exist, but does not')
   })
 }
 
-const fileShouldNotExist = function (userId, element) {
-  return fileExists(userId, element).then(function (res) {
+const fileShouldNotExist = function(userId, element) {
+  return fileExists(userId, element).then(function(res) {
     assert.ok(res.status < 300 || res.status >= 200, 'file/folder should not exist, but does')
   })
 }
 
-Then('as {string} file/folder {string} should not exist', function (userId, element) {
+Then('as {string} file/folder {string} should not exist', function(userId, element) {
   return fileShouldNotExist(userId, element)
 })
 
-Then('as {string} file/folder {string} should not exist on remote server', function (userId, element) {
+Then('as {string} file/folder {string} should not exist on remote server', function(
+  userId,
+  element
+) {
   return backendHelper.runOnRemoteBackend(fileShouldNotExist, userId, element)
 })
 
-Then('as {string} file/folder {string} should exist', function (userId, element) {
+Then('as {string} file/folder {string} should exist', function(userId, element) {
   return fileShouldExist(userId, element)
 })
 
-Then('as {string} file/folder {string} should exist on remote server', function (userId, element) {
+Then('as {string} file/folder {string} should exist on remote server', function(userId, element) {
   return backendHelper.runOnRemoteBackend(fileShouldExist, userId, element)
 })
 
-Then('as {string} file/folder {string} should exist inside folder {string}', function (user, file, folder) {
+Then('as {string} file/folder {string} should exist inside folder {string}', function(
+  user,
+  file,
+  folder
+) {
   return fileShouldExist(user, path.join(folder, file))
 })
 
-Then('as {string} the last uploaded folder should exist', function (userId) {
+Then('as {string} the last uploaded folder should exist', function(userId) {
   return fileShouldExist(userId, client.sessionId)
 })
 
 Then(
   'as {string} the last uploaded folder should contain the following files inside the sub-folders:',
-  async function (user, files) {
+  async function(user, files) {
     files = files.raw().map(item => item[0])
 
     const sessionId = client.sessionId
-    const response = await webdavHelper.propfind(
-      `/files/${user}/${sessionId}`,
-      user,
-      [],
-      2
-    )
+    const response = await webdavHelper.propfind(`/files/${user}/${sessionId}`, user, [], 2)
     const result = xml2js(response, { compact: true })
 
     const elements = _.get(result, 'd:multistatus.d:response')
@@ -75,13 +77,9 @@ Then(
       throw new Error('Received unexpected response:\n' + result)
     }
 
-    const uploadedFilesHref = elements
-      .map(elem => _.get(elem, 'd:href._text'))
-      .filter(item => item)
+    const uploadedFilesHref = elements.map(elem => _.get(elem, 'd:href._text')).filter(item => item)
 
-    const regexToExtractBaseName = RegExp(
-      `/${sessionId}/upload[0-9]+file/(.*)`
-    )
+    const regexToExtractBaseName = RegExp(`/${sessionId}/upload[0-9]+file/(.*)`)
     const uploadedFilesWithBaseName = uploadedFilesHref
       // unmatched items return null, else is array
       .map(file => _.nth(file.match(regexToExtractBaseName), 1))
@@ -97,8 +95,9 @@ Then(
   }
 )
 
-Given('user {string} has favorited element {string}', function (userId, element) {
-  const body = '<?xml version="1.0"?>\n' +
+Given('user {string} has favorited element {string}', function(userId, element) {
+  const body =
+    '<?xml version="1.0"?>\n' +
     '<d:propertyupdate xmlns:d="DAV:"\n' +
     'xmlns:oc="http://owncloud.org/ns">\n' +
     '  <d:set>\n' +
@@ -106,12 +105,9 @@ Given('user {string} has favorited element {string}', function (userId, element)
     '  </d:set>\n' +
     '</d:propertyupdate>'
 
-  return httpHelper.proppatch(
-    webdavHelper.createDavPath(userId, element),
-    userId,
-    body
-  )
-    .then(function (res) {
+  return httpHelper
+    .proppatch(webdavHelper.createDavPath(userId, element), userId, body)
+    .then(function(res) {
       if (res.status === 207) {
         return res
       } else {
@@ -120,24 +116,31 @@ Given('user {string} has favorited element {string}', function (userId, element)
     })
 })
 
-Then('as {string} file/folder {string} should exist in the trashbin', async function (user, element) {
+Then('as {string} file/folder {string} should exist in the trashbin', async function(
+  user,
+  element
+) {
   const items = await webdavHelper.getTrashBinElements(user)
   const trashFiles = items.map(item => item.originalFilename)
   assert.strictEqual(trashFiles.includes(element), true)
 })
 
-Then('as {string} the file/folder with original path {string} should not exist in the trashbin', function (user, path) {
-  return webdavHelper.getTrashBinElements(user)
-    .then(items => {
+Then(
+  'as {string} the file/folder with original path {string} should not exist in the trashbin',
+  function(user, path) {
+    return webdavHelper.getTrashBinElements(user).then(items => {
       const trashFiles = items.map(item => item.originalLocation)
       assert.strictEqual(trashFiles.includes(path), false)
     })
-})
+  }
+)
 
-Then('as {string} the file/folder with original path {string} should exist in the trashbin', function (user, path) {
-  return webdavHelper.getTrashBinElements(user)
-    .then(items => {
+Then(
+  'as {string} the file/folder with original path {string} should exist in the trashbin',
+  function(user, path) {
+    return webdavHelper.getTrashBinElements(user).then(items => {
       const trashFiles = items.map(item => item.originalLocation)
       assert.strictEqual(trashFiles.includes(path), true)
     })
-})
+  }
+)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3514,6 +3514,13 @@ escodegen@1.x.x:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-config-prettier@^6.10.0:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz#7b15e303bf9c956875c948f6b21500e48ded6a7f"
+  integrity sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==
+  dependencies:
+    get-stdin "^6.0.0"
+
 eslint-config-standard@^14.1.0:
   version "14.1.1"
   resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-14.1.1.tgz#830a8e44e7aef7de67464979ad06b406026c56ea"
@@ -3596,6 +3603,13 @@ eslint-plugin-node@^11.0.0:
     minimatch "^3.0.4"
     resolve "^1.10.1"
     semver "^6.1.0"
+
+eslint-plugin-prettier@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz#432e5a667666ab84ce72f945c72f77d996a5c9ba"
+  integrity sha512-GlolCC9y3XZfv3RQfwGew7NnuFDKsfI4lbvRK+PIIo23SFH+LemGs4cKwzAaRa+Mdb+lQO/STaIayno8T5sJJA==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
 
 eslint-plugin-promise@^4.2.1:
   version "4.2.1"
@@ -3969,6 +3983,11 @@ fast-deep-equal@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
   integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
+
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^3.0.3:
   version "3.2.2"
@@ -4360,6 +4379,11 @@ get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz#b5fde77f22cbe35f390b4e089922c50bce6ef664"
   integrity sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==
+
+get-stdin@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
+  integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
 
 get-stream@^4.0.0:
   version "4.1.0"
@@ -7490,6 +7514,13 @@ prepend-http@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
 
 prettier@1.16.3:
   version "1.16.3"


### PR DESCRIPTION
we might want to reduce the number of open PRs and then rebase before merging, as this affects all js and vue files.

## Description
This PR sets up the `prettier` plugin with `recommended` ruleset for eslint. As we already have lint fix running as commit hook, this automatically gets included now for files that were changed in the commit.

Applied `lint --fix` once so that we have everything with recommended code styles.

Would suggest to rebase this PR when the current sprint is done (so that the number of open PRs is smaller) and re-run the lint fixing again before merging.

## Related Issue
- Fixes https://github.com/owncloud/phoenix/issues/2992

## Motivation and Context
Prettier provides an out of the box awesome code style.

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 