### PR TITLE
Move indicators under resource name

### DIFF
--- a/apps/files/src/components/AllFilesList.vue
+++ b/apps/files/src/components/AllFilesList.vue
@@ -18,7 +18,6 @@
           <translate translate-context="Name column in files table">Name</translate>
         </sortable-column-header>
       </div>
-      <div v-if="!$_isFavoritesList"><!-- indicators column --></div>
       <div
         :class="{ 'uk-visible@s': !_sidebarOpen, 'uk-hidden': _sidebarOpen }"
         class="uk-text-meta uk-width-small"
@@ -52,16 +51,13 @@
       </div>
     </template>
     <template #rowColumns="{ item: rowItem, index }">
-      <div
-        :ref="index === 0 ? 'firstRowNameColumn' : null"
-        class="uk-text-truncate uk-width-expand"
-      >
+      <div :ref="index === 0 ? 'firstRowNameColumn' : null" class="uk-width-expand">
         <file-item
           :key="rowItem.viewId"
           :item="rowItem"
           :dav-url="davUrl"
           :show-path="$_isFavoritesList"
-          class="file-row-name"
+          :indicators="indicatorArray(rowItem)"
           @click.native.stop="
             rowItem.type === 'folder'
               ? navigateTo(rowItem.path.substr(1))
@@ -74,9 +70,6 @@
           :uk-tooltip="disabledActionTooltip(rowItem)"
           class="uk-margin-small-left"
         />
-      </div>
-      <div v-if="!$_isFavoritesList" class="uk-flex uk-flex-middle uk-flex-right">
-        <Indicators :default-indicators="indicatorArray(rowItem)" :item="rowItem" />
       </div>
       <div
         class="uk-text-meta uk-text-nowrap uk-width-small uk-text-right"
@@ -155,7 +148,6 @@
 </template>
 <script>
 import FileList from './FileList.vue'
-import Indicators from './FilesLists/Indicators.vue'
 import FileItem from './FileItem.vue'
 import NoContentMessage from './NoContentMessage.vue'
 import QuickActions from './FilesLists/QuickActions.vue'
@@ -172,7 +164,6 @@ export default {
   name: 'AllFilesList',
   components: {
     FileList,
-    Indicators,
     FileItem,
     NoContentMessage,
     SortableColumnHeader,
@@ -337,31 +328,24 @@ export default {
     },
 
     indicatorArray(item) {
-      const collaborators = {
-        id: 'files-sharing',
-        label: this.shareUserIconLabel(item),
-        visible: this.isUserShare(item),
-        icon: 'group',
-        handler: this.indicatorHandler
-      }
-      const links = {
-        id: 'file-link',
-        label: this.shareLinkIconLabel(item),
-        visible: this.isLinkShare(item),
-        icon: 'link',
-        handler: this.indicatorHandler
-      }
-      const indicators = []
+      const indicators = [
+        {
+          id: 'files-sharing',
+          label: this.shareUserIconLabel(item),
+          visible: this.isUserShare(item),
+          icon: 'group',
+          handler: this.indicatorHandler
+        },
+        {
+          id: 'file-link',
+          label: this.shareLinkIconLabel(item),
+          visible: this.isLinkShare(item),
+          icon: 'link',
+          handler: this.indicatorHandler
+        }
+      ]
 
-      if (collaborators.visible) {
-        indicators.push(collaborators)
-      }
-
-      if (links.visible) {
-        indicators.push(links)
-      }
-
-      return indicators
+      return indicators.filter(indicator => indicator.visible)
     },
 
     $_shareTypes(item) {

--- a/apps/files/src/components/Collaborators/SharedFilesList.vue
+++ b/apps/files/src/components/Collaborators/SharedFilesList.vue
@@ -18,7 +18,6 @@
           <translate translate-context="Name column in files table">Name</translate>
         </sortable-column-header>
       </div>
-      <div><!-- indicators column --></div>
       <div
         v-if="!$_isSharedWithMe"
         key="shared-with-header-cell"
@@ -56,12 +55,11 @@
       <div class="oc-icon" />
     </template>
     <template #rowColumns="{ item }">
-      <div class="uk-text-truncate uk-width-expand">
+      <div class="uk-width-expand">
         <file-item
           :key="item.path"
           :item="item"
           :dav-url="davUrl"
-          class="file-row-name"
           @click.native.stop="
             item.type === 'folder' ? navigateTo(item.path.substr(1)) : openFileActionBar(item)
           "
@@ -73,7 +71,6 @@
           class="uk-margin-small-left"
         />
       </div>
-      <div><!-- indicators column --></div>
       <div
         v-if="!$_isSharedWithMe"
         key="shared-with-cell"

--- a/apps/files/src/components/FileItem.vue
+++ b/apps/files/src/components/FileItem.vue
@@ -1,20 +1,62 @@
 <template>
-  <oc-file
-    :name="fileName"
-    :extension="item.extension"
-    :icon="previewIcon"
-    :icon-url="previewUrl"
-    :filename="item.name"
-    :data-preview-loaded="previewLoaded"
-  />
+  <div class="oc-file uk-flex uk-flex-middle" :data-preview-loaded="previewLoaded">
+    <oc-img
+      v-if="previewUrl"
+      key="file-preview"
+      class="files-list-file-preview uk-margin-small-right"
+      :class="{ 'files-list-file-preview-small': !hasTwoRows }"
+      :src="previewUrl"
+      alt=""
+    />
+    <oc-icon
+      v-else
+      key="file-icon"
+      :name="previewIcon"
+      :size="hasTwoRows ? 'medium' : 'small'"
+      aria-hidden="true"
+      class="uk-margin-small-right"
+    />
+    <div class="uk-width-expand">
+      <div class="file-row-name uk-text-truncate" :filename="item.name">
+        <span
+          class="uk-text-bold oc-cursor-pointer oc-file-name uk-padding-remove-left"
+          role="button"
+          v-text="fileName"
+        /><span
+          v-if="item.extension"
+          class="uk-text-meta oc-file-extension"
+          v-text="'.' + item.extension"
+        />
+      </div>
+      <div v-if="hasTwoRows" class="uk-flex uk-flex-middle">
+        <translate class="uk-margin-small-right">State:</translate>
+        <Indicators
+          v-if="indicators.length > 0"
+          key="status-indicators"
+          :default-indicators="indicators"
+          :item="item"
+          class="files-list-indicators"
+        />
+        <span v-else key="no-status-indicators" aria-hidden="true" v-text="'-'" />
+      </div>
+    </div>
+  </div>
 </template>
 <script>
 import queryString from 'query-string'
 import Mixins from '../mixins'
 
+import Indicators from './FilesLists/Indicators.vue'
+
 export default {
   name: 'FileItem',
+
+  components: {
+    Indicators
+  },
+
   mixins: [Mixins],
+
   props: {
     item: {
       type: Object,
@@ -34,6 +76,11 @@ export default {
     showPath: {
       type: Boolean,
       default: false
+    },
+    indicators: {
+      type: Array,
+      required: false,
+      default: () => []
     }
   },
   data: function() {
@@ -61,6 +108,10 @@ export default {
     },
     previewIcon() {
       return this.fileTypeIcon(this.item)
+    },
+
+    hasTwoRows() {
+      return this.$route.name === 'files-list' || this.$route.name === 'files-favorites'
     }
   },
   mounted() {
@@ -121,3 +172,23 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+.files-list-file-preview {
+  width: 36px;
+}
+
+.files-list-file-preview-small {
+  width: 24px;
+  height: 24px;
+  object-fit: cover;
+}
+
+.oc-file:hover .oc-file-name {
+  text-decoration: none;
+}
+
+.oc-file .oc-file-name:hover {
+  text-decoration: underline;
+}
+</style>

--- a/apps/files/src/components/FileList.vue
+++ b/apps/files/src/components/FileList.vue
@@ -40,7 +40,7 @@
           :key="fileData.length"
           class="uk-height-1-1"
           :items="fileData"
-          :item-size="55"
+          :item-size="hasTwoRows ? 77 : 55"
         >
           <div
             :data-is-visible="active"
@@ -185,6 +185,10 @@ export default {
 
     item() {
       return this.$route.params.item
+    },
+
+    hasTwoRows() {
+      return this.$route.name === 'files-list' || this.$route.name === 'files-favorites'
     }
   },
   watch: {

--- a/apps/files/src/components/FilesLists/Indicators.vue
+++ b/apps/files/src/components/FilesLists/Indicators.vue
@@ -8,7 +8,7 @@
         :class="{ 'uk-margin-xsmall-left': index > 0, 'uk-invisible': !indicator.visible }"
         :aria-label="indicator.label"
         variation="raw"
-        @click="indicator.handler(item, indicator.id)"
+        @click.native.stop="indicator.handler(item, indicator.id)"
       >
         <oc-icon :name="indicator.icon" class="uk-text-middle" size="small" variation="system" />
       </oc-button>

--- a/apps/files/src/components/Trashbin.vue
+++ b/apps/files/src/components/Trashbin.vue
@@ -39,13 +39,8 @@
           <div class="oc-icon" />
         </template>
         <template #rowColumns="{ item }">
-          <div class="uk-text-truncate uk-width-expand">
-            <file-item
-              :key="item.viewId"
-              :item="item"
-              :name="$_ocTrashbin_fileName(item)"
-              class="file-row-name"
-            />
+          <div class="uk-width-expand">
+            <file-item :key="item.viewId" :item="item" :name="$_ocTrashbin_fileName(item)" />
           </div>
           <div
             class="uk-text-meta uk-text-nowrap uk-width-small uk-text-right"

--- a/changelog/unreleased/move-indicators-under-resource
+++ b/changelog/unreleased/move-indicators-under-resource
@@ -1,0 +1,5 @@
+Change: Move status indicators under the resource name
+
+We've moved the sharing status indicators from an own column in the files list to a second row under the resource name.
+
+https://github.com/owncloud/phoenix/pull/3617

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -443,7 +443,7 @@ module.exports = {
           const virtualScrollWrapper = document.querySelector(scrollWrapperSelector)
           const tableHeaderPosition = document
             .querySelector(listHeaderSelector)
-            .getBoundingClientRect().top
+            .getBoundingClientRect().bottom
           let scrollDistance = virtualScrollWrapper.scrollTop
 
           function scrollUntilElementVisible() {

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -638,7 +638,7 @@ module.exports = {
       selector: '.file-row'
     },
     allFiles: {
-      selector: 'span.oc-file.file-row-name'
+      selector: 'div.oc-file.file-row-name'
     },
     loadingIndicator: {
       selector: '//*[contains(@class, "oc-loader")]',
@@ -656,33 +656,33 @@ module.exports = {
     },
     fileRowByName: {
       selector:
-        '//span[@class="oc-file-name"][text()=%s and not(../span[@class="oc-file-extension"])]/../../../../../div[@data-is-visible="true"]',
+        '//span[contains(@class, "oc-file-name") and text()=%s and not(../span[contains(@class, "oc-file-extension")])]/ancestor::div[@data-is-visible="true"]',
       locateStrategy: 'xpath'
     },
     fileRowByNameAndExtension: {
       selector:
-        '//span[span/text()=%s and span/text()="%s"]/../../../../div[@data-is-visible="true"]',
+        '//div[contains(@class, "file-row-name")][span/text()=%s and span/text()="%s"]/ancestor::div[@data-is-visible="true"]',
       locateStrategy: 'xpath'
     },
     fileLinkInFileRow: {
-      selector: '//span[contains(@class, "file-row-name")]',
+      selector: '//div[contains(@class, "file-row-name")]',
       locateStrategy: 'xpath'
     },
     fileIconInFileRow: {
-      selector: '//span[contains(@class, "file-row-name")]//*[local-name() = "svg"]',
+      selector: '//div[contains(@class, "oc-file")]//*[local-name() = "svg"]',
       locateStrategy: 'xpath'
     },
     filePreviewInFileRow: {
-      selector: '//span[contains(@class, "file-row-name")]//img',
+      selector: '//div[contains(@class, "oc-file")]//img',
       locateStrategy: 'xpath'
     },
     allFilePreviewsLoading: {
-      selector: '//span[contains(@class, "file-row-name") and @data-preview-loaded="false"]',
+      selector: '//div[contains(@class, "oc-file") and @data-preview-loaded="false"]',
       locateStrategy: 'xpath'
     },
     filePreviewLoadedInFileRow: {
       selector:
-        '//span[contains(@class, "file-row-name") and (@data-preview-loaded="true" or not(@data-preview-loaded))]',
+        '//div[contains(@class, "oc-file") and (@data-preview-loaded="true" or not(@data-preview-loaded))]',
       locateStrategy: 'xpath'
     },
     collaboratorsInFileRow: {


### PR DESCRIPTION
## Motivation and Context
Better separation from quick actions -> probably only temporarily solution (will be tested with real users).

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/25989331/84880298-a518d700-b08c-11ea-912f-428ad1983144.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests