### PR TITLE
Add X-OC-Mtime header for public link upload

### DIFF
--- a/apps/files/src/mixins.js
+++ b/apps/files/src/mixins.js
@@ -427,6 +427,12 @@ export default {
         const token = basePath.substr(0, tokenSplit)
         basePath = basePath.substr(tokenSplit + 1) || ''
         relativePath = pathUtil.join(basePath, relativePath)
+        const extraHeaders = {}
+        if (file.lastModifiedDate) {
+          extraHeaders['X-OC-Mtime'] = '' + file.lastModifiedDate.getTime() / 1000
+        } else if (file.lastModified) {
+          extraHeaders['X-OC-Mtime'] = '' + file.lastModified / 1000
+        }
         promise = this.uploadQueue.add(() =>
           this.$client.publicFiles.putFileContents(
             token,
@@ -434,6 +440,7 @@ export default {
             this.publicLinkPassword,
             file,
             {
+              headers: extraHeaders,
               onProgress: progress => {
                 this.$_ocUpload_onProgress(progress, file)
               },

--- a/changelog/unreleased/public-link-keep-mtime.md
+++ b/changelog/unreleased/public-link-keep-mtime.md
@@ -1,0 +1,6 @@
+Bugfix: Public upload now keeps modified time
+
+The public upload for public links now keeps the modification time of local files.
+This aligns the behavior with non-public file upload.
+
+https://github.com/owncloud/phoenix/pull/3686


### PR DESCRIPTION
## Description
This will tell the server to set that mtime for publicly uploaded files,
when available. This aligns the implementation with the regular upload.

## Related Issue
Found while working on https://github.com/owncloud/enterprise/issues/3883

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...