### PR TITLE
Fetch settings values from sdk and use language code

### DIFF
--- a/changelog/unreleased/3484-1
+++ b/changelog/unreleased/3484-1
@@ -1,0 +1,7 @@
+Change: Make settings available in phoenix
+
+We upgraded to a new owncloud-sdk version which provides loading settings from the
+settings service, if available. The settings values are available throughout phoenix
+and all extensions.
+
+https://github.com/owncloud/phoenix/pull/3484

--- a/changelog/unreleased/3484-2
+++ b/changelog/unreleased/3484-2
@@ -1,0 +1,5 @@
+Change: Use language setting
+
+We've changed phoenix to make use of the language the authenticated user has chosen in the settings.
+
+https://github.com/owncloud/phoenix/pull/3484

--- a/config.json.sample-ocis
+++ b/config.json.sample-ocis
@@ -15,5 +15,11 @@
     "pdf-viewer",
     "markdown-editor",
     "media-viewer"
+  ],
+  "external_apps": [
+    {
+      "id": "settings",
+      "path": "http://localhost:9190/settings.js"
+    }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "npm-run-all": "^4.1.5",
     "oidc-client": "^1.9.1",
     "owncloud-design-system": "^1.5.0",
-    "owncloud-sdk": "^1.0.0-620",
+    "owncloud-sdk": "^1.0.0-630",
     "p-limit": "^2.2.1",
     "p-queue": "^6.1.1",
     "parse-json": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "npm-run-all": "^4.1.5",
     "oidc-client": "^1.9.1",
     "owncloud-design-system": "^1.5.0",
-    "owncloud-sdk": "^1.0.0-608",
+    "owncloud-sdk": "^1.0.0-620",
     "p-limit": "^2.2.1",
     "p-queue": "^6.1.1",
     "parse-json": "^5.0.0",

--- a/src/Phoenix.vue
+++ b/src/Phoenix.vue
@@ -64,7 +64,8 @@ export default {
       'activeNotifications',
       'activeMessages',
       'capabilities',
-      'apps'
+      'apps',
+      'getSettingsValueByIdentifier'
     ]),
     $_applicationsList() {
       const list = []
@@ -154,6 +155,14 @@ export default {
       }
 
       return 'fade'
+    },
+
+    selectedLanguage() {
+      return this.getSettingsValueByIdentifier({
+        extension: 'ocis-accounts',
+        bundleKey: 'profile',
+        settingKey: 'language'
+      })
     }
   },
   watch: {
@@ -175,6 +184,16 @@ export default {
           this.$_updateNotifications()
         }, 30000)
       }
+    },
+    selectedLanguage: {
+      handler(language) {
+        if (language !== null) {
+          this.$language.current = language.listValue.values[0].stringValue
+        } else if (this.$language.defaultLanguage) {
+          this.$language.current = this.$language.defaultLanguage
+        }
+      },
+      immediate: true
     }
   },
 

--- a/src/Phoenix.vue
+++ b/src/Phoenix.vue
@@ -187,10 +187,12 @@ export default {
     },
     selectedLanguage: {
       handler(language) {
-        if (language !== null) {
-          this.$language.current = language.listValue.values[0].stringValue
-        } else if (this.$language.defaultLanguage) {
-          this.$language.current = this.$language.defaultLanguage
+        let languageCode = this.$language.defaultLanguage
+        if (language !== null && language.listValue.values.length > 0) {
+          languageCode = language.listValue.values[0].stringValue
+        }
+        if (languageCode) {
+          this.$language.current = languageCode
         }
       },
       immediate: true

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -9,6 +9,7 @@ import apps from './apps'
 import config from './config'
 import user from './user'
 import router from './router'
+import settings from './settings'
 
 Vue.use(Vuex)
 
@@ -34,7 +35,8 @@ export const Store = new Vuex.Store({
     apps,
     user,
     config,
-    router
+    router,
+    settings
   },
   strict
 })

--- a/src/store/settings.js
+++ b/src/store/settings.js
@@ -1,0 +1,74 @@
+const state = {
+  settingsValues: null
+}
+
+const actions = {
+  async loadSettingsValues({ commit }) {
+    commit('CLEAR_SETTINGS_VALUES')
+    const values = await this._vm.$client.settings.getSettingsValues()
+    commit('SET_SETTINGS_VALUES', values)
+  }
+}
+
+const mutations = {
+  CLEAR_SETTINGS_VALUES(state) {
+    state.settingsValues = null
+  },
+  SET_SETTINGS_VALUES(state, settingsValues) {
+    const map = new Map()
+    Array.from(settingsValues).forEach(value => applySettingsValueToMap(value, map))
+    state.settingsValues = map
+  },
+  SET_SETTINGS_VALUE(state, settingsValue) {
+    const map = new Map(state.settingsValues)
+    applySettingsValueToMap(settingsValue, map)
+    state.settingsValues = map
+  }
+}
+
+const getters = {
+  settingsValuesLoaded: state => {
+    return state.settingsValues !== null
+  },
+  hasSettingsValue: (state, getters) => ({ extension, bundleKey, settingKey }) => {
+    return getters.getSettingsValueByIdentifier({ extension, bundleKey, settingKey }) !== null
+  },
+  getSettingsValueByIdentifier: (state, getters) => ({ extension, bundleKey, settingKey }) => {
+    if (
+      getters.settingsValuesLoaded &&
+      state.settingsValues.has(extension) &&
+      state.settingsValues.get(extension).has(bundleKey) &&
+      state.settingsValues
+        .get(extension)
+        .get(bundleKey)
+        .has(settingKey)
+    ) {
+      return state.settingsValues
+        .get(extension)
+        .get(bundleKey)
+        .get(settingKey)
+    }
+    return null
+  }
+}
+
+export default {
+  state,
+  actions,
+  mutations,
+  getters
+}
+
+function applySettingsValueToMap(settingsValue, map) {
+  if (!map.has(settingsValue.identifier.extension)) {
+    map.set(settingsValue.identifier.extension, new Map())
+  }
+  if (!map.get(settingsValue.identifier.extension).has(settingsValue.identifier.bundleKey)) {
+    map.get(settingsValue.identifier.extension).set(settingsValue.identifier.bundleKey, new Map())
+  }
+  map
+    .get(settingsValue.identifier.extension)
+    .get(settingsValue.identifier.bundleKey)
+    .set(settingsValue.identifier.settingKey, settingsValue)
+  return map
+}

--- a/src/store/settings.js
+++ b/src/store/settings.js
@@ -3,21 +3,32 @@ const state = {
 }
 
 const actions = {
-  async loadSettingsValues({ commit }) {
-    commit('CLEAR_SETTINGS_VALUES')
-    const values = await this._vm.$client.settings.getSettingsValues()
-    commit('SET_SETTINGS_VALUES', values)
+  async loadSettingsValues({ commit, state, dispatch }) {
+    const oldSettingsValues = state.settingsValues
+    commit('SET_SETTINGS_VALUES', null)
+    try {
+      const values = await this._vm.$client.settings.getSettingsValues()
+      commit('SET_SETTINGS_VALUES', values)
+    } catch (error) {
+      commit('SET_SETTINGS_VALUES', oldSettingsValues)
+      dispatch('showMessage', {
+        title: 'Failed to load settings values.',
+        desc: error.response.statusText,
+        status: 'danger'
+      })
+    }
   }
 }
 
 const mutations = {
-  CLEAR_SETTINGS_VALUES(state) {
-    state.settingsValues = null
-  },
   SET_SETTINGS_VALUES(state, settingsValues) {
-    const map = new Map()
-    Array.from(settingsValues).forEach(value => applySettingsValueToMap(value, map))
-    state.settingsValues = map
+    if (settingsValues === null) {
+      state.settingsValues = null
+    } else {
+      const map = new Map()
+      Array.from(settingsValues).forEach(value => applySettingsValueToMap(value, map))
+      state.settingsValues = map
+    }
   },
   SET_SETTINGS_VALUE(state, settingsValue) {
     const map = new Map(state.settingsValues)

--- a/src/store/user.js
+++ b/src/store/user.js
@@ -29,6 +29,7 @@ const actions = {
   logout(context) {
     const logoutFinalizer = () => {
       context.dispatch('cleanUpLoginState')
+      context.dispatch('loadSettingsValues')
       // force redirect to login page after logout
       router.push({ name: 'login' })
     }
@@ -82,6 +83,7 @@ const actions = {
                   isAuthenticated: true,
                   groups: groups
                 })
+                context.dispatch('loadSettingsValues')
 
                 if (payload.autoRedirect) {
                   router.push({ path: '/' })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2907,9 +2907,9 @@ date-fns@^1.27.2:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
-"davclient.js@https://github.com/owncloud/davclient.js.git":
+"davclient.js@git+https://github.com/owncloud/davclient.js.git":
   version "0.2.1"
-  resolved "https://github.com/owncloud/davclient.js.git#bf19f590451b3c0658913568053ec7f300f7dfc1"
+  resolved "git+https://github.com/owncloud/davclient.js.git#bf19f590451b3c0658913568053ec7f300f7dfc1"
 
 de-indent@^1.0.2:
   version "1.0.2"
@@ -6944,11 +6944,12 @@ owncloud-design-system@^1.5.0:
     webfontloader "^1.6.28"
     weekstart "^1.0.0"
 
-owncloud-sdk@^1.0.0-608:
-  version "1.0.0-608"
-  resolved "https://registry.yarnpkg.com/owncloud-sdk/-/owncloud-sdk-1.0.0-608.tgz#d5263fd4ce7e804d00d8024373d45191a8714f93"
-  integrity sha512-iVKUsSq+Lywxncj54bUu/vSD1A98RrrKPG3WgSdoXyGJv5bdoosFMYVo+gSOsWvVBMCIBIwVRUwvnVfRsSEcKg==
+owncloud-sdk@^1.0.0-620:
+  version "1.0.0-620"
+  resolved "https://registry.yarnpkg.com/owncloud-sdk/-/owncloud-sdk-1.0.0-620.tgz#f1957a945a5bc163ceb76978fefb128a90dd9942"
+  integrity sha512-B9eq9Yhyk1VnXveeHaT/aBTXCWMVaTD7Se63Jgdp34eYJ3y3tiPcWbGbe8prM3EiFqty+Pi5ggyK6DabTaUgeg==
   dependencies:
+    axios "^0.19.2"
     browser-request "^0.3.3"
     davclient.js "https://github.com/owncloud/davclient.js.git"
     promise "^8.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6944,10 +6944,10 @@ owncloud-design-system@^1.5.0:
     webfontloader "^1.6.28"
     weekstart "^1.0.0"
 
-owncloud-sdk@^1.0.0-620:
-  version "1.0.0-620"
-  resolved "https://registry.yarnpkg.com/owncloud-sdk/-/owncloud-sdk-1.0.0-620.tgz#f1957a945a5bc163ceb76978fefb128a90dd9942"
-  integrity sha512-B9eq9Yhyk1VnXveeHaT/aBTXCWMVaTD7Se63Jgdp34eYJ3y3tiPcWbGbe8prM3EiFqty+Pi5ggyK6DabTaUgeg==
+owncloud-sdk@^1.0.0-630:
+  version "1.0.0-630"
+  resolved "https://registry.yarnpkg.com/owncloud-sdk/-/owncloud-sdk-1.0.0-630.tgz#48ab65a28578ddf2c076b2c9357620cbb95a3581"
+  integrity sha512-pW039ulDKdZutmL2AU/Sv0STDLRYGbPM2XnY5sehK/IvRDVMhceqy+5c9aN2f2AsBk6Am5OzH/v1lwH9/dWCCw==
   dependencies:
     axios "^0.19.2"
     browser-request "^0.3.3"


### PR DESCRIPTION
This PR depends on https://github.com/owncloud/owncloud-sdk/pull/475, so this has to stay WIP until the SDK-PR is merged and released.

## Description
We have a settings service, that is supposed to be integrated in Phoenix like described [in the docs](https://owncloud.github.io/extensions/ocis_settings/)

This PR uses settings values, coming from the settings service, to adapt the Phoenix UI for the authenticated user. At the moment, only the `language` setting is used: Changing the language in the settings frontend (has to be configured as a Phoenix app) results in having another language in Phoenix. In the future we can make use of this for a variety of customization:
- chosen theme
- notification preferences
- preferences regarding the shown elements in the files list (e.g. different quick actions)
- ...

## Related Issue
https://github.com/owncloud/product/issues/17

## Motivation and Context
We want to provide a customized user experience for users.

## How Has This Been Tested?
So far only in Chrome and Firefox. No tests implemented so far.

## Screenshots (if appropriate):
#### English UI
![Screenshot 2020-05-20 at 10 48 12](https://user-images.githubusercontent.com/3532843/82426002-94724280-9a87-11ea-9122-a3fd122e1c10.png)

#### Changed language to French
![Screenshot 2020-05-20 at 10 49 16](https://user-images.githubusercontent.com/3532843/82426041-a0f69b00-9a87-11ea-817d-4db94aa08015.png)

#### French UI (at least everything that's translated already)
![Screenshot 2020-05-20 at 10 48 55](https://user-images.githubusercontent.com/3532843/82426067-a7851280-9a87-11ea-947c-18c2a90d2b0c.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Depends on release of https://github.com/owncloud/owncloud-sdk/pull/475
- [x] Discuss tests