### PR TITLE
remove trailing slash from redirect uri

### DIFF
--- a/changelog/unreleased/logout_redirect_uri.md
+++ b/changelog/unreleased/logout_redirect_uri.md
@@ -1,0 +1,4 @@
+Bugfix: fix oidc redirect after logout 
+
+Changed the redirect uri to not contain a trailing slash so that the redirect in the oidc provider works.
+

--- a/changelog/unreleased/logout_redirect_uri.md
+++ b/changelog/unreleased/logout_redirect_uri.md
@@ -2,3 +2,4 @@ Bugfix: fix oidc redirect after logout
 
 Changed the redirect uri to not contain a trailing slash so that the redirect in the oidc provider works.
 
+https://github.com/owncloud/phoenix/pull/3284/files

--- a/changelog/unreleased/logout_redirect_uri.md
+++ b/changelog/unreleased/logout_redirect_uri.md
@@ -2,4 +2,4 @@ Bugfix: fix oidc redirect after logout
 
 Changed the redirect uri to not contain a trailing slash so that the redirect in the oidc provider works.
 
-https://github.com/owncloud/phoenix/pull/3284/files
+https://github.com/owncloud/phoenix/pull/3284

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -17,7 +17,7 @@ export function initVueAuthenticate (config) {
       response_mode: 'query',
       scope: 'openid profile offline_access',
       monitorSession: false,
-      post_logout_redirect_uri: baseUrl,
+      post_logout_redirect_uri: baseUrl.replace(/\/$/, ''), // trim the trailing slash
       silent_redirect_uri: baseUrl + 'oidc-silent-redirect.html',
       accessTokenExpiringNotificationTime: 10,
       automaticSilentRenew: true,


### PR DESCRIPTION
## Description
ocis-konnectd has several trusted redirect urls. They don't have a trailing slash.
When we logout in phoenix konnectd tries to verify if the provided redirect uri from phoenix is trusted. But since the provided uri contains a trailing slash it doesn't match the configured once.
So the solution is to remove the trailing slash 

## Motivation and Context
Fix logout

## How Has This Been Tested?
locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
