### PR TITLE
Fixed quick actions

### DIFF
--- a/apps/files/src/components/FileDetails.vue
+++ b/apps/files/src/components/FileDetails.vue
@@ -104,7 +104,7 @@ export default {
   },
 
   beforeDestroy() {
-    this.SET_CURRENT_SIDEBAR_TAB(null)
+    this.SET_CURRENT_SIDEBAR_TAB({})
   },
 
   methods: {

--- a/apps/files/src/quickActions.js
+++ b/apps/files/src/quickActions.js
@@ -8,7 +8,7 @@ function $gettext(msg) {
 
 function createPublicLink(ctx) {
   // FIXME: Translate name
-  const params = { name: 'Quick action link' }
+  const params = { name: 'Quick action link', permissions: 1 }
   const capabilities = ctx.store.state.user.capabilities
   const expirationDate = capabilities.files_sharing.public.expire_date
 

--- a/changelog/unreleased/set-default-permissions
+++ b/changelog/unreleased/set-default-permissions
@@ -1,0 +1,7 @@
+Bugfix: Set default permissions to public link quick action
+
+We've set a default permissions when creating a new public link via the quick actions.
+The permissions are set to `1`.
+
+https://github.com/owncloud/phoenix/issues/3675
+https://github.com/owncloud/phoenix/pull/3678

--- a/changelog/unreleased/set-empty-object-when-resetting-current-tab
+++ b/changelog/unreleased/set-empty-object-when-resetting-current-tab
@@ -1,0 +1,6 @@
+Bugfix: Set empty object when resetting current sidebar tab
+
+We've changed the argument from `null` to an empty object when resetting the current tab of the sidebar.
+
+https://github.com/owncloud/phoenix/issues/3676
+https://github.com/owncloud/phoenix/pull/3678


### PR DESCRIPTION
## Description
Set default perms in public link quick action and use empty object when resetting current sidebar tab

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #3675
- Fixes #3676

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests