### PR TITLE
File drop is disabled in case the folder is ready only or no space is…

### DIFF
--- a/apps/files/src/components/FilesAppBar.vue
+++ b/apps/files/src/components/FilesAppBar.vue
@@ -279,8 +279,10 @@ export default {
 
     hasFreeSpace() {
       return (
-        (this.quota && this.quota.free > 0) ||
-        (this.currentFolder && this.currentFolder.permissions.indexOf('M') >= 0) ||
+        (this.quota && this.quota.free) > 0 ||
+        (this.currentFolder &&
+          this.currentFolder.permissions &&
+          this.currentFolder.permissions.indexOf('M') >= 0) ||
         this.publicPage()
       )
     },

--- a/apps/files/src/components/FilesAppBar.vue
+++ b/apps/files/src/components/FilesAppBar.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="files-app-bar" class="oc-app-bar">
     <file-drop
-      v-if="!isIE11()"
+      v-if="!isIE11() && canUpload && hasFreeSpace"
       :root-path="item"
       :path="currentPath"
       :headers="headers"

--- a/changelog/unreleased/no-dragndrop-if-upload-not-allowed
+++ b/changelog/unreleased/no-dragndrop-if-upload-not-allowed
@@ -1,0 +1,4 @@
+Change: No file drop if upload is not allowed or no space is left
+
+
+https://github.com/owncloud/phoenix/pull/3677


### PR DESCRIPTION
… left

## Description
In case a folder is read only or not enough space is left file drop is being disabled.

## Related Issue
https://jira.owncloud.com/browse/XLXFN-17

## How Has This Been Tested?
- share a folder readonly with another user A
- A wants to drop files from desktop to the browser with this folder
- no drop zone shall be visible

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...