### PR TITLE
[Tests-Only] Use owncloudci nodejs 11 docker image

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -776,7 +776,7 @@ def installFederatedServer(version, db, dbSuffix = '-federated'):
 def installNPM():
 	return [{
 		'name': 'npm-install',
-		'image': 'owncloudci/nodejs:10',
+		'image': 'owncloudci/nodejs:11',
 		'pull': 'always',
 		'commands': [
 			'yarn install --frozen-lockfile'
@@ -786,7 +786,7 @@ def installNPM():
 def lintTest():
 	return [{
 		'name': 'lint-test',
-		'image': 'owncloudci/nodejs:10',
+		'image': 'owncloudci/nodejs:11',
 		'pull': 'always',
 		'commands': [
 			'yarn run lint'
@@ -796,7 +796,7 @@ def lintTest():
 def buildPhoenix():
 	return [{
 		'name': 'build-phoenix',
-		'image': 'owncloudci/nodejs:10',
+		'image': 'owncloudci/nodejs:11',
 		'pull': 'always',
 		'commands': [
 			'yarn dist',
@@ -837,7 +837,7 @@ def buildRelease(ctx):
 	return [
 		{
 			'name': 'make',
-			'image': 'owncloudci/nodejs:10',
+			'image': 'owncloudci/nodejs:11',
 			'pull': 'always',
 			'commands': [
 				'cd /var/www/owncloud/phoenix',


### PR DESCRIPTION
## Description
Use the `owncloudci/nodejs:11` docker image for all pipeline steps.

(Both `owncloudci/nodejs:10` and `owncloudci/nodejs:11` docker images are currently based on Ubuntu 16.04, but we can update that separately later e.g. https://github.com/owncloud-ci/nodejs/pull/6 )

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...