### PR TITLE
Fix media-viewer on private pages

### DIFF
--- a/apps/media-viewer/src/Mediaviewer.vue
+++ b/apps/media-viewer/src/Mediaviewer.vue
@@ -81,7 +81,7 @@ export default {
       }
     },
     headers () {
-      if (!this.publicPage()) {
+      if (!this.isPublicContext()) {
         return null
       }
 
@@ -105,7 +105,7 @@ export default {
         a: 1
       })
 
-      if (this.publicPage()) {
+      if (this.isPublicContext()) {
         const path = [
           '..',
           'dav',
@@ -164,6 +164,12 @@ export default {
   },
 
   methods: {
+    isPublicContext () {
+      // TODO: Can we rely on not being "authenticated" while viewing a public link?
+      // Currently it works. We cannot use publicPage() because that will still return
+      // true when opening the mediaviewer from authenticated routes
+      return !this.isAuthenticated
+    },
     loadImage () {
       this.loading = true
 

--- a/changelog/unreleased/fix_media_viewer_on_private_pages.md
+++ b/changelog/unreleased/fix_media_viewer_on_private_pages.md
@@ -1,0 +1,5 @@
+Bugfix: fix media-viewer on private pages
+
+media-viewer incorrectly assumed it was on a public page when opened from a private page.
+
+https://github.com/owncloud/phoenix/pull/3288


### PR DESCRIPTION
## Description
I've made the mediaviewer app depend only on this.isAuthenticated instead of this.publicPage().

publicPage() is always true because (at least I assume so) it's rendered in its own route that is always public. In my tests I could use isAuthenticated to determine whether it was loaded from a private page or from a public link e.g.

It feels hackish, happy to hear if there's a better API to use.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/phoenix/issues/3287

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1: I looked at the picture from regular files view
- test case 2: I looked at the file from public link view
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
