### PR TITLE
Remove outline around files list

### DIFF
--- a/apps/files/src/components/FilesApp.vue
+++ b/apps/files/src/components/FilesApp.vue
@@ -9,7 +9,7 @@
       <div
         ref="filesListWrapper"
         tabindex="-1"
-        class="uk-width-expand uk-overflow-auto uk-height-1-1"
+        class="uk-width-expand uk-overflow-auto uk-height-1-1 files-list-wrapper"
         :class="{ 'uk-visible@m': _sidebarOpen }"
         @dragover="$_ocApp_dragOver"
       >
@@ -171,3 +171,9 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+.files-list-wrapper:focus {
+  outline: none;
+}
+</style>

--- a/changelog/unreleased/files-list-outline
+++ b/changelog/unreleased/files-list-outline
@@ -1,0 +1,8 @@
+Change: Do not display outline when the files list is focused
+
+The files list was displaying outline when it received focus after a click.
+Since the focus is meant only programatically, the outline was not supposed to be displayed.
+
+https://github.com/owncloud/phoenix/issues/3747
+https://github.com/owncloud/phoenix/issues/3551
+https://github.com/owncloud/phoenix/pull/3752


### PR DESCRIPTION
## Description
The files list was displaying an outline when it received focus after a click.
Since the focus is meant only programmatically, the outline was not supposed to be displayed.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #3747
- Fixes #3551

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Click on a row in files list or in the header whitespace.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests