### PR TITLE
[Tests-Only] Actually run acceptance test scenarios in iPhone resolution

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -79,7 +79,7 @@ config = {
 				'OPENID_LOGIN': 'true',
 				'SCREEN_RESOLUTION': '375x812'
 			},
-			'filterTags': '@smokeTest and not @skipOnIphoneResolution and not @skip and @skipOnOC10'
+			'filterTags': '@smokeTest and not @skipOnIphoneResolution and not @skip and not @skipOnOC10'
 		},
 		'webUI-ocis': {
 			'suites': {


### PR DESCRIPTION
## Description
PR #2914 implemented tags for `skipOnOC10` `skipOnOCIS` etc.
https://github.com/owncloud/phoenix/pull/2914/files#diff-74dc60589e0610c07e491b31f8693b2bR75

But it had the wrong logic for the iPhone resolution pipeline. This resulted in no test scenarios actually being run in that pipeline.

Note: the XGA pipeline has it correct
https://github.com/owncloud/phoenix/pull/2914/files#diff-74dc60589e0610c07e491b31f8693b2bR66

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...