### PR TITLE
Use chunk size and method override from caps

### DIFF
--- a/apps/files/src/mixins.js
+++ b/apps/files/src/mixins.js
@@ -447,9 +447,20 @@ export default {
         // FIXME: this might break if relativePath is not the currentFolder
         // and is a mount point that has no chunk support
         if (this.browserSupportsChunked && this.currentFolder.isChunkedUploadSupported) {
+          let chunkSize = this.configuration.uploadChunkSize
+          if (this.capabilities.files.tus_support.max_chunk_size > 0) {
+            if (
+              chunkSize === null ||
+              chunkSize === 0 ||
+              chunkSize > this.capabilities.files.tus_support.max_chunk_size
+            ) {
+              chunkSize = this.capabilities.files.tus_support.max_chunk_size
+            }
+          }
           promise = this.uploadQueue.add(() => {
             return this.uploadChunkedFile(file, pathUtil.dirname(relativePath), {
-              chunkSize: this.configuration.uploadChunkSize,
+              chunkSize: chunkSize,
+              overridePatchMethod: !!this.capabilities.files.tus_support.http_method_override,
               emitProgress: progress => {
                 this.$_ocUpload_onProgress(progress, file)
               }

--- a/changelog/unreleased/3568
+++ b/changelog/unreleased/3568
@@ -1,0 +1,11 @@
+Enhancement: Use TUS settings from capabilities
+
+The TUS settings advertise the maximum chunk size, so we now use the smallest chunk size from
+the one configured in config.json and the one from the capabilities.
+
+If the capabilities report that one should use the X-HTTP-Override-Method header,
+the upload will now use a POST request for uploads with that header set
+instead of PATCH.
+
+https://github.com/owncloud/ocis-reva/issues/177
+https://github.com/owncloud/phoenix/pull/3568

--- a/src/plugins/upload.js
+++ b/src/plugins/upload.js
@@ -25,6 +25,7 @@ export default {
               headers: headers,
               chunkSize: options.chunkSize || Infinity,
               removeFingerprintOnSuccess: true,
+              overridePatchMethod: !!options.overridePatchMethod,
               retryDelays: [0, 3000, 5000, 10000, 20000],
               metadata: {
                 filename: file.name,


### PR DESCRIPTION
Use the chunk size from the capabilities if it is higher than the
locally configured one.

Use HTTP method override mode if the TUS capabilities says so.

For https://github.com/owncloud/ocis-reva/issues/177.
Requires https://github.com/owncloud/ocis-reva/pull/228 for testing the capabilities
Requires https://github.com/cs3org/reva/pull/792 for testing the method override.

I've tested with the above PRs and the upload is using the correct chunk value and is also setting `overridePatchMethod` whenever the matching capability is set.

Note: merging this should be safe due to default values.