### PR TITLE
Do not remove first char in etag

### DIFF
--- a/apps/files/src/components/FileItem.vue
+++ b/apps/files/src/components/FileItem.vue
@@ -87,7 +87,7 @@ export default {
       if (this.item.etag) {
         // add etag for URL based caching
         // strip double quotes from etag
-        query.c = this.item.etag.substr(2, this.item.etag.length - 2)
+        query.c = this.item.etag.substr(1, this.item.etag.length - 2)
       }
 
       let itemPath = this.item.path

--- a/changelog/unreleased/3274
+++ b/changelog/unreleased/3274
@@ -1,0 +1,6 @@
+Bugfix: Do not remove first character of etag
+
+When stripping away double quotes in etag of the file thumbnails, we accidentally
+removed first character as well. We've stopped removing that character.
+
+https://github.com/owncloud/phoenix/pull/3274


### PR DESCRIPTION
## Description
Follow up on #3187. The first char of etag was being removed when stripping away double quotes.