### PR TITLE
Transpile with babel only src folder in core

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -81,9 +81,7 @@ module.exports = {
       {
         test: /\.js$/,
         use: 'babel-loader',
-        include: [
-          /src/
-        ]
+        include: path.resolve(__dirname, './src')
       },
       {
         test: /\.jsx?$/,


### PR DESCRIPTION
## Description
Resolve path of src folder in `include` in babel-loader.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #3338