### PR TITLE
Add collaborators quick action

### DIFF
--- a/apps/files/src/components/FilesApp.vue
+++ b/apps/files/src/components/FilesApp.vue
@@ -30,7 +30,6 @@
       </div>
       <file-details
         v-if="_sidebarOpen && $route.name !== 'files-trashbin'"
-        ref="fileDetails"
         class="uk-width-1-1 uk-width-1-2@m uk-width-1-3@xl uk-height-1-1"
         @reset="setHighlightedFile(null)"
       />
@@ -46,7 +45,7 @@ import FilesAppBar from './FilesAppBar.vue'
 import AllFilesList from './AllFilesList.vue'
 import TrashBin from './Trashbin.vue'
 import SharedFilesList from './Collaborators/SharedFilesList.vue'
-import { mapActions, mapGetters } from 'vuex'
+import { mapActions, mapGetters, mapMutations } from 'vuex'
 import FileOpenActions from './FileOpenActions.vue'
 const UploadProgress = () => import('./UploadProgress.vue')
 
@@ -112,6 +111,7 @@ export default {
   methods: {
     ...mapActions('Files', ['dragOver', 'setHighlightedFile']),
     ...mapActions(['openFile', 'showMessage']),
+    ...mapMutations('Files', ['SET_CURRENT_SIDEBAR_TAB']),
 
     trace() {
       console.info('trace', arguments)
@@ -156,9 +156,8 @@ export default {
 
     openSideBar(file, sideBarName) {
       this.setHighlightedFile(file)
-      const self = this
-      this.$nextTick().then(() => {
-        self.$refs.fileDetails.showSidebar(sideBarName)
+      setTimeout(() => {
+        this.SET_CURRENT_SIDEBAR_TAB({ tab: sideBarName })
       })
     },
 

--- a/apps/files/src/components/FilesLists/QuickActions.vue
+++ b/apps/files/src/components/FilesLists/QuickActions.vue
@@ -1,11 +1,12 @@
 <template>
   <div>
     <oc-button
-      v-for="action in actions"
+      v-for="action in filteredActions"
       :id="`files-quick-action-${action.id}`"
       :key="action.label"
       :aria-label="$gettext(action.label)"
       variation="raw"
+      class="uk-margin-xsmall-right"
       @click.native.stop="action.handler({ item, client: $client, store: $store })"
     >
       <oc-icon :name="action.icon" aria-hidden="true" size="small" class="uk-flex" />
@@ -14,6 +15,8 @@
 </template>
 
 <script>
+import filterObject from 'filter-obj'
+
 export default {
   name: 'QuickActions',
 
@@ -25,6 +28,14 @@ export default {
     item: {
       type: Object,
       required: true
+    }
+  },
+
+  computed: {
+    filteredActions() {
+      return filterObject(this.actions, (key, value) => {
+        return value.displayed(this.item, this.$store) === true
+      })
     }
   }
 }

--- a/apps/files/src/quickActions.js
+++ b/apps/files/src/quickActions.js
@@ -39,11 +39,37 @@ function createPublicLink(ctx) {
   })
 }
 
+function openNewCollaboratorsPanel(ctx) {
+  ctx.store.dispatch('Files/setHighlightedFile', ctx.item)
+
+  // Workaround for displaying the new collaborators panel even when one is already opened
+  // Creating timeout takes care of the event loop
+  // TODO: Get rid of this after we use overlay instead of sidebar
+  setTimeout(() => {
+    ctx.store.commit('Files/SET_CURRENT_SIDEBAR_TAB', {
+      tab: 'files-sharing',
+      options: { collaboratorsCurrentPanel: 'newCollaborator' }
+    })
+  })
+}
+
+function canShare(item, store) {
+  return store.state.user.capabilities.files_sharing.api_enabled && item.canShare()
+}
+
 export default {
+  collaborators: {
+    id: 'collaborators',
+    label: $gettext('Add new collaborators'),
+    icon: 'group',
+    handler: openNewCollaboratorsPanel,
+    displayed: canShare
+  },
   publicLink: {
     id: 'public-link',
     label: $gettext('Create and copy public link'),
     icon: 'link',
-    handler: createPublicLink
+    handler: createPublicLink,
+    displayed: canShare
   }
 }

--- a/apps/files/src/store/mutations.js
+++ b/apps/files/src/store/mutations.js
@@ -244,5 +244,13 @@ export default {
       }
     })
     state.files = []
+  },
+
+  SET_CURRENT_SIDEBAR_TAB(state, { tab, options }) {
+    state.currentSidebarTab = { tab, options }
+  },
+
+  SET_CURRENT_SIDEBAR_TAB_OPTIONS(state, options) {
+    state.currentSidebarTab.options = options
   }
 }

--- a/apps/files/src/store/state.js
+++ b/apps/files/src/store/state.js
@@ -50,5 +50,10 @@ export default {
   highlightedFile: null,
   publicLinkPassword: null,
   uploaded: [],
-  actionsInProgress: []
+  actionsInProgress: [],
+
+  /**
+   * Sidebar
+   */
+  currentSidebarTab: null
 }

--- a/changelog/unreleased/add-collaborators-quick-action
+++ b/changelog/unreleased/add-collaborators-quick-action
@@ -1,0 +1,5 @@
+Enhancement: Add collaborators quick action
+
+We've added a new quick action which opens the new collaborators tab in the files list sidebar.
+
+https://github.com/owncloud/phoenix/pull/3573

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -793,3 +793,16 @@ Feature: Sharing files and folders with internal users
     And the setting "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     When user "user1" logs in using the webUI
     Then the expiration information displayed on the WebUI of share "lorem.txt" shared with user "User Two" should be "Expires in 15 days" or "Expires in 14 days"
+
+  Scenario: share a file with another internal user via collaborators quick action
+    Given user "user1" has logged in using the webUI
+    And the setting "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    When the user shares resource "simple-folder" with user "User Two" using the quick action in the webUI
+    Then user "User Two" should be listed as "Viewer" in the collaborators list for folder "simple-folder" on the webUI
+    And user "user2" should have received a share with these details:
+      | field       | value                |
+      | uid_owner   | user1                |
+      | share_with  | user2                |
+      | file_target | /simple-folder (2)   |
+      | item_type   | folder               |
+      | permissions | read                 |

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -110,9 +110,22 @@ module.exports = {
      * @return {Promise<module.exports.commands>}
      */
     isSharingButtonPresent: async function(resource) {
-      await this.waitForFileVisible(resource)
-      await filesRow.openFileActionsMenu(resource).isSharingBtnPresent()
-      return this
+      const sharingBtnSelector = util.format(
+        filesRow.elements.quickAction.selector,
+        'collaborators'
+      )
+      const resourceRowSelector = this.getFileRowSelectorByFileName(resource)
+      let isPresent = true
+
+      await this.api.elements(
+        this.elements.shareButtonInFileRow.locateStrategy,
+        resourceRowSelector + sharingBtnSelector,
+        result => {
+          isPresent = result.value.length > 0
+        }
+      )
+
+      return isPresent
     },
     /**
      * @return {Promise<*>}

--- a/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
@@ -146,6 +146,7 @@ module.exports = {
      * @param {string} permissions
      * @param {boolean} remote
      * @param {string} days
+     * @param {boolean} quickAction Asserts whether the quick actions should be used to open new collaborators panel
      *
      * @return void
      */
@@ -155,9 +156,13 @@ module.exports = {
       role,
       permissions,
       remote = false,
-      days
+      days,
+      quickAction = false
     ) {
-      await collaboratorDialog.clickCreateShare()
+      if (!quickAction) {
+        await collaboratorDialog.clickCreateShare()
+      }
+
       await this.selectCollaboratorForShare(sharee, shareWithGroup, remote)
       await this.selectRoleForNewCollaborator(role)
 


### PR DESCRIPTION
## Description
Added a new quick action which opens the new collaborators tab in the files list sidebar.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Refs https://github.com/owncloud/product/issues/80

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Acceptance tests

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/25989331/84143366-c22f2380-aa56-11ea-9901-81145994562a.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Rebase after merging quick actions
- [ ] Fix clicking on quick action when sidebar is already opened