### PR TITLE
Use alternative temporary ids for uniqueness in views

### DIFF
--- a/apps/files/src/components/AllFilesList.vue
+++ b/apps/files/src/components/AllFilesList.vue
@@ -240,7 +240,7 @@ export default {
           this.$nextTick(() => {
             const file = this.activeFiles.find(item => item.name === scrollTo)
             this.setHighlightedFile(file)
-            this.$scrollTo(`#file-row-${file.id}`, 500, {
+            this.$scrollTo(`#file-row-${file.viewId}`, 500, {
               container: '#files-list-container'
             })
           })

--- a/apps/files/src/components/FileLinkSidebar.vue
+++ b/apps/files/src/components/FileLinkSidebar.vue
@@ -270,7 +270,7 @@ export default {
 
       if (l1Direct === l2Direct) {
         if (name1 === name2) {
-          return textUtils.naturalSortCompare(l1.id + '', l2.id + '')
+          return l1.stime - l2.stime
         }
 
         return textUtils.naturalSortCompare(name1, name2)

--- a/apps/files/src/components/FileList.vue
+++ b/apps/files/src/components/FileList.vue
@@ -31,7 +31,7 @@
             :data-is-visible="active"
             @click="selectRow(item, $event); hideRowActionsDropdown()"
           >
-            <oc-grid :ref="index === 0 ? 'firstRow' : null" gutter="small" flex class="uk-padding-small oc-border-top" :class="_rowClasses(item)" :id="'file-row-' + item.id">
+            <oc-grid :ref="index === 0 ? 'firstRow' : null" gutter="small" flex class="uk-padding-small oc-border-top" :class="_rowClasses(item)" :id="'file-row-' + item.viewId">
               <div>
                 <oc-checkbox
                   class="uk-margin-small-left"
@@ -44,7 +44,7 @@
               <slot name="rowColumns" :item="item" :index="index" />
               <div class="uk-text-right uk-margin-left uk-margin-small-right">
                 <oc-button
-                  :id="actionsDropdownButtonId(item.id, active)"
+                  :id="actionsDropdownButtonId(item.viewId, active)"
                   class="files-list-row-show-actions"
                   :disabled="$_actionInProgress(item)"
                   :aria-label="$gettext('Show file actions')"
@@ -165,49 +165,6 @@ export default {
       'resetFileSelection', 'addFileSelection', 'removeFileSelection', 'toggleFileSelection'
     ]),
 
-    $_ocFilesFolder_getFolder () {
-      let absolutePath
-
-      if (this.configuration.rootFolder) {
-        absolutePath = !this.item ? this.configuration.rootFolder : this.item
-      } else {
-        absolutePath = !this.item ? this.configuration.rootFolder : this.item
-      }
-
-      this.loadFolder({
-        client: this.$client,
-        absolutePath: absolutePath,
-        $gettext: this.$gettext,
-        routeName: this.$route.name
-      }).then(() => {
-        const scrollTo = this.$route.query.scrollTo
-        if (scrollTo && this.activeFiles.length > 0) {
-          this.$nextTick(() => {
-            const file = this.activeFiles.find(item => item.name === scrollTo)
-            this.setHighlightedFile(file)
-            this.$scrollTo(`#file-row-${file.id}`, 500, {
-              container: '#files-list-container'
-            })
-          })
-        }
-      }).catch((error) => {
-        // password for public link shares is missing -> this is handled on the caller side
-        if (this.publicPage() && error.statusCode === 401) {
-          this.$router.push({
-            name: 'public-link',
-            params: {
-              token: this.$route.params.item
-            }
-          })
-          return
-        }
-        this.showMessage({
-          title: this.$gettext('Loading folder failed…'),
-          desc: error.message,
-          status: 'danger'
-        })
-      })
-    },
     labelSelectSingleItem (item) {
       return this.$gettextInterpolate(this.labelSelectSingleItemText, { name: item.name, type: item.type }, true)
     },
@@ -302,12 +259,12 @@ export default {
       this.rowActions = []
     },
 
-    actionsDropdownButtonId (id, active) {
+    actionsDropdownButtonId (viewId, active) {
       if (active) {
-        return `files-file-list-action-button-${id}-active`
+        return `files-file-list-action-button-${viewId}-active`
       }
 
-      return `files-file-list-action-button-${id}`
+      return `files-file-list-action-button-${viewId}`
     },
 
     $_resizeHeader () {

--- a/apps/files/src/components/FilesLists/RowActionsDropdown.vue
+++ b/apps/files/src/components/FilesLists/RowActionsDropdown.vue
@@ -1,9 +1,9 @@
 <template>
   <oc-drop
     v-if="displayed"
-    :boundary="`#files-file-list-action-button-${item.id}-active`"
+    :boundary="`#files-file-list-action-button-${item.viewId}-active`"
     :options="{ offset: 0 }"
-    :toggle="`#files-file-list-action-button-${item.id}-active`"
+    :toggle="`#files-file-list-action-button-${item.viewId}-active`"
     position="bottom-right"
     id="files-list-row-actions-dropdown"
     class="uk-open uk-drop-stack"

--- a/apps/files/src/store/actions.js
+++ b/apps/files/src/store/actions.js
@@ -19,7 +19,10 @@ function _buildFile (file) {
   const ext = (file.type !== 'dir') ? _extName(file.name) : ''
   return ({
     type: (file.type === 'dir') ? 'folder' : file.type,
+    // actual file id (string)
     id: file.fileInfo['{http://owncloud.org/ns}fileid'],
+    // temporary list id, to be used for view only and for uniqueness inside the list
+    viewId: _.uniqueId('file-'),
     starred: file.fileInfo['{http://owncloud.org/ns}favorite'] !== '0',
     mdate: file.fileInfo['{DAV:}getlastmodified'],
     mdateMoment: moment(file.fileInfo['{DAV:}getlastmodified']),

--- a/changelog/unreleased/3214
+++ b/changelog/unreleased/3214
@@ -1,0 +1,12 @@
+Bugfix: Fix file actions menu when using OCIS backend
+
+When using OCIS as backend, the ids of resources is a string instead of
+integer. So we cannot embed those into DOM node ids and need to use
+another alternative. This fix introduces a unique viewId which is only
+there to provide uniqueness across the current list and should not be
+used for any data related operation.
+
+This fixes the file actions menu when using OCIS as backend.
+
+https://github.com/owncloud/phoenix/issues/3214
+https://github.com/owncloud/ocis-phoenix/issues/51


### PR DESCRIPTION
## Description
When using OCIS as backend, the ids of resources is a string instead of
integer. So we cannot embed those into DOM node ids and need to use
another alternative. This fix introduces a unique listId which is only
there to provide uniqueness across the current list and should not be
used for any data related operation.

This fixes the file actions menu when using OCIS as backend.

## Related Issue
Fixes https://github.com/owncloud/phoenix/issues/3214
Fixes https://github.com/owncloud/ocis-phoenix/issues/51

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manual test with OCIS backend (see https://github.com/owncloud/phoenix/pull/3212 for setup)
Manual test with OC 10 backend just in case, also to test the "stime" sorting change which can currently only be tested with OC 10.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
