### PR TITLE
[Test-only] Create selenium command with port forwarding for mac

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -20,7 +20,9 @@ There are multiple ways to run Selenium:
 ### Setup using Docker
 
 - Set the environment variables `SELENIUM_HOST` as `localhost` and `SERVER_HOST` in the format `http://<ip_addr>:9100`.
-- Run `yarn run selenium`
+- Run `yarn run selenium` (available only on Linux)
+- If you are a Mac user, you can run `yarn run selenium:mac`
+  - This command creates docker container which uses port forwarding instead of host networking [which is not supported on Mac](https://docs.docker.com/network/host/)
 
 ### Setup using Docker Desktop for Mac
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "acceptance-tests": "cucumber-js --require-module @babel/register --require-module @babel/polyfill --require tests/acceptance/setup.js --require tests/acceptance/stepDefinitions --format node_modules/cucumber-pretty -t \"${TEST_TAGS:-not @skip and not @skipOnOC10}\"",
     "acceptance-tests-ocis": "cucumber-js --require-module @babel/register --require-module @babel/polyfill --require tests/acceptance/setup.js --require tests/acceptance/stepDefinitions --format node_modules/cucumber-pretty -t \"${TEST_TAGS:-not @skip and not @skipOnOCIS}\"",
     "acceptance-tests-drone": "cucumber-js --retry 1 --require-module @babel/register --require-module @babel/polyfill --require tests/acceptance/setup.js --require tests/acceptance/stepDefinitions --format node_modules/cucumber-pretty tests/acceptance/features/$TEST_CONTEXT -t \"${TEST_TAGS}\"",
-    "selenium": "docker run --rm -d --network=\"host\" -v /dev/shm:/dev/shm -v ${REMOTE_UPLOAD_DIR:-$PWD/tests/acceptance/filesForUpload}:${LOCAL_UPLOAD_DIR:-/uploads}:ro --name selenium selenium/standalone-chrome-debug"
+    "selenium": "docker run --rm -d --network=\"host\" -v /dev/shm:/dev/shm -v ${REMOTE_UPLOAD_DIR:-$PWD/tests/acceptance/filesForUpload}:${LOCAL_UPLOAD_DIR:-/uploads}:ro --name selenium selenium/standalone-chrome-debug",
+    "selenium:mac": "docker run --rm -d -p ${SELENIUM_PORT:-4444}:4444 -p 5900:5900 -v /dev/shm:/dev/shm -v ${REMOTE_UPLOAD_DIR:-$PWD/tests/acceptance/filesForUpload}:${LOCAL_UPLOAD_DIR:-/uploads}:ro --name selenium selenium/standalone-chrome-debug"
   },
   "author": "Felix Heidecke",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## Motivation and Context
`--network=host` option does not work in Mac https://docs.docker.com/network/host/