### PR TITLE
Fix share indicators click to open the correct panel

### DIFF
--- a/apps/files/src/components/AllFilesList.vue
+++ b/apps/files/src/components/AllFilesList.vue
@@ -91,11 +91,7 @@
         />
       </div>
       <div v-if="!$_isFavoritesList" class="uk-flex uk-flex-middle uk-flex-right">
-        <Indicators
-          :default-indicators="indicatorArray(rowItem)"
-          :item="rowItem"
-          @click="$_openSideBar"
-        />
+        <Indicators :default-indicators="indicatorArray(rowItem)" :item="rowItem" />
       </div>
       <div
         class="uk-text-meta uk-text-nowrap uk-width-small uk-text-right"
@@ -444,7 +440,7 @@ export default {
     },
 
     indicatorHandler(item, sideBarName) {
-      this.$emit('click', item, sideBarName)
+      this.$_openSideBar(item, sideBarName)
     }
   }
 }

--- a/apps/files/src/components/FilesLists/Indicators.vue
+++ b/apps/files/src/components/FilesLists/Indicators.vue
@@ -1,10 +1,6 @@
 <template>
   <span>
-    <div
-      v-if="displayDefaultIndicators"
-      :class="{ 'uk-margin-xsmall-right': customIndicators }"
-      @click="openSidebar"
-    >
+    <div v-if="displayDefaultIndicators" :class="{ 'uk-margin-xsmall-right': customIndicators }">
       <oc-button
         v-for="(indicator, index) in defaultIndicators"
         :key="index"
@@ -59,13 +55,6 @@ export default {
 
     customIndicators() {
       return this.customFilesListIndicators
-    }
-  },
-
-  methods: {
-    // TODO: Adjust to send the event via store
-    openSidebar(item, indicatorId) {
-      this.$emit('click', item, indicatorId)
     }
   }
 }

--- a/changelog/unreleased/3324
+++ b/changelog/unreleased/3324
@@ -1,0 +1,6 @@
+Bugfix: Fix share indicators click to open the correct panel
+
+When clicking on a share indicator inside a file list row, the correct share panel will now be displayed.
+
+https://github.com/owncloud/phoenix/issues/3324
+https://github.com/owncloud/phoenix/pull/3420


### PR DESCRIPTION
## Description
When clicking on a share indicator inside a file list row, the correct share panel will now be displayed.

## Related Issue
Fixes https://github.com/owncloud/phoenix/issues/3324

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manual test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...