### PR TITLE
Add missing question mark in trashbin delete dialog

### DIFF
--- a/apps/files/src/components/FilesApp.vue
+++ b/apps/files/src/components/FilesApp.vue
@@ -69,8 +69,7 @@ export default {
       upload: false,
       fileName: '',
       selected: [],
-      breadcrumbs: [],
-      self: {}
+      breadcrumbs: []
     }
   },
   computed: {

--- a/apps/files/src/mixins/deleteResources.js
+++ b/apps/files/src/mixins/deleteResources.js
@@ -68,7 +68,7 @@ export default {
         ? this.$gettext(
             'Are you sure you want to delete all selected resources? All their content will be permanently removed. This action cannot be undone.'
           )
-        : this.$gettext('Are you sure you want to delete all selected resources')
+        : this.$gettext('Are you sure you want to delete all selected resources?')
     }
   },
 

--- a/changelog/unreleased/trashbin-delete-confirmation-question-mark
+++ b/changelog/unreleased/trashbin-delete-confirmation-question-mark
@@ -1,0 +1,5 @@
+Bugfix: Add missing question mark to delete confirmation dialog in trashbin
+
+We've added missing question mark to the delete confirmation dialog inside of the trashbin.
+
+https://github.com/owncloud/phoenix/pull/3566


### PR DESCRIPTION
## Description
Follow up on #3378. The mentioned PR got merged before addressing comments about `self` key in data and missing question mark. This PR fixes that.