### PR TITLE
mediaviewer: add state to urls

### DIFF
--- a/apps/files/src/components/FilesApp.vue
+++ b/apps/files/src/components/FilesApp.vue
@@ -170,7 +170,7 @@ export default {
       this.openFile({
         filePath: file.path
       })
-      let actions = this.extensions(file.extension)
+      let actions = this.extensions(file.extension.toLowerCase())
       actions = actions.map(action => {
         if (action.version === 3) {
           return {

--- a/apps/files/src/fileactions.js
+++ b/apps/files/src/fileactions.js
@@ -213,11 +213,16 @@ export default {
         }
         return
       }
-      // TODO: rewire code below ....
-      const appId = action.app
-      // TODO path to state
+
+      const routeName = action.routeName ? action.app + '/' + action.routeName : action.app
+      const params = {
+        filePath,
+        contextRouteName: this.$route.name
+      }
+
       this.$router.push({
-        name: appId
+        name: routeName,
+        params
       })
     }
   }

--- a/apps/media-viewer/src/Mediaviewer.vue
+++ b/apps/media-viewer/src/Mediaviewer.vue
@@ -5,7 +5,7 @@
         <img v-show="!loading && activeMediaFileCached" :src="image.url" :alt="image.name" :data-id="image.id" style="max-width:90vw;max-height:90vh" class="uk-box-shadow-medium">
       </transition>
     </div>
-    <oc-spinner class="uk-position-center" v-if="loading" size="large" />
+    <oc-spinner :ariaLabel="this.$gettext('Loading media')" class="uk-position-center" v-if="loading" size="large" />
     <oc-icon v-if="failed" name="review" variation="danger" size="large" class="uk-position-center uk-z-index" />
 
     <div class="uk-position-medium uk-position-bottom-center">
@@ -14,7 +14,7 @@
         <div class="uk-width-large uk-flex uk-flex-middle uk-flex-center uk-flex-around" style="user-select:none;">
           <oc-icon role="button" class="oc-cursor-pointer" size="medium" @click="prev" name="chevron_left" />
           <!-- @TODO: Bring back working uk-light -->
-          <span class="uk-text-small" style="color:#fff"> {{ activeIndex + 1 }} <span v-translate>of</span> {{ mediaFiles.length }} </span>
+          <span v-if="!$_loader_folderLoading" class="uk-text-small" style="color:#fff"> {{ activeIndex + 1 }} <span v-translate>of</span> {{ mediaFiles.length }} </span>
           <oc-icon role="button" class="oc-cursor-pointer" size="medium" @click="next" name="chevron_right" />
           <oc-icon role="button" class="oc-cursor-pointer" @click="downloadImage" name="file_download"  />
           <oc-icon role="button" class="oc-cursor-pointer" @click="closeApp" name="close"/>
@@ -25,10 +25,13 @@
 </template>
 <script>
 import { mapGetters } from 'vuex'
-import queryString from 'query-string'
+import Loader from './mixins/loader.js'
 
 export default {
   name: 'Mediaviewer',
+  mixins: [
+    Loader
+  ],
   data () {
     return {
       loading: true,
@@ -46,7 +49,7 @@ export default {
   },
 
   computed: {
-    ...mapGetters('Files', ['activeFiles', 'publicLinkPassword']),
+    ...mapGetters('Files', ['activeFiles']),
     ...mapGetters(['getToken']),
 
     mediaFiles () {
@@ -80,22 +83,8 @@ export default {
         default: return 3840
       }
     },
-    headers () {
-      if (!this.isPublicContext()) {
-        return null
-      }
-
-      const headers = new Headers()
-      headers.append('X-Requested-With', 'XMLHttpRequest')
-
-      const password = this.publicLinkPassword
-      if (password) {
-        headers.append('Authorization', 'Basic ' + Buffer.from('public:' + password).toString('base64'))
-      }
-      return headers
-    },
     thumbPath () {
-      const query = queryString.stringify({
+      const query = {
         x: this.thumbDimensions,
         y: this.thumbDimensions,
         // strip double quotes from etag
@@ -103,27 +92,9 @@ export default {
         scalingup: 0,
         preview: 1,
         a: 1
-      })
-
-      if (this.isPublicContext()) {
-        const path = [
-          '..',
-          'dav',
-          'public-files',
-          this.activeMediaFile.path
-        ].join('/')
-
-        return this.$client.files.getFileUrl(path) + '?' + query
       }
-      const path = [
-        '..',
-        'dav',
-        'files',
-        this.$store.getters.user.id,
-        this.activeMediaFile.path
-      ].join('/')
 
-      return this.$client.files.getFileUrl(path) + '?' + query
+      return this.$_loader_getDavFilePath(this.activeMediaFile.path, query)
     }
   },
 
@@ -135,28 +106,21 @@ export default {
     }
   },
 
-  mounted () {
+  async mounted () {
     document.addEventListener('keyup', this.handleKeyPress)
 
-    // Return if no Image is selected
-    if (this.$store.getters.activeFile.path === '') {
-      this.$router.push({
-        path: '/files'
-      })
-      return
-    }
+    // keep a local history for this component
+    window.addEventListener('popstate', this.handleLocalHistoryEvent)
 
-    // Set initial file
-    for (let i = 0; i < this.mediaFiles.length; i++) {
-      if (this.mediaFiles[i].path === this.$store.getters.activeFile.path) {
-        this.activeIndex = i
-        break
-      }
-    }
+    const filePath = this.$route.params.filePath
+    await this.$_loader_loadFolder(this.$route.params.contextRouteName, filePath)
+    this.setCurrentFile(filePath)
   },
 
   beforeDestroy () {
     document.removeEventListener('keyup', this.handleKeyPress)
+
+    window.removeEventListener('popstate', this.handleLocalHistoryEvent)
 
     this.images.forEach(image => {
       window.URL.revokeObjectURL(image.url)
@@ -164,12 +128,27 @@ export default {
   },
 
   methods: {
-    isPublicContext () {
-      // TODO: Can we rely on not being "authenticated" while viewing a public link?
-      // Currently it works. We cannot use publicPage() because that will still return
-      // true when opening the mediaviewer from authenticated routes
-      return !this.isAuthenticated
+    setCurrentFile (filePath) {
+      for (let i = 0; i < this.mediaFiles.length; i++) {
+        if (this.mediaFiles[i].path === filePath) {
+          this.activeIndex = i
+          break
+        }
+      }
     },
+
+    // react to PopStateEvent ()
+    handleLocalHistoryEvent () {
+      const result = this.$router.resolve(document.location)
+      this.setCurrentFile(result.route.params.filePath)
+    },
+
+    // update route and url
+    updateLocalHistory () {
+      this.$route.params.filePath = this.activeMediaFile.path
+      history.pushState({}, document.title, this.$router.resolve(this.$route).href)
+    },
+
     loadImage () {
       this.loading = true
 
@@ -199,12 +178,13 @@ export default {
         this.failed = true
       })
     },
+
     downloadImage () {
       if (this.loading) {
         return
       }
 
-      return this.downloadFile(this.mediaFiles[this.activeIndex])
+      return this.downloadFile(this.mediaFiles[this.activeIndex], this.$_loader_publicContext)
     },
     next () {
       if (this.loading) { return }
@@ -215,6 +195,7 @@ export default {
         return
       }
       this.activeIndex++
+      this.updateLocalHistory()
     },
     prev () {
       if (this.loading) { return }
@@ -225,6 +206,7 @@ export default {
         return
       }
       this.activeIndex--
+      this.updateLocalHistory()
     },
     handleKeyPress (e) {
       if (!e) return false
@@ -232,7 +214,7 @@ export default {
       else if (e.key === 'ArrowLeft') this.prev()
     },
     closeApp () {
-      this.$router.go(-1)
+      this.$_loader_navigateToContextRoute(this.$route.params.contextRouteName, this.$route.params.filePath)
     }
   }
 

--- a/apps/media-viewer/src/app.js
+++ b/apps/media-viewer/src/app.js
@@ -4,11 +4,11 @@ import translationsJson from '../l10n/translations'
 import Mediaviewer from './Mediaviewer.vue'
 
 const routes = [{
-  path: '/mediaviewer',
+  path: '/:contextRouteName/:filePath',
   components: {
     app: Mediaviewer
   },
-  name: 'mediaviewer',
+  name: 'mediaviewer/image',
   meta: { auth: false }
 }]
 
@@ -17,13 +17,17 @@ const appInfo = {
   id: 'mediaviewer',
   icon: 'image',
   extensions: [{
-    extension: 'png'
+    extension: 'png',
+    routeName: 'image'
   }, {
-    extension: 'jpg'
+    extension: 'jpg',
+    routeName: 'image'
   }, {
-    extension: 'jpeg'
+    extension: 'jpeg',
+    routeName: 'image'
   }, {
-    extension: 'gif'
+    extension: 'gif',
+    routeName: 'image'
   }]
 }
 

--- a/apps/media-viewer/src/mixins/loader.js
+++ b/apps/media-viewer/src/mixins/loader.js
@@ -1,0 +1,135 @@
+import { mapActions, mapGetters } from 'vuex'
+import queryString from 'query-string'
+import { basename, dirname } from 'path'
+
+// TODO: this file is a first attempt to separate file/folder loading logic out of the mediaviewer
+// Discussion how to progress from here can be found in this issue:
+// https://github.com/owncloud/phoenix/issues/3301
+
+export default {
+  computed: {
+    ...mapGetters('Files', ['publicLinkPassword']),
+    $_loader_publicContext () {
+      // TODO: Can we rely on not being "authenticated" while viewing a public link?
+      // Currently it works. We cannot use publicPage() because that will still return
+      // true when opening the mediaviewer from authenticated routes
+      return !this.isAuthenticated
+    },
+    $_loader_folderLoading () {
+      return this.$_internal_loader_folderLoading
+    }
+  },
+
+  data () {
+    return {
+      $_internal_loader_folderLoading: true
+    }
+  },
+
+  methods: {
+    ...mapActions('Files', ['loadFolder']),
+
+    // This methods ensures the folder is loaded if we don't have a folder loaded currently
+    async $_loader_loadFolder (contextRouteName, filePath) {
+      // FIXME: handle public-files with passwords and everything, until then we redirect to the main public link page
+      if (this.$store.getters.activeFile.path === '' && contextRouteName === 'public-files') {
+        const path = this.$route.params.filePath.substring(1)
+        const token = path.substr(0, path.indexOf('/'))
+        this.$nextTick(() => {
+          this.$router.push({
+            name: 'publicLink',
+            params: {
+              token
+            }
+          })
+        })
+        throw new Error('public-files')
+      }
+
+      // load files
+      if (this.$store.getters.activeFile.path === '') {
+        const absolutePath = filePath.substring(1, filePath.lastIndexOf('/'))
+
+        return this.loadFolder({
+          client: this.$client,
+          absolutePath: absolutePath,
+          $gettext: this.$gettext,
+          routeName: contextRouteName,
+          loadSharesTree: !this.publicPage()
+        }).then(() => {
+          this.$data.$_internal_loader_folderLoading = false
+        }).catch((error) => {
+          // FIXME: Loading of public link folders doesn't work at all and is disabled hence, so this code should be unreachable
+
+          // // password for public link shares is missing -> this is handled on the caller side
+          // if (this.$_loader_publicContext && error.statusCode === 401) {
+          //   this.$router.push({
+          //     name: 'public-link',
+          //     params: {
+          //       token: this.$route.params.item
+          //     }
+          //   })
+          //   return
+          // }
+
+          this.showMessage({
+            title: this.$gettext('Loading folder failed…'),
+            desc: error.message,
+            status: 'danger'
+          })
+        })
+      }
+
+      // folder already loaded, nothing to do …
+      this.$data.$_internal_loader_folderLoading = false
+    },
+
+    $_loader_getDavFilePath (filePath, query) {
+      let path = [
+        '..',
+        'dav',
+        'public-files',
+        filePath
+      ].join('/')
+
+      if (!this.$_loader_publicContext) {
+        path = [
+          '..',
+          'dav',
+          'files',
+          this.$store.getters.user.id,
+          filePath
+        ].join('/')
+      }
+
+      return this.$client.files.getFileUrl(path) + '?' + queryString.stringify(query)
+    },
+
+    $_loader_headers () {
+      if (!this.$_loader_publicContext) {
+        return null
+      }
+
+      const headers = new Headers()
+      headers.append('X-Requested-With', 'XMLHttpRequest')
+
+      const password = this.publicLinkPassword
+      if (password) {
+        headers.append('Authorization', 'Basic ' + Buffer.from('public:' + password).toString('base64'))
+      }
+      return headers
+    },
+
+    $_loader_navigateToContextRoute (contextRouteName, filePath) {
+      this.$router.push({
+        name: contextRouteName,
+        params: {
+          item: dirname(filePath) || '/'
+        },
+        query: {
+          scrollTo: basename(filePath)
+        }
+      })
+    }
+  }
+}

--- a/changelog/unreleased/app_state_in_urls.md
+++ b/changelog/unreleased/app_state_in_urls.md
@@ -1,0 +1,6 @@
+Enhancement: add state to app urls
+
+Currently opened file can be added to app routes so reloading the page can be made to work
+For now it's only implemented in mediaviewer
+
+https://github.com/owncloud/phoenix/pull/3294

--- a/src/plugins/phoenix.js
+++ b/src/plugins/phoenix.js
@@ -20,10 +20,12 @@ export default {
           // but also when accessing pages that require no auth even when authenticated
           return !this.isAuthenticated || this.$route.meta.auth === false
         },
-        downloadFile (file) {
+        // FIXME: optional publicContext parameter is a mess
+        downloadFile (file, publicContext = null) {
           this.addActionToProgress(file)
+          const publicPage = publicContext !== null ? publicContext : this.publicPage()
           let headers = {}
-          if (this.publicPage()) {
+          if (publicPage) {
             const url = this.$client.publicFiles.getFileUrl(file.path)
             const password = this.publicLinkPassword
             if (password) {


### PR DESCRIPTION
Hey everyone,

I'm sorry this PR addresses a bunch of separate issues/topics at once.
I wanted to figure out what can be done and what is possible in which scope. I would like to discuss the overall approach here, if desired I can send more fine grained PRs for individual aspects.

Commits can obviously still be cleaned up a bit :) 
Loader is also obviously a stupid name for the mixin, any better ideas?
I specifically tried to encapsulate all folder loading logic there so it can be reused in other apps, what do you think about that? Where could we put that? 

This includes the commit from #3288.

## Description
This PR adds state to app routes (i.e. the context from which they were opened and the file they open). They are accessible as `contextRouteName` and `filePath`.

Moreover it adds a local history to the mediaviewer app, so forward and back buttons work and we can smootly animate between different pictures without transitioning between routes (and to keep the changes somewhat limited in this regard).


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
Apps opened from the files view did not contain state in the url, so F5 is broken. We should either not route to apps or make the urls useful (which I think is a pretty good idea for webapps anyway).

## How Has This Been Tested?
I tested local files, favorites and public links.
Navigating to a folder, opening pictures, clicking prev and next, using the forward and back buttons in the browser works as expected, I could not break it or find any behavior that I did not expect... 

shares don't allow me to open apps, so not tested.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Loading the mediaviewer directly for a public link didn't work, even without a password needed ... I don't know why, I couldn't make loadFolder work.