### PR TITLE
[Tests-only] revert selenium chrome docker image to 3.141.59-20200326

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -566,7 +566,7 @@ def browserService(alternateSuiteName, browser):
 	if browser == 'chrome':
 		return [{
 			'name': 'selenium',
-			'image': 'selenium/standalone-chrome-debug:latest',
+			'image': 'selenium/standalone-chrome-debug:3.141.59-20200326',
 			'pull': 'always',
 			'volumes': [{
 				'name': 'uploads',


### PR DESCRIPTION
## Description
CI failed when trying to make a screenshot, seems to be an issue in chromedriver, see https://github.com/SeleniumHQ/selenium/issues/8218
reverting selenium to 3.141.59-20200326

## Motivation and Context
make CI stable agail

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...