### PR TITLE
[Tests-Only] Unpin osixia/openldap version in CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1393,7 +1393,7 @@ def runWebuiAcceptanceTests(suite, alternateSuiteName, filterTags, extraEnvironm
 def ldapService():
 	return[{
 		'name': 'ldap',
-		'image': 'osixia/openldap:1.4.0',
+		'image': 'osixia/openldap',
 		'pull': 'always',
 		'environment': {
 			'LDAP_DOMAIN': 'owncloud.com',


### PR DESCRIPTION
PR #3738 bumped `osixia/openldap` to 1.4.0

Actually we can unpin the version so that we get whatever is the latest docker image. That way we do not have to mess about checking and updating the version ourselves in the future.