### PR TITLE
Load and display quick actions

### DIFF
--- a/apps/files/package.json
+++ b/apps/files/package.json
@@ -25,6 +25,7 @@
     "@babel/preset-env": "^7.6.0",
     "@babel/register": "^7.6.0",
     "babel-loader": "^8.0.6",
+    "copy-to-clipboard": "^3.3.1",
     "core-js": "3.6.4",
     "css-loader": "^3.1.0",
     "intersection-observer": "^0.7.0",

--- a/apps/files/src/components/AllFilesList.vue
+++ b/apps/files/src/components/AllFilesList.vue
@@ -35,7 +35,7 @@
       </div>
       <div
         :class="{ 'uk-visible@s': !_sidebarOpen, 'uk-hidden': _sidebarOpen }"
-        class="uk-text-nowrap uk-text-meta uk-width-small uk-margin-right"
+        class="uk-text-nowrap uk-text-meta uk-width-small"
       >
         <sortable-column-header
           :aria-label="$gettext('Sort files by updated time')"
@@ -45,7 +45,7 @@
           @click="toggleSort('mdateMoment')"
         >
           <translate
-            translate-context="Short column label in files able for the time at which a file was modified"
+            translate-context="Short column label in files table for the time at which a file was modified"
             >Updated</translate
           >
         </sortable-column-header>
@@ -90,6 +90,9 @@
       >
         {{ formDateFromNow(rowItem.mdate) }}
       </div>
+    </template>
+    <template #rowActions="{ item: rowItem }">
+      <quick-actions :actions="app.quickActions" :item="rowItem" />
     </template>
     <template #noContentMessage>
       <no-content-message v-if="!$_isFavoritesList" icon="folder">
@@ -155,11 +158,12 @@ import FileList from './FileList.vue'
 import Indicators from './FilesLists/Indicators.vue'
 import FileItem from './FileItem.vue'
 import NoContentMessage from './NoContentMessage.vue'
-import { mapGetters, mapActions, mapState } from 'vuex'
+import QuickActions from './FilesLists/QuickActions.vue'
+import SortableColumnHeader from './FilesLists/SortableColumnHeader.vue'
 
+import { mapGetters, mapActions, mapState } from 'vuex'
 import Mixins from '../mixins'
 import FileActions from '../fileactions'
-import SortableColumnHeader from './FilesLists/SortableColumnHeader.vue'
 import intersection from 'lodash/intersection'
 import { shareTypes, userShareTypes } from '../helpers/shareTypes'
 import { getParentPaths } from '../helpers/path'
@@ -171,7 +175,8 @@ export default {
     Indicators,
     FileItem,
     NoContentMessage,
-    SortableColumnHeader
+    SortableColumnHeader,
+    QuickActions
   },
   mixins: [Mixins, FileActions],
   props: {
@@ -199,7 +204,7 @@ export default {
     }
   },
   computed: {
-    ...mapState(['route']),
+    ...mapState(['route', 'app']),
     ...mapGetters('Files', [
       'loadingFolder',
       'activeFiles',

--- a/apps/files/src/components/Collaborators/SharedFilesList.vue
+++ b/apps/files/src/components/Collaborators/SharedFilesList.vue
@@ -42,7 +42,7 @@
         translate-context="Owner table column"
         v-text="$gettext('Owner')"
       />
-      <div class="uk-visible@s uk-text-nowrap uk-text-meta uk-width-small uk-margin-right">
+      <div class="uk-visible@s uk-text-nowrap uk-text-meta uk-width-small">
         <sortable-column-header
           :aria-label="$gettext('Sort files by share time')"
           :is-active="fileSortField == 'shareTimeMoment'"
@@ -53,6 +53,7 @@
           <translate translate-context="Share time column in files table">Share time</translate>
         </sortable-column-header>
       </div>
+      <div class="oc-icon" />
     </template>
     <template #rowColumns="{ item }">
       <div class="uk-text-truncate uk-width-expand">

--- a/apps/files/src/components/FileList.vue
+++ b/apps/files/src/components/FileList.vue
@@ -24,7 +24,14 @@
           />
         </div>
         <slot name="headerColumns" />
-        <div class="uk-margin-small-right oc-icon" />
+        <div
+          v-if="$scopedSlots.rowActions"
+          class="uk-text-nowrap uk-text-meta uk-text-right uk-width-small"
+        >
+          <translate translate-context="Short column label in files table for the actions"
+            >Actions</translate
+          >
+        </div>
       </oc-grid>
       <div v-if="!loading" id="files-list-container" class="uk-flex-1 uk-overflow-auto">
         <RecycleScroller
@@ -61,7 +68,11 @@
                 />
               </div>
               <slot name="rowColumns" :item="rowItem" :index="index" />
-              <div class="uk-text-right uk-margin-left uk-margin-small-right">
+              <div
+                class="uk-flex uk-flex-middle uk-flex-right"
+                :class="{ 'uk-width-small': $scopedSlots.rowActions }"
+              >
+                <slot name="rowActions" :item="rowItem" />
                 <oc-button
                   :id="actionsDropdownButtonId(rowItem.viewId, active)"
                   class="files-list-row-show-actions"
@@ -101,7 +112,7 @@ import { mapGetters, mapActions, mapState } from 'vuex'
 import { RecycleScroller } from 'vue-virtual-scroller'
 import 'vue-virtual-scroller/dist/vue-virtual-scroller.css'
 
-const RowActionsDropdown = () => import('./FilesLists/RowActionsDropdown.vue')
+import RowActionsDropdown from './FilesLists/RowActionsDropdown.vue'
 
 export default {
   name: 'FileList',

--- a/apps/files/src/components/FilesLists/QuickActions.vue
+++ b/apps/files/src/components/FilesLists/QuickActions.vue
@@ -1,0 +1,31 @@
+<template>
+  <div>
+    <oc-button
+      v-for="action in actions"
+      :id="`files-quick-action-${action.id}`"
+      :key="action.label"
+      :aria-label="$gettext(action.label)"
+      variation="raw"
+      @click.native.stop="action.handler({ item, client: $client, store: $store })"
+    >
+      <oc-icon :name="action.icon" aria-hidden="true" size="small" class="uk-flex" />
+    </oc-button>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'QuickActions',
+
+  props: {
+    actions: {
+      type: Object,
+      required: true
+    },
+    item: {
+      type: Object,
+      required: true
+    }
+  }
+}
+</script>

--- a/apps/files/src/components/Trashbin.vue
+++ b/apps/files/src/components/Trashbin.vue
@@ -25,7 +25,7 @@
             class="uk-text-nowrap uk-text-meta uk-width-small"
           >
             <sortable-column-header
-              class="uk-align-right uk-margin-right"
+              class="uk-align-right"
               :aria-label="$gettext('Sort files by deletion time')"
               :is-active="fileSortField === 'deleteTimestampMoment'"
               :is-desc="fileSortDirectionDesc"
@@ -36,6 +36,7 @@
               </translate>
             </sortable-column-header>
           </div>
+          <div class="oc-icon" />
         </template>
         <template #rowColumns="{ item }">
           <div class="uk-text-truncate uk-width-expand">

--- a/apps/files/src/default.js
+++ b/apps/files/src/default.js
@@ -9,8 +9,9 @@ import FileLinkSidebar from './components/FileLinkSidebar.vue'
 import PrivateLink from './components/PrivateLink.vue'
 import PublicLink from './components/PublicLinks/PublicLink.vue'
 import FilesDrop from './components/PublicLinks/FilesDrop.vue'
-import translationsJson from '../l10n/translations.json'
 
+import translationsJson from '../l10n/translations.json'
+import quickActionsImport from './quickActions'
 const store = require('./store')
 
 // just a dummy function to trick gettext tools
@@ -217,11 +218,16 @@ const routes = [
   }
 ]
 
+// Prepare imported modules to be exported
+// If we do not define these constants, the export will be undefined
 const translations = translationsJson
+const quickActions = quickActionsImport
+
 export default define({
   appInfo,
   store,
   routes,
   navItems,
+  quickActions,
   translations
 })

--- a/apps/files/src/quickActions.js
+++ b/apps/files/src/quickActions.js
@@ -1,0 +1,49 @@
+import moment from 'moment'
+import copyToClipboard from 'copy-to-clipboard'
+
+// just a dummy function to trick gettext tools
+function $gettext(msg) {
+  return msg
+}
+
+function createPublicLink(ctx) {
+  // FIXME: Translate name
+  const params = { name: 'Quick action link' }
+  const capabilities = ctx.store.state.user.capabilities
+  const expirationDate = capabilities.files_sharing.public.expire_date
+
+  if (expirationDate.enabled) {
+    params.expireDate = moment()
+      .add(parseInt(expirationDate.days, 10), 'days')
+      .endOf('day')
+      .toISOString()
+  }
+
+  return new Promise((resolve, reject) => {
+    ctx.client.shares
+      .shareFileWithLink(ctx.item.path, params)
+      .then(res => {
+        copyToClipboard(res.shareInfo.url)
+        ctx.store.dispatch('showMessage', {
+          title: $gettext('Public link created'),
+          desc: $gettext(
+            'Public link has been successfully created and copied into your clipboard.'
+          ),
+          status: 'success'
+        })
+        resolve()
+      })
+      .catch(e => {
+        reject(e)
+      })
+  })
+}
+
+export default {
+  publicLink: {
+    id: 'public-link',
+    label: $gettext('Create and copy public link'),
+    icon: 'link',
+    handler: createPublicLink
+  }
+}

--- a/apps/files/yarn.lock
+++ b/apps/files/yarn.lock
@@ -1184,7 +1184,7 @@
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
   integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
 
-abbrev@1, abbrev@^1.1.1:
+abbrev@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
@@ -1305,7 +1305,7 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-aproba@^1.0.3, aproba@^1.1.1:
+aproba@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
   integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
@@ -1314,14 +1314,6 @@ archy@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
   integrity sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=
-
-are-we-there-yet@~1.1.2:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz#4b35c2944f062a8bfcda66410760350fe9ddfc21"
-  integrity sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==
-  dependencies:
-    delegates "^1.0.0"
-    readable-stream "^2.0.6"
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -1903,11 +1895,6 @@ console-browserify@^1.1.0:
   resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.2.0.tgz#67063cef57ceb6cf4993a2ab3a55840ae8c49336"
   integrity sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==
 
-console-control-strings@^1.0.0, console-control-strings@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
-  integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
-
 consolidate@^0.15.1:
   version "0.15.1"
   resolved "https://registry.yarnpkg.com/consolidate/-/consolidate-0.15.1.tgz#21ab043235c71a07d45d9aad98593b0dba56bab7"
@@ -1943,6 +1930,13 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
+
+copy-to-clipboard@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz#115aa1a9998ffab6196f93076ad6da3b913662ae"
+  integrity sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==
+  dependencies:
+    toggle-selection "^1.0.6"
 
 core-js-compat@^3.6.2:
   version "3.6.5"
@@ -2172,11 +2166,6 @@ degenerator@^1.0.4:
     escodegen "1.x.x"
     esprima "3.x.x"
 
-delegates@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
-  integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
-
 depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
@@ -2194,11 +2183,6 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
   integrity sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 diff@^4.0.1:
   version "4.0.2"
@@ -2749,13 +2733,6 @@ fs-constants@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
-fs-minipass@^1.2.5:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
-  integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
-  dependencies:
-    minipass "^2.6.0"
-
 fs-readdir-recursive@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz#e32fc030a2ccee44a6b5371308da54be0b397d27"
@@ -2801,20 +2778,6 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
-
-gauge@~2.7.3:
-  version "2.7.4"
-  resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
-  integrity sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=
-  dependencies:
-    aproba "^1.0.3"
-    console-control-strings "^1.0.0"
-    has-unicode "^2.0.0"
-    object-assign "^4.1.0"
-    signal-exit "^3.0.0"
-    string-width "^1.0.1"
-    strip-ansi "^3.0.1"
-    wide-align "^1.1.0"
 
 gensync@^1.0.0-beta.1:
   version "1.0.0-beta.1"
@@ -2996,11 +2959,6 @@ has-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
   integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
 
-has-unicode@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
-  integrity sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=
-
 has-value@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/has-value/-/has-value-0.3.1.tgz#7b1f58bada62ca827ec0a2078025654845995e1f"
@@ -3134,13 +3092,6 @@ iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
-
-ignore-walk@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz#017e2447184bfeade7c238e4aefdd1e8f95b1e37"
-  integrity sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==
-  dependencies:
-    minimatch "^3.0.4"
 
 ignore@^4.0.6:
   version "4.0.6"
@@ -3886,21 +3837,6 @@ minimist@^1.2.0, minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
-minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
-  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
-  dependencies:
-    safe-buffer "^5.1.2"
-    yallist "^3.0.0"
-
-minizlib@^1.2.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
-  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
-  dependencies:
-    minipass "^2.9.0"
-
 mississippi@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/mississippi/-/mississippi-3.0.0.tgz#ea0a3291f97e0b5e8776b363d5f0a12d94c67022"
@@ -3925,7 +3861,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3:
+mkdirp@^0.5.1, mkdirp@^0.5.3:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -4006,7 +3942,7 @@ nconf@^0.10.0:
     secure-keys "^1.0.0"
     yargs "^3.19.0"
 
-needle@^2.2.1, needle@^2.2.4, needle@^2.3.3, needle@^2.4.0:
+needle@^2.2.4, needle@^2.3.3, needle@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/needle/-/needle-2.4.1.tgz#14af48732463d7475696f937626b1b993247a56a"
   integrity sha512-x/gi6ijr4B7fwl6WYL9FwlCvRQKGlUNvnceho8wxkwXqN8jvVmmmATTmZPRRG7b/yC1eode26C2HO9jl78Du9g==
@@ -4064,34 +4000,10 @@ node-modules-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-releases@^1.1.53:
   version "1.1.53"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.53.tgz#2d821bfa499ed7c5dffc5e2f28c88e78a08ee3f4"
   integrity sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ==
-
-nopt@^4.0.1:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.3.tgz#a375cad9d02fd921278d954c2254d5aa57e15e48"
-  integrity sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==
-  dependencies:
-    abbrev "1"
-    osenv "^0.1.4"
 
 normalize-path@^2.1.1:
   version "2.1.1"
@@ -4110,27 +4022,6 @@ normalize-url@^3.3.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
   integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
 
-npm-bundled@^1.0.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.1.tgz#1edd570865a94cdb1bc8220775e29466c9fb234b"
-  integrity sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==
-  dependencies:
-    npm-normalize-package-bin "^1.0.1"
-
-npm-normalize-package-bin@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz#6e79a41f23fd235c0623218228da7d9c23b8f6e2"
-  integrity sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==
-
-npm-packlist@^1.1.6:
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
-  integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
-  dependencies:
-    ignore-walk "^3.0.1"
-    npm-bundled "^1.0.1"
-    npm-normalize-package-bin "^1.0.1"
-
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -4138,22 +4029,12 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-npmlog@^4.0.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
-  integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
-  dependencies:
-    are-we-there-yet "~1.1.2"
-    console-control-strings "~1.1.0"
-    gauge "~2.7.3"
-    set-blocking "~2.0.0"
-
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
-object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -4247,11 +4128,6 @@ os-browserify@^0.3.0:
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
   integrity sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=
 
-os-homedir@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
-  integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
-
 os-locale@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-1.4.0.tgz#20f9f17ae29ed345e8bde583b13d2009803c14d9"
@@ -4276,18 +4152,10 @@ os-name@^3.0.0:
     macos-release "^2.2.0"
     windows-release "^3.1.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
+os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
-
-osenv@^0.1.4:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
-  integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
-  dependencies:
-    os-homedir "^1.0.0"
-    os-tmpdir "^1.0.0"
 
 p-defer@^1.0.0:
   version "1.0.0"
@@ -4764,7 +4632,7 @@ raw-body@^2.2.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
+rc@^1.0.1, rc@^1.1.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -4774,7 +4642,7 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-"readable-stream@1 || 2", readable-stream@2, readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@2, readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -4982,7 +4850,7 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.3:
+rimraf@^2.5.4, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -5082,7 +4950,7 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
+semver@^5.0.3, semver@^5.1.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -5097,7 +4965,7 @@ serialize-javascript@^2.1.2:
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
   integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
 
-set-blocking@^2.0.0, set-blocking@~2.0.0:
+set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
@@ -5591,7 +5459,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-"string-width@^1.0.2 || 2", string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
+string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
@@ -5725,19 +5593,6 @@ tar-stream@^2.1.0:
     fs-constants "^1.0.0"
     inherits "^2.0.3"
     readable-stream "^3.1.1"
-
-tar@^4.4.2:
-  version "4.4.13"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
-  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
-  dependencies:
-    chownr "^1.1.1"
-    fs-minipass "^1.2.5"
-    minipass "^2.8.6"
-    minizlib "^1.2.1"
-    mkdirp "^0.5.0"
-    safe-buffer "^5.1.2"
-    yallist "^3.0.3"
 
 temp-dir@^1.0.0:
   version "1.0.0"
@@ -5878,6 +5733,11 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
+
+toggle-selection@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
+  integrity sha1-bkWxJj8gF/oKzH2J14sVuL932jI=
 
 toidentifier@1.0.0:
   version "1.0.0"
@@ -6244,13 +6104,6 @@ which@^1.2.14, which@^1.2.9, which@^1.3.1:
   dependencies:
     isexe "^2.0.0"
 
-wide-align@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"
-  integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
-  dependencies:
-    string-width "^1.0.2 || 2"
-
 widest-line@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-2.0.1.tgz#7438764730ec7ef4381ce4df82fb98a53142a3fc"
@@ -6376,7 +6229,7 @@ yallist@^2.1.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
-yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
+yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==

--- a/changelog/unreleased/load-and-display-quick-actions
+++ b/changelog/unreleased/load-and-display-quick-actions
@@ -1,0 +1,6 @@
+Enhancement: Load and display quick actions
+
+We've added an extension point into files apps for quick actions.
+By creating and exporting an object called quickActions, developers can define an action which will be then displayed in the files list.
+
+https://github.com/owncloud/phoenix/pull/3573

--- a/src/components/MessageBar.vue
+++ b/src/components/MessageBar.vue
@@ -4,8 +4,8 @@
       <oc-notification-message
         v-for="item in $_ocMessages_limited"
         :key="item.id"
-        :title="item.title"
-        :message="item.desc"
+        :title="$gettext(item.title)"
+        :message="$gettext(item.desc)"
         :status="item.status"
         class="uk-width-large"
         @close="deleteMessage(item)"

--- a/src/phoenix.js
+++ b/src/phoenix.js
@@ -139,6 +139,10 @@ function loadApps () {
       })
     }
 
+    if(app.quickActions) {
+      store.commit('ADD_QUICK_ACTIONS', app.quickActions)
+    }
+
     if (app.store) {
       registerStoreModule(app)
     }

--- a/src/store/app.js
+++ b/src/store/app.js
@@ -4,7 +4,8 @@ const state = {
     loading: true,
     failed: false,
     data: []
-  }
+  },
+  quickActions: {}
 }
 
 const actions = {
@@ -86,6 +87,10 @@ const mutations = {
       return n.notification_id !== notification
     })
     state.notifications.data = data
+  },
+
+  ADD_QUICK_ACTIONS(state, quickActions) {
+    state.quickActions = Object.assign(state.quickActions, quickActions)
   }
 }
 

--- a/tests/acceptance/features/webUIFiles/fileList.feature
+++ b/tests/acceptance/features/webUIFiles/fileList.feature
@@ -35,3 +35,6 @@ Feature: User can view files inside a folder
     When the user uploads file "new-data.zip" using the webUI
     Then the file "new-data.zip" should have a file type icon displayed on the webUI
 
+  Scenario: All files list displays public link quick action
+    When the user has browsed to the files page
+    Then quick action "public link" should be displayed on the webUI

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -857,3 +857,19 @@ Feature: Share by public link
       | path | /simple-folder |
     And user "user1" logs in using the webUI
     Then a public link with the last created link share token as name should be listed for resource "simple-folder" on the webUI
+
+  Scenario: User can create a public link via quick action
+    Given user "user1" has logged in using the webUI
+    When the user creates a public link via quick action for resource "simple-folder" using the webUI
+    Then user "user1" should have a share with these details:
+      | field       | value              |
+      | share_type  | public_link        |
+      | uid_owner   | user1              |
+      | permissions | read               |
+      | path        | /simple-folder     |
+      | name        | Quick action link  |
+    And the following success message should be displayed on the webUI
+      """
+      Public link created
+      Public link has been successfully created and copied into your clipboard.
+      """

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -609,6 +609,21 @@ module.exports = {
     replaceChar: function(string, targetChar, newChar) {
       const regex = new RegExp(targetChar, 'g')
       return string.replace(regex, newChar)
+    },
+
+    useQuickAction: async function(resource, action) {
+      action = action.replace(/\s/, '-')
+      const actionSelector = util.format(
+        this.api.page.FilesPageElement.filesRow().elements.quickAction.selector,
+        action
+      )
+      const resourceRowSelector = this.getFileRowSelectorByFileName(resource)
+
+      await this.waitForFileVisible(resource)
+
+      return this.useXpath()
+        .click(resourceRowSelector + actionSelector)
+        .useCss()
     }
   },
   elements: {

--- a/tests/acceptance/pageObjects/FilesPageElement/filesRow.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesRow.js
@@ -1,4 +1,6 @@
+/* eslint-disable no-unused-expressions */
 const { client } = require('nightwatch-api')
+const util = require('util')
 const filesList = client.page.FilesPageElement.filesList()
 
 module.exports = {
@@ -31,11 +33,24 @@ module.exports = {
         .click(fileActionsBtnSelector)
         .useCss()
       return this.api.page.FilesPageElement.fileActionsMenu()
+    },
+    isQuickActionVisible: function(action) {
+      action = action.replace(/\s/, '-')
+      const actionSelector = util.format(this.elements.quickAction.selector, action)
+
+      this.useXpath().expect.element(actionSelector).to.be.visible
+      this.useCss()
+
+      return this
     }
   },
   elements: {
     fileActionsButtonInFileRow: {
       selector: '//button[contains(@class, "files-list-row-show-actions")]',
+      locateStrategy: 'xpath'
+    },
+    quickAction: {
+      selector: '//button[@id="files-quick-action-%s"]',
       locateStrategy: 'xpath'
     }
   }

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -1038,3 +1038,7 @@ Then('the file {string} should have a file type icon displayed on the webUI', as
   )
   assert.strictEqual(null, iconUrl, 'No icon URL expected when file type icon is displayed')
 })
+
+Then('quick action {string} should be displayed on the webUI', function(action) {
+  return client.page.FilesPageElement.filesRow().isQuickActionVisible(action)
+})

--- a/tests/acceptance/stepDefinitions/publicLinkContext.js
+++ b/tests/acceptance/stepDefinitions/publicLinkContext.js
@@ -266,3 +266,10 @@ Then(
     return assert.ok(share.name.length > 0)
   }
 )
+
+When(
+  'the user creates a public link via quick action for resource {string} using the webUI',
+  function(resource) {
+    return client.page.FilesPageElement.filesList().useQuickAction(resource, 'public link')
+  }
+)


### PR DESCRIPTION
## Description
Adding an extension point into files apps for quick actions.
By creating and exporting object called quickActions, developers can define an action which will be then displayed in the files list.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/25989331/83750304-67b45280-a665-11ea-9dfd-102285411b88.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Add acceptance tests