### PR TITLE
show token string if link name is empty in FileLinkSidebar

### DIFF
--- a/apps/files/src/components/PublicLinksSidebar/PublicLinkListItem.vue
+++ b/apps/files/src/components/PublicLinksSidebar/PublicLinkListItem.vue
@@ -24,7 +24,7 @@
           target="_blank"
           :uk-tooltip="$_tooltipTextLink"
           class="uk-text-bold uk-text-truncate oc-files-file-link-url"
-          >{{ link.name }}</a
+          >{{ $_linkNameText }}</a
         >
         <br />
         <span class="uk-text-meta uk-text-break">
@@ -129,6 +129,9 @@ export default {
     }
   },
   computed: {
+    $_linkNameText() {
+      return this.link.name ? this.link.name : this.link.token
+    },
     $_loadingSpinnerVisible() {
       return this.modifiable && this.removalInProgress
     },

--- a/apps/files/src/store/actions.js
+++ b/apps/files/src/store/actions.js
@@ -258,7 +258,7 @@ function _buildLink(link, $gettext) {
     permissions: link.permissions,
     description,
     stime: link.stime,
-    name: link.name,
+    name: typeof link.name === 'string' ? link.name : '',
     password: !!(link.share_with && link.share_with_displayname),
     expiration:
       typeof link.expiration === 'string' ? moment(link.expiration).format('YYYY-MM-DD') : null,

--- a/changelog/unreleased/3297
+++ b/changelog/unreleased/3297
@@ -1,0 +1,7 @@
+Bugfix: Show token string if link name is empty in FileLinkSidebar
+
+owncloud-js-client was parsing empty link name xml attribute as empty object. The empty object was changed with
+an empty string. Also, FileLinkSidebar behaviour fixed by showing token as name for the link shares without a name.
+
+https://github.com/owncloud/phoenix/pull/3297
+https://github.com/owncloud/phoenix/issues/2517

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -118,9 +118,12 @@ Feature: Share by public link
 
   Scenario Outline: user tries to change the role of an existing public link role without entering share password while enforce password for that role is enforced
     Given the setting "<setting-name>" of app "core" has been set to "yes"
-    And user "user1" has shared folder "simple-folder" with link with "<initial-permissions>" permissions
+    And user "user1" has created a public link with following settings
+      | path        | simple-folder         |
+      | name        | Public-link           |
+      | permissions | <initial-permissions> |
     And user "user1" has logged in using the webUI
-    When the user edits the public link named "{}" of folder "simple-folder" changing following
+    When the user edits the public link named "Public-link" of folder "simple-folder" changing following
       | role | <role> |
     Then the user should see an error message on the public link share dialog saying "Passwords are enforced for link shares"
     And user "user1" should have a share with these details:
@@ -138,9 +141,13 @@ Feature: Share by public link
 
   Scenario Outline: user tries to delete the password of an existing public link role while enforce password for that role is enforced
     Given the setting "<setting-name>" of app "core" has been set to "yes"
-    And user "user1" has shared folder "simple-folder" with link with "<initial-permissions>" permissions and password "123"
+    And user "user1" has created a public link with following settings
+      | path        | simple-folder         |
+      | name        | Public-link           |
+      | permissions | <initial-permissions> |
+      | password    | 123                   |
     And user "user1" has logged in using the webUI
-    When the user edits the public link named "{}" of folder "simple-folder" changing following
+    When the user edits the public link named "Public-link" of folder "simple-folder" changing following
       | password | |
     Then the user should see an error message on the public link share dialog saying "Passwords are enforced for link shares"
     And user "user1" should have a share with these details:
@@ -158,9 +165,13 @@ Feature: Share by public link
 
   Scenario Outline: user changes the role of an existing public link role without entering share password while enforce password for the original role is enforced
     Given the setting "<setting-name>" of app "core" has been set to "yes"
-    And user "user1" has shared folder "simple-folder" with link with "<initial-permissions>" permissions and password "123"
+    And user "user1" has created a public link with following settings
+      | path        | simple-folder         |
+      | name        | Public-link           |
+      | permissions | <initial-permissions> |
+      | password    | 123                   |
     And user "user1" has logged in using the webUI
-    When the user edits the public link named "{}" of folder "simple-folder" changing following
+    When the user edits the public link named "Public-link" of folder "simple-folder" changing following
       | role     | <role> |
       | password |        |
     Then user "user1" should have a share with these details:
@@ -315,8 +326,12 @@ Feature: Share by public link
 
   Scenario: user edits a name of an already existing public link
     Given user "user1" has logged in using the webUI
-    And user "user1" has shared folder "simple-folder" with link with "read" permissions and password "pass123"
-    When the user edits the public link named "{}" of folder "simple-folder" changing following
+    And user "user1" has created a public link with following settings
+      | path        | simple-folder |
+      | name        | Public-link   |
+      | permissions | read          |
+      | password    | pass123       |
+    When the user edits the public link named "Public-link" of folder "simple-folder" changing following
     | name  | simple-folder Share |
     And the public uses the webUI to access the last public link created by user "user1" with password "pass123"
     Then file "lorem.txt" should be listed on the webUI
@@ -333,34 +348,49 @@ Feature: Share by public link
       | simple-folder       | Public |
 
   Scenario: user edits the password of an already existing public link
-    Given user "user1" has shared folder "simple-folder" with link with "read, update, create, delete" permissions and password "pass123"
+    Given user "user1" has created a public link with following settings
+      | path        | simple-folder                |
+      | name        | Public-link                  |
+      | permissions | read, update, create, delete |
+      | password    | pass123                      |
     And user "user1" has logged in using the webUI
-    When the user edits the public link named "{}" of folder "simple-folder" changing following
+    When the user edits the public link named "Public-link" of folder "simple-folder" changing following
       | password |  qwertyui  |
     And the public uses the webUI to access the last public link created by user "user1" with password "qwertyui"
     Then file "lorem.txt" should be listed on the webUI
 
   Scenario: user edits the password of an already existing public link and tries to access with old password
     Given user "user1" has shared folder "simple-folder" with link with "read, update, create, delete" permissions and password "pass123"
+    Given user "user1" has created a public link with following settings
+      | path        | simple-folder                |
+      | name        | Public-link                  |
+      | permissions | read, update, create, delete |
+      | password    | pass123                      |
     And user "user1" has logged in using the webUI
-    And the user edits the public link named "{}" of folder "simple-folder" changing following
+    And the user edits the public link named "Public-link" of folder "simple-folder" changing following
       | password |  qwertyui  |
     When the public uses the webUI to access the last public link created by user "user1" with password "pass123"
     Then the public should not get access to the publicly shared file
 
   Scenario: user edits the permission of an already existing public link from read-write to read
-    Given user "user1" has shared folder "simple-folder" with link with "read, update, create, delete" permissions
+    Given user "user1" has created a public link with following settings
+      | path        | simple-folder                |
+      | name        | Public-link                  |
+      | permissions | read, update, create, delete |
     And user "user1" has logged in using the webUI
-    When the user edits the public link named "{}" of folder "simple-folder" changing following
+    When the user edits the public link named "Public-link" of folder "simple-folder" changing following
       | role  | Viewer  |
     And the public uses the webUI to access the last public link created by user "user1"
     Then file "lorem.txt" should be listed on the webUI
     And it should not be possible to delete file "lorem.txt" using the webUI
 
   Scenario: user edits the permission of an already existing public link from read to read-write
-    Given user "user1" has shared folder "simple-folder" with link with "read" permissions
+    Given user "user1" has created a public link with following settings
+      | path        | simple-folder |
+      | name        | Public-link   |
+      | permissions | read          |
     And user "user1" has logged in using the webUI
-    When the user edits the public link named "{}" of folder "simple-folder" changing following
+    When the user edits the public link named "Public-link" of folder "simple-folder" changing following
       | role | Editor |
     And the public uses the webUI to access the last public link created by user "user1"
     And the user deletes the following elements using the webUI
@@ -474,7 +504,7 @@ Feature: Share by public link
       | path        | /lorem.txt  |
       | name        | Public link |
       | expiration  | +16         |
-    
+
   Scenario: user can set an expiry date when creating a public link to a date that is before the enforced max expiry date
     Given the setting "shareapi_default_expire_date" of app "core" has been set to "yes"
     And the setting "shareapi_enforce_expire_date" of app "core" has been set to "yes"
@@ -521,8 +551,11 @@ Feature: Share by public link
 
   Scenario: user removes the public link of a file using webUI
     Given user "user1" has logged in using the webUI
-    And user "user1" has shared file "lorem.txt" with link with "read" permissions
-    When the user removes the public link named "{}" of file "lorem.txt" using the webUI
+    And user "user1" has created a public link with following settings
+      | path        | lorem.txt   |
+      | name        | Public-link |
+      | permissions | read        |
+    When the user removes the public link named "Public-link" of file "lorem.txt" using the webUI
     Then user "user1" should not have any public link
 
   @skip @yetToImplement
@@ -597,9 +630,12 @@ Feature: Share by public link
     And file "lorem (2).txt" should be listed on the webUI
 
   Scenario: user browses to public link share using copy link button
-    Given user "user1" has shared folder "simple-folder" with link with "read" permissions
+    Given user "user1" has created a public link with following settings
+      | path        | simple-folder  |
+      | name        | Public-link    |
+      | permissions | read           |
     And user "user1" has logged in using the webUI
-    When the user copies the url of public link named "{}" of folder "simple-folder" using the webUI
+    When the user copies the url of public link named "Public-link" of folder "simple-folder" using the webUI
     And the user navigates to the copied public link using the webUI
     Then file "lorem.txt" should be listed on the webUI
 
@@ -815,3 +851,9 @@ Feature: Share by public link
     And a link named "Public Link Sub" should be listed with role "Viewer" in the public link list of resource "simple-empty-folder" on the webUI
     When the user browses to the favorites page using the webUI
     Then a link named "Public Link" should be listed with role "Viewer" in the public link list of resource "simple-folder/simple-empty-folder" via "simple-folder" on the webUI
+
+  Scenario: token is shown for links without a name
+    When user "user1" has created a public link with following settings
+      | path | /simple-folder |
+    And user "user1" logs in using the webUI
+    Then a public link with the last created link share token as name should be listed for resource "simple-folder" on the webUI

--- a/tests/acceptance/stepDefinitions/publicLinkContext.js
+++ b/tests/acceptance/stepDefinitions/publicLinkContext.js
@@ -253,3 +253,16 @@ Then('the tokens should be unique for each public links on the webUI', async fun
   const isUnique = publicLinkUrls.length === new Set(publicLinkUrls).size
   return assert.ok(isUnique)
 })
+
+Then(
+  'a public link with the last created link share token as name should be listed for resource {string} on the webUI',
+  async function(resource) {
+    const lastShare = await sharingHelper.fetchLastPublicLinkShare(client.globals.currentUser)
+    await client.page.FilesPageElement.appSideBar()
+      .closeSidebar(100)
+      .openPublicLinkDialog(resource)
+    const shares = await client.page.FilesPageElement.publicLinksDialog().getPublicLinkList()
+    const share = shares.find(link => link.name === lastShare.token)
+    return assert.ok(share.name.length > 0)
+  }
+)


### PR DESCRIPTION
## Description
owncloud-js-client was parsing empty link name xml attribute as empty object. Empty object was changed with an empty string in store action.

Also, now FileLinkSidebar shows token string as name for the link shares without a name.

## Related Issue
- Fixes #2517 


## How Has This Been Tested?
- Tested with issue steps.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 