### PR TITLE
Add engines information

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,5 +139,8 @@
       "yarn lint --fix",
       "git add"
     ]
+  },
+  "engines": { 
+    "node": ">=10 <13" 
   }
 }


### PR DESCRIPTION
## Description
I added engines information in package.json so other developers know which node version to use. This was after one of my colleague tried with node 14 and spent some time thinking about what the issue was.

## Related Issue
I think it's a bit overkill to create an issue for this?

## Motivation and Context
Developers trying to run phoenix with the wrong node version and spend a lot of time trying to figure out what is wrong in their setups.

## How Has This Been Tested?
Only information added, project builds.

## Types of changes
Updated information.

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
-  Unit tests added - can't add unit tests for this
-  Acceptance tests added - can't add acceptance tests for this