### PR TITLE
[skip-ci] fix path of example config file in documentation

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -78,7 +78,7 @@ see [available settings](#available-settings-to-be-set-by-environment-variables)
     yarn run redis-server
     ```
 4. For Mac Users: create a new phoenix config.json file.
-      As starting point and example that should work when running every service on localhost use `tests/acceptance/ocis-mac-config-local.json`
+      As starting point and example that should work when running every service on localhost use `tests/acceptance/ocis-mac-config.json`
 
 5. Run the OCIS server with the necessary configurations
     ```sh


### PR DESCRIPTION
## Description
the path was wrong in this place 

## Related Issue
part of https://github.com/owncloud/phoenix/issues/3633
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...