### PR TITLE
[Tests-only] add slash at the end of redirect_uri to allow correct logout

### DIFF
--- a/tests/drone/identifier-registration.yml
+++ b/tests/drone/identifier-registration.yml
@@ -8,7 +8,7 @@ clients:
     insecure: yes
     redirect_uris:
       - http://phoenix:9100/oidc-callback.html
-      - http://phoenix:9100
+      - http://phoenix:9100/
     origins:
       -  http://phoenix:9100
 


### PR DESCRIPTION
## Description
for the logout to work correctly with kopano, we need the `/` at the end of the uri

## Motivation and Context
avoiding future confusion

## How Has This Been Tested?
:robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...