### PR TITLE
Apply proper file type icons also for uppercase file extensions

### DIFF
--- a/apps/files/src/mixins.js
+++ b/apps/files/src/mixins.js
@@ -106,7 +106,7 @@ export default {
         if (file.type === 'folder') {
           return 'folder'
         }
-        const icon = fileTypeIconMappings[file.extension]
+        const icon = fileTypeIconMappings[file.extension.toLowerCase()]
         if (icon) return `${icon}`
       }
       return 'x-office-document'

--- a/changelog/unreleased/file-type-icons-for-uppercase-file-extensions
+++ b/changelog/unreleased/file-type-icons-for-uppercase-file-extensions
@@ -1,0 +1,4 @@
+Bugfix: Fix file type icons for uppercase file extensions
+
+
+https://github.com/owncloud/phoenix/pull/3670


### PR DESCRIPTION
## Description
Uppercase file extensions now receive proper icon

## How Has This Been Tested?
- upload file.PDF and see the proper pdf icon

## Screenshots (if appropriate):
Just wrong icon ...
![Screenshot from 2020-06-24 16-40-07](https://user-images.githubusercontent.com/1005065/85577293-6610f580-b639-11ea-892e-582836caf071.png)



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

