### PR TITLE
Configure ocis proxy as default entry point

### DIFF
--- a/changelog/unreleased/3454
+++ b/changelog/unreleased/3454
@@ -1,0 +1,6 @@
+Bugfix: Set server config to ocis proxy in example config file
+
+We fixed the ocis example config to point to the default oCIS Proxy address
+instead of the default Phoenix service address.
+
+https://github.com/owncloud/phoenix/pull/3454

--- a/config.json.sample-ocis
+++ b/config.json.sample-ocis
@@ -1,5 +1,5 @@
 {
-  "server": "http://localhost:9140",
+  "server": "https://localhost:9200",
   "theme": "owncloud",
   "version": "0.1.0",
   "openIdConnect": {


### PR DESCRIPTION
## Description
With oCIS, everything has to run through the proxy (not critical now, but in the near future, when we need the proxy to append data to request headers). Changed default config for oCIS to reflect that.

## Motivation and Context

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- by running ocis single binary with env variable `PHOENIX_WEB_CONFIG` set to the `config.json.sample-ocis` file.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 