### PR TITLE
[Tests-Only] Add drone CI code to allow specifying OCIS Commit

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -344,6 +344,7 @@ def acceptance():
 		'federatedServerVersion': '',
 		'runningOnOCIS': False,
 		'screenShots': False,
+		'ocisCommit': '',
 	}
 
 	if 'defaults' in config:
@@ -424,7 +425,7 @@ def acceptance():
 										glauthService()+
 										fixPermissions()
 									) if not params['runningOnOCIS'] else (
-										buildOCIS() +
+										buildOCIS(params['ocisCommit']) +
 										ocisService() +
 										getSkeletonFiles()
 									)
@@ -1115,7 +1116,7 @@ def konnectdService():
 		}],
 	}]
 
-def buildOCIS():
+def buildOCIS(ocisCommit):
 	return[{
 		'name': 'build-ocis',
 		'image': 'webhippie/golang:1.13',
@@ -1127,6 +1128,9 @@ def buildOCIS():
 			'cd github.com/owncloud/',
 			'git clone http://github.com/owncloud/ocis',
 			'cd ocis',
+		] + ([
+			'git checkout %s' % (ocisCommit)
+		] if ocisCommit != '' else []) + [
 			'make build',
 			'cp bin/ocis /var/www/owncloud'
 		],

--- a/.drone.star
+++ b/.drone.star
@@ -116,6 +116,7 @@ config = {
 
 	'defaults': {
 		'acceptance': {
+			'ocisBranch': 'master',
 			'ocisCommit': '284a9996dffa912cc1382e259b748c56ddc4aa0f',
 		}
 	},

--- a/.drone.star
+++ b/.drone.star
@@ -350,6 +350,7 @@ def acceptance():
 		'federatedServerVersion': '',
 		'runningOnOCIS': False,
 		'screenShots': False,
+		'ocisBranch': 'master',
 		'ocisCommit': '',
 	}
 
@@ -431,7 +432,7 @@ def acceptance():
 										glauthService()+
 										fixPermissions()
 									) if not params['runningOnOCIS'] else (
-										buildOCIS(params['ocisCommit']) +
+										buildOCIS(params['ocisBranch'], params['ocisCommit']) +
 										ocisService() +
 										getSkeletonFiles()
 									)
@@ -1122,7 +1123,7 @@ def konnectdService():
 		}],
 	}]
 
-def buildOCIS(ocisCommit):
+def buildOCIS(ocisBranch, ocisCommit):
 	return[{
 		'name': 'build-ocis',
 		'image': 'webhippie/golang:1.13',
@@ -1132,7 +1133,7 @@ def buildOCIS(ocisCommit):
 			'cd $GOPATH/src',
 			'mkdir -p github.com/owncloud/',
 			'cd github.com/owncloud/',
-			'git clone http://github.com/owncloud/ocis',
+			'git clone -b %s --single-branch --no-tags https://github.com/owncloud/ocis' % (ocisBranch),
 			'cd ocis',
 		] + ([
 			'git checkout %s' % (ocisCommit)

--- a/.drone.star
+++ b/.drone.star
@@ -114,6 +114,12 @@ config = {
 		}
 	},
 
+	'defaults': {
+		'acceptance': {
+			'ocisCommit': '284a9996dffa912cc1382e259b748c56ddc4aa0f',
+		}
+	},
+
 	'build': True
 }
 


### PR DESCRIPTION
## Description
Specify the `ocisBranch` and `ocisCommit` to use for the drone CI pipelines that test phoenix against an OCIS server.

## Related Issue
Part of https://github.com/owncloud/ocis/issues/303

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...