### PR TITLE
[Tests-only] Fix invalid depth header for recursion

### DIFF
--- a/tests/acceptance/features/webUIUpload/upload.feature
+++ b/tests/acceptance/features/webUIUpload/upload.feature
@@ -15,7 +15,7 @@ Feature: File Upload
     And file "new-lorem.txt" should be listed on the webUI
     And as "user1" the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 
-  @smokeTest @skipOnOCIS @issue-phoenix-3458
+  @smokeTest
   Scenario: simple upload of a folder that does not exist before
     When the user uploads a folder containing the following files in separate sub-folders using the webUI:
       | lorem.txt     |

--- a/tests/acceptance/helpers/webdavHelper.js
+++ b/tests/acceptance/helpers/webdavHelper.js
@@ -71,7 +71,7 @@ exports.move = function(userId, fromName, toName) {
  * @param {array} properties
  * @param {number} folderDepth
  */
-exports.propfind = function(path, userId, properties, folderDepth = 1) {
+exports.propfind = function(path, userId, properties, folderDepth = '1') {
   const davPath = encodeURI(path)
   let propertyBody = ''
   properties.map(prop => {

--- a/tests/acceptance/stepDefinitions/webdavContext.js
+++ b/tests/acceptance/stepDefinitions/webdavContext.js
@@ -69,7 +69,12 @@ Then(
     files = files.raw().map(item => item[0])
 
     const sessionId = client.sessionId
-    const response = await webdavHelper.propfind(`/files/${user}/${sessionId}`, user, [], 2)
+    const response = await webdavHelper.propfind(
+      `/files/${user}/${sessionId}`,
+      user,
+      [],
+      'infinity'
+    )
     const result = xml2js(response, { compact: true })
 
     const elements = _.get(result, 'd:multistatus.d:response')


### PR DESCRIPTION
Replaced depth:2 with depth:infinity for gathering deep folder contents

Fixes https://github.com/owncloud/phoenix/issues/3458

- [x] REQUIRES: https://github.com/owncloud/ocis-reva/issues/212 and https://github.com/cs3org/reva/pull/758
