### PR TITLE
Remove obsolete (and duplicate) error alert

### DIFF
--- a/apps/files/src/components/ocDialogPrompt.vue
+++ b/apps/files/src/components/ocDialogPrompt.vue
@@ -15,13 +15,6 @@
         :fix-message-line="true"
         class="oc-dialog-prompt-input-offset"
       ></oc-text-input>
-      <transition name="custom-classes-transition"
-                  enter-active-class="uk-animation-slide-left-small uk-animation-fast"
-                  leave-active-class="uk-animation-slide-right-small uk-animation-fast uk-animation-reverse">
-        <oc-alert v-if="ocErrorDelayed" class="oc-dialog-prompt-alert" :noClose="true" variation="danger">
-          {{ ocErrorDelayed }}
-        </oc-alert>
-      </transition>
       <oc-loader v-if="ocLoading"></oc-loader>
     </template>
     <template slot="footer">

--- a/changelog/unreleased/3342
+++ b/changelog/unreleased/3342
@@ -1,0 +1,6 @@
+Bugfix: Remove duplicate error display in input prompt
+
+Validation errors within the input prompt dialog were showing up twice. One of them is a leftover from the
+old version. We've fixed the dialog by removing the old validation error type.
+
+https://github.com/owncloud/phoenix/pull/3342


### PR DESCRIPTION
## Description
Somehow the old `oc-alert` snuck in in the dialog prompt. When squashing the recent PR which added the new error message in `oc-text-input` I dropped a commit - I suppose that removing the old `oc-alert` was part of that commit and I've probably missed that... This PR fixes the dialog prompt by removing it again.
## Motivation and Context
Dialog prompt shows the error message twice right now. Once within the oc-text-input component and once as an alert below. Obviously the alert has to be removed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally in Chrome and Firefox.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 