### PR TITLE
Fix extension name for top bar on broken applications

### DIFF
--- a/changelog/unreleased/3376
+++ b/changelog/unreleased/3376
@@ -1,0 +1,6 @@
+Bugfix: Fix name of selected extension on broken apps
+
+With the edge case of a broken app in config.json, the top bar is broken, because appInfo can't be loaded.
+We made ocis-web more robust by just showing the extension id in the top bar when the appInfo is not available.
+
+https://github.com/owncloud/phoenix/pull/3376

--- a/src/components/Top-Bar.vue
+++ b/src/components/Top-Bar.vue
@@ -80,7 +80,10 @@ export default {
     },
 
     currentExtensionName() {
-      return this.$gettext(this.apps[this.currentExtension].name)
+      if (this.apps[this.currentExtension]) {
+        return this.$gettext(this.apps[this.currentExtension].name)
+      }
+      return this.currentExtension
     }
   },
   methods: {


### PR DESCRIPTION
## Description
With the edge case of a broken app in config.json, the top bar is broken, because `appInfo` can't be loaded. This PR makes ocis-web more robust by just showing the extension id when the appInfo is not available.

## Motivation and Context
Make ocis-web more robust.

## How Has This Been Tested?
Locally with chrome and firefox.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 