### PR TITLE
Unite direct and indirect indicators

### DIFF
--- a/apps/files/src/components/AllFilesList.vue
+++ b/apps/files/src/components/AllFilesList.vue
@@ -337,7 +337,6 @@ export default {
         label: this.shareUserIconLabel(item),
         visible: this.isUserShare(item),
         icon: 'group',
-        status: this.shareUserIconVariation(item),
         handler: this.indicatorHandler
       }
       const links = {
@@ -345,7 +344,6 @@ export default {
         label: this.shareLinkIconLabel(item),
         visible: this.isLinkShare(item),
         icon: 'link',
-        status: this.shareLinkIconVariation(item),
         handler: this.indicatorHandler
       }
       const indicators = []
@@ -396,14 +394,6 @@ export default {
 
     isLinkShare(item) {
       return this.isDirectLinkShare(item) || this.isIndirectLinkShare(item)
-    },
-
-    shareUserIconVariation(item) {
-      return this.isDirectUserShare(item) ? 'active' : 'passive'
-    },
-
-    shareLinkIconVariation(item) {
-      return this.isDirectLinkShare(item) ? 'active' : 'passive'
     },
 
     shareUserIconLabel(item) {

--- a/apps/files/src/components/FilesLists/Indicators.vue
+++ b/apps/files/src/components/FilesLists/Indicators.vue
@@ -10,12 +10,7 @@
         variation="raw"
         @click="indicator.handler(item, indicator.id)"
       >
-        <oc-icon
-          :name="indicator.icon"
-          class="uk-text-middle"
-          size="small"
-          :variation="indicator.status"
-        />
+        <oc-icon :name="indicator.icon" class="uk-text-middle" size="small" variation="system" />
       </oc-button>
     </div>
     <template v-if="customIndicators">

--- a/changelog/unreleased/unite-status-indicators
+++ b/changelog/unreleased/unite-status-indicators
@@ -1,0 +1,7 @@
+Change: Unite files list status indicators
+
+We've merged direct and indirect status indicators in the files list.
+With this change, we focus on the important information of the indicator (e.g. resource is shared).
+Any additional information can then be displayed in the related tab of the sidebar.
+
+https://github.com/owncloud/phoenix/pull/3567


### PR DESCRIPTION
## Description
Merge direct and indirect status indicators in the files list to one indicator.

## Motivation and Context
The important information for the user is that the file is shared. If it is direct or indirect comes secondary and so it doesn't necessarily need to be visible at first glance. By uniting those two indicators we are saving space and removing one additional feature that the user might need to learn. The difference between the shares is still available in the sidebar.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests