### PR TITLE
Upgrade owncloud-sdk

### DIFF
--- a/changelog/unreleased/fix-empty-settings.md
+++ b/changelog/unreleased/fix-empty-settings.md
@@ -1,0 +1,8 @@
+Bugfix: Fix empty settings values
+
+We've updated owncloud-sdk to version 1.0.0-638 which makes sure that an empty array gets returned
+whenever there are no settings values for the authenticated user. Previously having no settings
+values broke our detection of whether settings values finished loading.
+
+https://github.com/owncloud/phoenix/pull/3602
+https://github.com/owncloud/ocis-settings/issues/24

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "npm-run-all": "^4.1.5",
     "oidc-client": "^1.9.1",
     "owncloud-design-system": "^1.6.0",
-    "owncloud-sdk": "^1.0.0-630",
+    "owncloud-sdk": "^1.0.0-638",
     "p-limit": "^2.2.1",
     "p-queue": "^6.1.1",
     "parse-json": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6897,10 +6897,10 @@ owncloud-design-system@^1.6.0:
     webfontloader "^1.6.28"
     weekstart "^1.0.0"
 
-owncloud-sdk@^1.0.0-630:
-  version "1.0.0-630"
-  resolved "https://registry.yarnpkg.com/owncloud-sdk/-/owncloud-sdk-1.0.0-630.tgz#48ab65a28578ddf2c076b2c9357620cbb95a3581"
-  integrity sha512-pW039ulDKdZutmL2AU/Sv0STDLRYGbPM2XnY5sehK/IvRDVMhceqy+5c9aN2f2AsBk6Am5OzH/v1lwH9/dWCCw==
+owncloud-sdk@^1.0.0-638:
+  version "1.0.0-638"
+  resolved "https://registry.yarnpkg.com/owncloud-sdk/-/owncloud-sdk-1.0.0-638.tgz#81c5c0da0fb0b0514ef6138ad751e485c70c05eb"
+  integrity sha512-5xH1Meo2b+KR55PXq1YilU/aYmTL00dbdFmkCDPxpfE1hrUIVERkfWpFfBphpaicFeFDfKyJad7HooWPfPJIiQ==
   dependencies:
     axios "^0.19.2"
     browser-request "^0.3.3"


### PR DESCRIPTION
## Description
We've updated owncloud-sdk to version 1.0.0-638 which makes sure that an empty array gets returned whenever there are no settings values for the authenticated user. Previously having no settings values broke our detection of whether settings values finished loading.

## Related Issue
- Fixes https://github.com/owncloud/ocis-settings/issues/24

## Motivation and Context
Fixes a bug

## How Has This Been Tested?
Local chrome + firefox.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 