### PR TITLE
[Tests-Only]Test for share error message

### DIFF
--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -687,6 +687,27 @@ Feature: Sharing files and folders with internal users
       | expiration  | +30        |
       | permissions | read       |
 
+  Scenario: user cannot update the date of a share after the system maximum expiry date has been reduced
+    Given the setting "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
+    And the setting "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
+    And the setting "shareapi_expire_after_n_days_user_share" of app "core" has been set to "30"
+    And user "user1" has created a new share with following settings
+      | path             | lorem.txt |
+      | shareWith        | user2     |
+      | expireDate       | +30       |
+    And user "user1" has logged in using the webUI
+    And the setting "shareapi_expire_after_n_days_user_share" of app "core" has been set to "10"
+    When the user tries to edit the collaborator "User Two" of file "lorem.txt" changing following
+      | expireDate       | +15    |
+    Then the user should see an error message on the collaborator share dialog saying "Cannot set expiration date more than 10 days in the future"
+    And user "user1" should have a share with these details:
+      | field       | value      |
+      | path        | /lorem.txt |
+      | share_type  | user       |
+      | uid_owner   | user1      |
+      | share_with  | user2      |
+      | expiration  | +30        |
+
   @issue-3174
   Scenario Outline: enforced expiry date for group affect user shares
     Given the setting "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -663,6 +663,30 @@ Feature: Sharing files and folders with internal users
       | lorem.txt       |
       | simple-folder   |
 
+  Scenario: user cannot concurrently update the role and date of a share after the system maximum expiry date has been reduced
+    Given the setting "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
+    And the setting "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
+    And the setting "shareapi_expire_after_n_days_user_share" of app "core" has been set to "30"
+    And user "user1" has created a new share with following settings
+      | path             | lorem.txt |
+      | shareWith        | user2     |
+      | expireDate       | +30       |
+      | permissionString | read      |
+    And user "user1" has logged in using the webUI
+    And the setting "shareapi_expire_after_n_days_user_share" of app "core" has been set to "10"
+    When the user tries to edit the collaborator "User Two" of file "lorem.txt" changing following
+      | expireDate       | +15    |
+      | permissionString | Editor |
+    Then the user should see an error message on the collaborator share dialog saying "Cannot set expiration date more than 10 days in the future"
+    And user "user1" should have a share with these details:
+      | field       | value      |
+      | path        | /lorem.txt |
+      | share_type  | user       |
+      | uid_owner   | user1      |
+      | share_with  | user2      |
+      | expiration  | +30        |
+      | permissions | read       |
+
   @issue-3174
   Scenario Outline: enforced expiry date for group affect user shares
     Given the setting "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"

--- a/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
@@ -531,9 +531,55 @@ module.exports = {
           disabled = result.value
         })
       return disabled
+    },
+    /**
+     * tries to change the settings of collaborator
+     * @param {string} collaborator Name of the collaborator
+     * @return {*}
+     */
+    changeCollaboratorSettings: async function (collaborator, editData) {
+      await collaboratorDialog.clickEditShare(collaborator)
+      for (const [key, value] of Object.entries(editData)) {
+        await this.setCollaboratorForm(key, value)
+      }
+      return this.waitForElementVisible('@saveShareButton')
+        .click('@saveShareButton')
+    },
+    /**
+     * function sets different fields for collaborator form
+     *
+     * @param key fields like permissionString, expireDate
+     * @param value values for the different fields to be set
+     * @returns {*|Promise<void>|exports}
+     */
+    setCollaboratorForm: function (key, value) {
+      if (key === 'permissionString') {
+        return this.changeCollaboratorRoleInDropdown(value)
+      } else if (key === 'expireDate') {
+        const dateToSet = calculateDate(value)
+        return this.openExpirationDatePicker()
+          .setExpirationDate(dateToSet)
+      }
+      return this
+    },
+    /**
+     *
+     * @returns {Promise<string>}
+     */
+    getErrorMessage: async function () {
+      let message
+      await this.waitForElementVisible('@collaboratorErrorAlert')
+        .getText('xpath', this.elements.collaboratorErrorAlert.selector, function (result) {
+          message = result.value
+        })
+      return message
     }
   },
   elements: {
+    collaboratorErrorAlert: {
+      selector: '//div[contains(@class, "collaborator-error-alert")]',
+      locateStrategy: 'xpath'
+    },
     sharingSidebarRoot: {
       selector: '//*[@id="oc-files-sharing-sidebar"]',
       locateStrategy: 'xpath'

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -163,6 +163,24 @@ Given('user {string} has created a new share with following settings',
     )
   })
 
+When('the user tries to edit the collaborator {string} of file/folder/resource {string} changing following',
+  async function (collaborator, resource, dataTable) {
+    const settings = dataTable.rowsHash()
+    const api = client.page.FilesPageElement
+    await api
+      .appSideBar()
+      .closeSidebar(100)
+      .openSharingDialog(resource)
+    return api.sharingDialog().changeCollaboratorSettings(collaborator, settings)
+  })
+
+Then('the user should see an error message on the collaborator share dialog saying {string}', async function (expectedMessage) {
+  const actualMessage = await client.page.FilesPageElement
+    .sharingDialog()
+    .getErrorMessage()
+  return client.assert.strictEqual(actualMessage, expectedMessage)
+})
+
 /**
  * sets up data into a standard format for creating new public link share
  *


### PR DESCRIPTION
## Description
A new test scenario has been added to check for the error message in contributor share with respect to the changes made in https://github.com/owncloud/phoenix/pull/3241

## How Has This Been Tested?
locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...