### PR TITLE
remove deleted files from search result

### DIFF
--- a/apps/files/src/store/actions.js
+++ b/apps/files/src/store/actions.js
@@ -600,6 +600,7 @@ export default {
         .then(() => {
           context.commit('REMOVE_FILE', file)
           context.commit('REMOVE_FILE_SELECTION', file)
+          context.commit('REMOVE_FILE_FROM_SEARCHED', file)
         })
         .catch(error => {
           let translated = $gettext('Error while deleting "%{file}"')

--- a/apps/files/src/store/mutations.js
+++ b/apps/files/src/store/mutations.js
@@ -58,6 +58,9 @@ export default {
   LOAD_FILES_SEARCHED(state, files) {
     state.filesSearched = files
   },
+  REMOVE_FILE_FROM_SEARCHED(state, file) {
+    state.filesSearched = state.filesSearched.filter(i => file.id !== i.id)
+  },
   SET_FILES_SORT(state, { field, directionIsDesc }) {
     state.fileSortDirectionDesc = directionIsDesc
     state.fileSortField = field
@@ -72,7 +75,7 @@ export default {
   },
   REMOVE_FILE_SELECTION(state, file) {
     if (state.selected.length > 1) {
-      state.selected = state.selected.filter(i => ![file].includes(i))
+      state.selected = state.selected.filter(i => file.id !== i.id)
       return
     }
     state.selected = []
@@ -91,7 +94,7 @@ export default {
     state.files.push(file)
   },
   REMOVE_FILE(state, file) {
-    state.files = state.files.filter(i => ![file].includes(i))
+    state.files = state.files.filter(i => file.id !== i.id)
   },
   SET_SEARCH_TERM(state, searchTerm) {
     state.searchTermGlobal = searchTerm

--- a/changelog/unreleased/3266
+++ b/changelog/unreleased/3266
@@ -1,0 +1,8 @@
+Bugfix: Remove deleted files from search result
+
+Deleted file has been removed from filesSearched state by adding a new mutation.
+Also, filter condition in remove file mutations has been changed from object reference to unique file id.
+
+https://github.com/owncloud/phoenix/pull/3266
+https://github.com/owncloud/phoenix/issues/3043
+https://github.com/owncloud/phoenix/issues/3044

--- a/tests/acceptance/features/webUIFiles/search.feature
+++ b/tests/acceptance/features/webUIFiles/search.feature
@@ -155,15 +155,10 @@ Feature: Search
     Then folder "favorite folder" should be listed on the webUI
     And folder "not favorite folder" should be listed on the webUI
 
-  @issue-3044
   Scenario: Delete file from search list
-    Given the following files have been deleted by user "user1"
-      | name          |
-      | lorem-big.txt |
-    And user "user1" has uploaded file with content "uploaded content" to "lorem-big.txt"
-    When the user searches for "lorem-big" using the webUI
-    And the user deletes file "lorem-big.txt" using the webUI
-    Then file "lorem-big.txt" should be listed on the webUI
-    #Then file "lorem-big.txt" should not be listed on the webUI
-    And as "user1" file "lorem-big.txt" should not exist
-    And as "user1" the file with original path "lorem-big.txt" should exist in the trashbin
+    Given user "user1" has uploaded file with content "uploaded content" to "file-to-delete.txt"
+    When the user searches for "file-to" using the webUI
+    And the user deletes file "file-to-delete.txt" using the webUI
+    Then file "file-to-delete.txt" should not be listed on the webUI
+    And as "user1" file "file-to-delete.txt" should not exist
+    And as "user1" the file with original path "file-to-delete.txt" should exist in the trashbin

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -359,9 +359,9 @@ Then('the last uploaded folder should be listed on the webUI', async function() 
   return client
 })
 
-Then('file {string} should not be listed on the webUI', async function(folder) {
-  const state = await client.page.FilesPageElement.filesList().isElementListed(folder, 'file')
-  return client.assert.ok(!state, `Error: Resource ${folder} is listed on the filesList`)
+Then('file {string} should not be listed on the webUI', async function(file) {
+  const state = await client.page.FilesPageElement.filesList().isElementListed(file, 'file')
+  return client.assert.ok(!state, `Error: Resource ${file} is listed on the filesList`)
 })
 
 Then('folder {string} should not be listed on the webUI', async folder => {


### PR DESCRIPTION
## Description
Deleted file removed from `filesSearched` state by adding a new mutation. Also, filter condition in remove file mutations changed from object reference to unique file id.

## Related Issue
- Fixes https://github.com/owncloud/phoenix/issues/3044
- Fixes https://github.com/owncloud/phoenix/issues/3043

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Applied the described steps in the issues.

## Types of changes\
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 