### PR TITLE
In slow networks requirejs reuquests can timeout. The timeout is set …

### DIFF
--- a/changelog/unreleased/3293
+++ b/changelog/unreleased/3293
@@ -1,0 +1,5 @@
+Bugfix: Set a higher timeout for requirejs
+
+ In slow networks requirejs requests can timeout. The timeout is now set to a higher value (200 secs)
+
+ https://github.com/owncloud/phoenix/pull/3293

--- a/src/phoenix.js
+++ b/src/phoenix.js
@@ -245,6 +245,10 @@ function requireError (err) {
     // TODO: frozen object would be great ...
     window.phoenixConfig = config
 
+    // requirejs.config({waitSeconds:200}) is not really working ... reason unknown
+    // we are manipulating requirejs directly
+    requirejs.s.contexts._.config.waitSeconds = 200
+
     requirejs(apps, loadApps, requireError)
   } catch (err) {
     router.push('missing-config')


### PR DESCRIPTION
…not to a higher value (200 secs)

## Description

## How Has This Been Tested?
- under test in a customer setup

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...