### PR TITLE
Fix breadcrumb last element

### DIFF
--- a/apps/files/src/components/FilesAppBar.vue
+++ b/apps/files/src/components/FilesAppBar.vue
@@ -261,19 +261,16 @@ export default {
       }
 
       for (let i = startIndex; i < pathSplit.length; i++) {
-        let clickHandler = null
         let itemPath =
           baseUrl + encodeURIComponent(pathUtil.join.apply(null, pathSplit.slice(0, i + 1)))
         if (i === pathSplit.length - 1) {
           itemPath = null
-          clickHandler = () => this.$router.go()
         }
 
         breadcrumbs.push({
           index: i,
           text: pathSplit.slice(0, i + 1)[i],
-          to: itemPath,
-          onClick: clickHandler
+          to: itemPath
         })
       }
 

--- a/changelog/unreleased/fix-breadcrumb.md
+++ b/changelog/unreleased/fix-breadcrumb.md
@@ -1,0 +1,7 @@
+Bugfix: Remove anchor on last breadcrumb segment
+
+The last segment of the breadcrumb was clickable, while it's expected that nothing happens (as it is the current path). We fixed that, the last breadcrumb element is not clickable anymore.
+
+https://github.com/owncloud/phoenix/issues/3722
+https://github.com/owncloud/phoenix/issues/2965
+https://github.com/owncloud/phoenix/pull/3723

--- a/changelog/unreleased/fix-breadcrumb.md
+++ b/changelog/unreleased/fix-breadcrumb.md
@@ -1,7 +1,9 @@
 Bugfix: Remove anchor on last breadcrumb segment
 
-The last segment of the breadcrumb was clickable, while it's expected that nothing happens (as it is the current path). We fixed that, the last breadcrumb element is not clickable anymore.
+The last segment of the breadcrumb was clickable, while it's expected that nothing happens (as it is the current path). 
+We fixed that, the last breadcrumb element is not clickable anymore.
 
 https://github.com/owncloud/phoenix/issues/3722
 https://github.com/owncloud/phoenix/issues/2965
 https://github.com/owncloud/phoenix/pull/3723
+https://github.com/owncloud/phoenix/issues/1883

--- a/tests/acceptance/features/webUIFiles/breadcrumb.feature
+++ b/tests/acceptance/features/webUIFiles/breadcrumb.feature
@@ -25,8 +25,10 @@ Feature: access breadcrumb
   Scenario: Select breadcrumb inside folder with problematic name
     Given the property "rootFolder" has been deleted in phoenix config file
     And user "user1" has created folder "folder%2Fwith%2FSlashes"
+    And user "user1" has created folder "folder%2Fwith%2FSlashes/subfolder"
     And user "user1" has logged in using the webUI
     When the user opens folder "folder%2Fwith%2FSlashes" using the webUI
+    And the user opens folder "subfolder" using the webUI
     And the user browses to folder "folder%2Fwith%2FSlashes" using the breadcrumb on the webUI
     Then the error message with header "Loading folder failed…" should be displayed on the webUI
 #    Then no message should be displayed on the webUI

--- a/tests/acceptance/features/webUIFiles/breadcrumb.feature
+++ b/tests/acceptance/features/webUIFiles/breadcrumb.feature
@@ -12,6 +12,15 @@ Feature: access breadcrumb
     When the user opens folder "simple-folder" using the webUI
     Then breadcrumb for folder "simple-folder" should be displayed on the webUI
 
+  Scenario: Breadcrumb navigation should not happen on last segment
+    Given the property "rootFolder" has been set to "" in phoenix config file
+    And user "user1" has created folder "simple-folder/subfolder"
+    And user "user1" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    And the user opens folder "subfolder" using the webUI
+    Then clickable breadcrumb for folder "simple-folder" should be displayed on the webUI
+    And non-clickable breadcrumb for folder "subfolder" should be displayed on the webUI
+
   @ocis-reva-issue-106
   Scenario: Change rootFolder to simple-folder and check for the displayed files
     Given the property "rootFolder" has been set to "simple-folder" in phoenix config file

--- a/tests/acceptance/features/webUIFiles/breadcrumb.feature
+++ b/tests/acceptance/features/webUIFiles/breadcrumb.feature
@@ -30,11 +30,10 @@ Feature: access breadcrumb
     When the user opens folder "folder%2Fwith%2FSlashes" using the webUI
     And the user opens folder "subfolder" using the webUI
     And the user browses to folder "folder%2Fwith%2FSlashes" using the breadcrumb on the webUI
-    Then the error message with header "Loading folder failed…" should be displayed on the webUI
-#    Then no message should be displayed on the webUI
+    Then no message should be displayed on the webUI
 
   @issue-1883
-  Scenario: Reload webUI inside the problamatic folder
+  Scenario: Reload webUI inside the problematic folder
     Given user "user1" has created folder "folder%2Fwith%2FSlashes"
     And user "user1" has logged in using the webUI
     When the user opens folder "folder%2Fwith%2FSlashes" using the webUI

--- a/tests/acceptance/pageObjects/filesPage.js
+++ b/tests/acceptance/pageObjects/filesPage.js
@@ -35,7 +35,7 @@ module.exports = {
      * @param {string} resource
      */
     navigateToBreadcrumb: function(resource) {
-      const breadcrumbElement = this.elements.resourceBreadcrumb
+      const breadcrumbElement = this.elements.resourceBreadcrumbClickable
       const resourceXpath = util.format(breadcrumbElement.selector, resource)
       return this.useStrategy(breadcrumbElement)
         .waitForElementVisible(resourceXpath)
@@ -314,6 +314,10 @@ module.exports = {
     resourceBreadcrumb: {
       selector:
         '//div[@id="files-breadcrumb"]//*[(self::a or self::span) and contains(text(),"%s")]',
+      locateStrategy: 'xpath'
+    },
+    resourceBreadcrumbClickable: {
+      selector: '//div[@id="files-breadcrumb"]//a[contains(text(),"%s")]',
       locateStrategy: 'xpath'
     },
     fileUploadButton: {

--- a/tests/acceptance/pageObjects/filesPage.js
+++ b/tests/acceptance/pageObjects/filesPage.js
@@ -312,7 +312,8 @@ module.exports = {
       selector: '#files-breadcrumb li:nth-of-type(2)'
     },
     resourceBreadcrumb: {
-      selector: '//div[@id="files-breadcrumb"]//a[contains(text(),"%s")]',
+      selector:
+        '//div[@id="files-breadcrumb"]//*[(self::a or self::span) and contains(text(),"%s")]',
       locateStrategy: 'xpath'
     },
     fileUploadButton: {

--- a/tests/acceptance/pageObjects/filesPage.js
+++ b/tests/acceptance/pageObjects/filesPage.js
@@ -43,6 +43,25 @@ module.exports = {
         .useCss()
     },
     /**
+     * Gets the breadcrumb element selector for the provided combination of clickable
+     * and non-clickable breadcrumb segments.
+     * Note: the combination (false,false) is invalid.
+     *
+     * @param clickable Whether a clickable breadcrumb is wanted
+     * @param nonClickable Whether a non-clickable breadcrumb is wanted
+     * @returns {null|{locateStrategy: string, selector: string}}
+     */
+    getBreadcrumbSelector: function(clickable, nonClickable) {
+      if (clickable && nonClickable) {
+        return this.elements.resourceBreadcrumb
+      } else if (clickable) {
+        return this.elements.resourceBreadcrumbClickable
+      } else if (nonClickable) {
+        return this.elements.resourceBreadcrumbNonClickable
+      }
+      return null
+    },
+    /**
      * Create a folder with the given name
      *
      * @param {string} name to set or null to use default value from dialog
@@ -318,6 +337,10 @@ module.exports = {
     },
     resourceBreadcrumbClickable: {
       selector: '//div[@id="files-breadcrumb"]//a[contains(text(),"%s")]',
+      locateStrategy: 'xpath'
+    },
+    resourceBreadcrumbNonClickable: {
+      selector: '//div[@id="files-breadcrumb"]//span[contains(text(),"%s")]',
       locateStrategy: 'xpath'
     },
     fileUploadButton: {

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -170,8 +170,20 @@ Then('there should be no breadcrumb displayed on the webUI', function() {
   return assertBreadCrumbIsNotDisplayed()
 })
 
+Then('non-clickable breadcrumb for folder {string} should be displayed on the webUI', function(
+  resource
+) {
+  return assertBreadcrumbIsDisplayedFor(resource, false, true)
+})
+
+Then('clickable breadcrumb for folder {string} should be displayed on the webUI', function(
+  resource
+) {
+  return assertBreadcrumbIsDisplayedFor(resource, true, false)
+})
+
 Then('breadcrumb for folder {string} should be displayed on the webUI', function(resource) {
-  return assertBreadcrumbIsDisplayedFor(resource)
+  return assertBreadcrumbIsDisplayedFor(resource, true, true)
 })
 
 /**
@@ -580,9 +592,11 @@ const assertBreadCrumbIsNotDisplayed = function() {
 /**
  *
  * @param {string} resource
+ * @param {boolean} clickable
+ * @param {boolean} nonClickable
  */
-const assertBreadcrumbIsDisplayedFor = function(resource) {
-  const breadcrumbElement = client.page.filesPage().elements.resourceBreadcrumb
+const assertBreadcrumbIsDisplayedFor = function(resource, clickable, nonClickable) {
+  const breadcrumbElement = client.page.filesPage().getBreadcrumbSelector(clickable, nonClickable)
   const resourceBreadcrumbXpath = util.format(breadcrumbElement.selector, resource)
   return client
     .useStrategy(breadcrumbElement)


### PR DESCRIPTION
## Description
This PR removes the anchor on the last breadcrumb segment.

## Related Issue
- Fixes https://github.com/owncloud/phoenix/issues/3722
- Partly fixes https://github.com/owncloud/phoenix/issues/1883

## Motivation and Context
Comply with common sense

## How Has This Been Tested?
- locally in chrome and firefox
- [ ] drone

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
