### PR TITLE
Send mtime with uploads

### DIFF
--- a/apps/files/src/mixins.js
+++ b/apps/files/src/mixins.js
@@ -421,8 +421,15 @@ export default {
             })
           })
         } else {
+          const extraHeaders = {}
+          if (file.lastModifiedDate) {
+            extraHeaders['X-OC-Mtime'] = '' + file.lastModifiedDate.getTime() / 1000
+          } else if (file.lastModified) {
+            extraHeaders['X-OC-Mtime'] = '' + file.lastModified / 1000
+          }
           promise = this.uploadQueue.add(() =>
             this.$client.files.putFileContents(relativePath, file, {
+              headers: extraHeaders,
               onProgress: progress => {
                 this.$_ocUpload_onProgress(progress, file)
               },

--- a/changelog/unreleased/3377
+++ b/changelog/unreleased/3377
@@ -1,0 +1,9 @@
+Enhancement: Send mtime with uploads
+
+When uploading a file, the modification time is now sent along.
+This means that the uploaded file will have the same modification time
+like the one it had on disk.
+This aligns the behavior with the desktop client which also keeps the mtime.
+
+https://github.com/owncloud/phoenix/issues/2969
+https://github.com/owncloud/phoenix/pull/3377


### PR DESCRIPTION
## Description
Aligns with the behavior of OC 10 which itself was aligned with the
behavior of the desktop client.

## Related Issue
Fixes https://github.com/owncloud/phoenix/issues/2969

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
See https://github.com/owncloud/phoenix/issues/2969

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...