### PR TITLE
[Tests-Only]Intermittent fails is fixed on scenario Create a folder with default name

### DIFF
--- a/tests/acceptance/pageObjects/filesPage.js
+++ b/tests/acceptance/pageObjects/filesPage.js
@@ -49,7 +49,8 @@ module.exports = {
      * @param {boolean} expectToSucceed
      */
     createFolder: async function(name, expectToSucceed = true) {
-      await this.waitForElementVisible('@newFileMenuButton', 500000)
+      await this.waitForElementVisible('@newFileMenuButtonAnyState')
+        .waitForElementEnabled(this.elements.newFileMenuButtonAnyState.selector)
         .click('@newFileMenuButton')
         .click('@newFolderButton')
         .waitForElementVisible('@dialog')
@@ -60,7 +61,7 @@ module.exports = {
         await this.setValue('@dialogInput', name)
       }
 
-      await this.click('@dialogConfirmBtn')
+      await this.click('@dialogConfirmBtn').waitForAjaxCallsToStartAndFinish()
 
       if (expectToSucceed) {
         await this.waitForElementNotPresent('@dialog')


### PR DESCRIPTION
## Description
`waitForElementVisible('@newFileMenuButton', 500000)` does not make the execution to wait for 500000 ms. Here the element `newFileMenuButton` is the selector of the file menu button when it is enabled. So instead of waiting for the enabled element, I modified the code to wait for the file menu button in any state, and when it is visible wait for that element to be enabled.

## Related Issue
- Fixes https://github.com/owncloud/phoenix/issues/3500

## How Has This Been Tested?
- https://github.com/owncloud/phoenix/pull/3584

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 