### PR TITLE
Do not expand resource name width over its content

### DIFF
--- a/apps/files/src/components/FileItem.vue
+++ b/apps/files/src/components/FileItem.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="oc-file uk-flex uk-flex-middle" :data-preview-loaded="previewLoaded">
+  <div
+    class="oc-file uk-flex-inline uk-flex-middle uk-width-auto"
+    :data-preview-loaded="previewLoaded"
+  >
     <oc-img
       v-if="previewUrl"
       key="file-preview"

--- a/changelog/unreleased/resource-line-width
+++ b/changelog/unreleased/resource-line-width
@@ -1,0 +1,8 @@
+Bugfix: Do not expand the width of resource name over it's content
+
+The width of the resource name in the files list was expanded more than the actual width of it's content.
+This caused that when clicked outside of the resource name, the action to navigate or open the resource has been triggered instead of opening the sidebar.
+We've fixed the width that it is now equal to the width of the content.
+
+https://github.com/owncloud/phoenix/issues/3685
+https://github.com/owncloud/phoenix/pull/3687


### PR DESCRIPTION
## Description
The width of the resource name in the files list was expanded over its actual content. This caused triggering the open action instead of displaying sidebar. Now the width does not exceed the content width.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests