### PR TITLE
Do not fallback to appId if the file action route is not defined

### DIFF
--- a/apps/pdf-viewer/src/PdfViewer.vue
+++ b/apps/pdf-viewer/src/PdfViewer.vue
@@ -1,14 +1,15 @@
 <template lang="html">
-  <div id="pdf-viewer">
+  <div id="pdf-viewer" class="uk-flex uk-flex-column">
     <pdf-viewer-app-bar />
-    <oc-progress v-if="loading" :max="100" indeterminate></oc-progress>
+    <oc-progress v-if="loading" :max="100" indeterminate />
     <pdf
       v-if="!loading"
       :page="currentPage"
       :src="content"
+      class="uk-overflow-auto uk-flex-1"
       @error="error"
       @num-pages="loadPages"
-    ></pdf>
+    />
   </div>
 </template>
 <script>

--- a/apps/pdf-viewer/src/app.js
+++ b/apps/pdf-viewer/src/app.js
@@ -10,7 +10,7 @@ const PdfViewer = () => ({
 
 const routes = [
   {
-    path: '/pdf-viewer',
+    path: '/',
     components: {
       app: PdfViewer
     },

--- a/changelog/unreleased/file-editors-path
+++ b/changelog/unreleased/file-editors-path
@@ -1,0 +1,9 @@
+Change: Don't fallback to appId in case the route of file action is not defined
+
+When opening a file in a editor or a viewer the path was falling back to an appId.
+This made it impossible to navigate via the file actions into an app which doesn't have duplicate appId in the route.
+We've stopped falling back to this value and in case that the route of the file action is not defined, we use the root path of the app.
+
+https://github.com/owncloud/product/issues/69
+https://github.com/owncloud/ocis/issues/356
+https://github.com/owncloud/phoenix/pull/3740

--- a/src/store/apps.js
+++ b/src/store/apps.js
@@ -98,7 +98,7 @@ const mutations = {
           app: appInfo.id,
           icon: e.icon,
           newTab: e.newTab || false,
-          routeName: e.routeName || appInfo.id,
+          routeName: e.routeName,
           newFileMenu: e.newFileMenu || null
         }
         if (!state.extensions[e.extension]) {


### PR DESCRIPTION
## Description
When opening a file in a editor or a viewer the path was falling back to an appId.
This made it impossible to navigate via the file actions into an app which doesn't have duplicate appId in the route.
We've stopped falling back to this value and in case that the route of the file action is not defined, we use the root path of the app.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/ocis/issues/356
- Refs https://github.com/owncloud/product/issues/69

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- open pdf file
- open md file

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests