### PR TITLE
Do not use optional chaining in location picker

### DIFF
--- a/apps/files/src/components/LocationPicker/LocationPicker.vue
+++ b/apps/files/src/components/LocationPicker/LocationPicker.vue
@@ -212,7 +212,7 @@ export default {
     },
 
     canConfirm() {
-      return this.currentFolder?.canCreate()
+      return this.currentFolder && this.currentFolder.canCreate()
     },
 
     title() {


### PR DESCRIPTION
## Description
I forgot and sneaked in an optional chaining operator again even though it fails the translation sync. This PR removes it.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Refs #3603

## Motivation and Context
Make translations sync job green again

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run `make l10n-read`