### PR TITLE
Dialog prompt message fix

### DIFF
--- a/apps/files/src/components/FilesAppBar.vue
+++ b/apps/files/src/components/FilesAppBar.vue
@@ -17,7 +17,6 @@
       <div v-if="!publicPage()" class="uk-width-auto uk-visible@m">
         <oc-search-bar
           @search="onFileSearch"
-          :value="searchTerm"
           :label="$_searchLabel"
           :loading="isLoadingSearch"
           :buttonHidden="true"
@@ -108,6 +107,7 @@
       name="new-file-dialog"
       :oc-active="createFile"
       v-model="newFileName"
+      ocInputId="new-file-input"
       :ocLoading="fileFolderCreationLoading"
       :ocError="newFileErrorMessage"
       :ocTitle="$_createFileDialogTitle"

--- a/changelog/unreleased/1906
+++ b/changelog/unreleased/1906
@@ -1,0 +1,9 @@
+Enhancement: Visual improvement to errors in input prompts
+
+We've adjusted the input prompts to show a visually less prominent text below the input field.
+Also, error messages now appear with a small delay, so that those happening during
+typing get ignored (e.g. trailing whitespace is not allowed in folder names and previously caused
+an error to show on every typed blank).
+
+https://github.com/owncloud/phoenix/issues/1906
+https://github.com/owncloud/phoenix/pull/3240

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "node-fs-extra": "^0.8.2",
     "npm-run-all": "^4.1.5",
     "oidc-client": "^1.9.1",
-    "owncloud-design-system": "^1.1.1",
+    "owncloud-design-system": "^1.2.2",
     "owncloud-sdk": "^1.0.0-544",
     "p-limit": "^2.2.1",
     "p-queue": "^6.1.1",

--- a/tests/acceptance/pageObjects/filesPage.js
+++ b/tests/acceptance/pageObjects/filesPage.js
@@ -301,8 +301,7 @@ module.exports = {
       selector: '#new-folder-input'
     },
     newFileInput: {
-      selector: "//div[@id='new-file-dialog']//input[@type='text']",
-      locateStrategy: 'xpath'
+      selector: '#new-file-input'
     },
     newFolderOkButton: {
       selector: '#new-folder-ok'

--- a/tests/acceptance/pageObjects/phoenixPage.js
+++ b/tests/acceptance/pageObjects/phoenixPage.js
@@ -187,14 +187,14 @@ module.exports = {
       selector: '#resolve-notification-button'
     },
     ocDialogPromptAlert: {
-      selector: '.uk-modal.uk-open .oc-dialog-prompt-alert'
+      selector: '.uk-modal.uk-open .oc-text-input-message'
     },
     searchInputFieldHighResolution: {
-      selector: '(//input[contains(@class, "oc-search-input")])[1]',
+      selector: '(//div[contains(@class, "oc-search-input")]//input)[1]',
       locateStrategy: 'xpath'
     },
     searchInputFieldLowResolution: {
-      selector: '(//input[contains(@class, "oc-search-input")])[2]',
+      selector: '(//div[contains(@class, "oc-search-input")]//input)[2]',
       locateStrategy: 'xpath'
     },
     searchLoadingIndicator: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2894,9 +2894,9 @@ date-fns@^1.27.2:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
-"davclient.js@git+https://github.com/owncloud/davclient.js.git":
+"davclient.js@https://github.com/owncloud/davclient.js.git":
   version "0.2.1"
-  resolved "git+https://github.com/owncloud/davclient.js.git#bf19f590451b3c0658913568053ec7f300f7dfc1"
+  resolved "https://github.com/owncloud/davclient.js.git#bf19f590451b3c0658913568053ec7f300f7dfc1"
 
 de-indent@^1.0.2:
   version "1.0.2"
@@ -6028,6 +6028,11 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+luxon@^1.22.0:
+  version "1.23.0"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.23.0.tgz#23b748ad0f2d5494dc4d2878c19278c1e651410c"
+  integrity sha512-+6a/bXsCWrrR8vfbL41iM92es12zwV2Rum/KPkT+ubOZnnU3Sqbqok/FmD1xsWlWN2Y9Hu0fU/vNgU24ns7bpA==
+
 make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
@@ -6352,6 +6357,11 @@ mocha@^6.2.2:
     yargs "13.3.2"
     yargs-parser "13.1.2"
     yargs-unparser "1.6.0"
+
+moment@^2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -6872,13 +6882,14 @@ os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
-owncloud-design-system@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/owncloud-design-system/-/owncloud-design-system-1.1.1.tgz#4c23e9f4b2555c5e2d1ea8049a8c7c4a80346f2e"
-  integrity sha512-dIuMbhJLqsVfV8eXvBSMizJrrxXUDFA0WLIxS2MZ5qPAa9VjiDiPxzLQZKSYEotSpN+lgermzH/Mr0xU8w6Ksg==
+owncloud-design-system@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/owncloud-design-system/-/owncloud-design-system-1.2.2.tgz#e52459bcfc4004dba0e48b3d04c2703f544e15ec"
+  integrity sha512-kFmBURf4Q+MfjpDPPLfJTVKWkyL7VuGs4Bj6ik9+/DnrWzNAT4rgEqzW3ToBPovF/NGVP877mlvCa7DpxE4BQA==
   dependencies:
-    lodash "^4.17.11"
+    luxon "^1.22.0"
     mini-css-extract-plugin "^0.9.0"
+    moment "^2.24.0"
     postcss-import "^12.0.1"
     postcss-loader "^3.0.0"
     postcss-safe-parser "^4.0.2"
@@ -6887,11 +6898,12 @@ owncloud-design-system@^1.1.1:
     uikit "3.3.2"
     vue "^2.6.11"
     vue-avatar "^2.2.0"
-    vue-lodash "^2.1.1"
+    vue-datetime "^1.0.0-beta.10"
     vue-meta "^2.3.2"
     vue-router "^3.1.5"
     vuex "^3.1.1"
     webfontloader "^1.6.28"
+    weekstart "^1.0.0"
 
 owncloud-sdk@^1.0.0-544:
   version "1.0.0-544"
@@ -9618,6 +9630,11 @@ vue-clipboard2@^0.3.1:
   dependencies:
     clipboard "^2.0.0"
 
+vue-datetime@^1.0.0-beta.10:
+  version "1.0.0-beta.11"
+  resolved "https://registry.yarnpkg.com/vue-datetime/-/vue-datetime-1.0.0-beta.11.tgz#283b5182dabe0ab372e375e9c47acb3b41524ffa"
+  integrity sha512-znOQCX0n4nPMsfcwAhlCL47u52NwnYPrlGrqiSsT1sLZgtZmfNMBVO/c0QF6VA5ZszVtopxU0fjZVxu/VpM/Ug==
+
 vue-drag-drop@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/vue-drag-drop/-/vue-drag-drop-1.1.4.tgz#6e94aeb10304b91d651614b7307d0b90f0227e89"
@@ -9662,11 +9679,6 @@ vue-loader@^15.7.1:
     loader-utils "^1.1.0"
     vue-hot-reload-api "^2.3.0"
     vue-style-loader "^4.1.0"
-
-vue-lodash@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/vue-lodash/-/vue-lodash-2.1.2.tgz#1ec2b1471ee289518e8d285250a25516adee6c51"
-  integrity sha512-6QsNC7/XjrK4xKxFhh6Ppvcrfm0uAeR/lFsySsMgfEFUWkvRztcAIS3MsqAI4bBnAaLo9ou+8tUfJ8d+yrljQg==
 
 vue-meta@^2.2.2, vue-meta@^2.3.2:
   version "2.3.3"
@@ -9924,6 +9936,11 @@ websocket-extensions@>=0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
   integrity sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==
+
+weekstart@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/weekstart/-/weekstart-1.0.1.tgz#950970b48e5797e06fc1a762f3d0f013312321e1"
+  integrity sha512-h6B1HSJxg7sZEXqIpDqAtwiDBp3x5y2jY8WYcUSBhLTcTCy7laQzBmamqMuQM5fpvo1pgpma0OCRpE2W8xrA9A==
 
 whatwg-fetch@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## Description
Make error messages in dialog prompts less annoying.
Within the dialog prompt for several small tasks (e.g. creating a new folder) there are three things changed:
1. the error message is now shown below the input field, using new properties from `oc-text-input` in ODS.
2. the changes on error messages are debounced for 400 milliseconds. As a result error messages that would appear during typing (like if you type a folder name which contains a blank in between two words) are not shown at all (if you type more than 1 character every 400 milliseconds).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/phoenix/issues/1906

## Motivation and Context
UX improvement

## How Has This Been Tested?

## Screenshots (if appropriate):
![jumpy error message gone](https://user-images.githubusercontent.com/3532843/77755185-02246400-702d-11ea-914d-0f2f7aab07ea.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
