### PR TITLE
Use 'Shared With' as a label for indicators

### DIFF
--- a/apps/files/src/components/FileItem.vue
+++ b/apps/files/src/components/FileItem.vue
@@ -29,7 +29,7 @@
         />
       </div>
       <div v-if="hasTwoRows" class="uk-flex uk-flex-middle">
-        <translate class="uk-margin-small-right">State:</translate>
+        <translate class="uk-margin-small-right">Shared with:</translate>
         <Indicators
           v-if="indicators.length > 0"
           key="status-indicators"

--- a/changelog/unreleased/indicators-label
+++ b/changelog/unreleased/indicators-label
@@ -1,0 +1,6 @@
+Change: Use "Shared with" as a label for indicators
+
+Instead of "State" we've started using the "Shared with" as a label for the indicators in the files list.
+This is only intermediate solution because the indicators can be extended by other indicators which don't have to be related to sharing.
+
+https://github.com/owncloud/phoenix/pull/3688


### PR DESCRIPTION
## Description
Instead of "State" we've started using the "Shared with" as a label for the indicators in the files list.
This is only intermediate solution because the indicators can be extended by other indicators which don't have to be related to sharing.

## Motivation and Context
"State" has not been met with positive feedback.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/25989331/85997645-0d12da00-ba0a-11ea-91cd-cc169f805550.png)