### PR TITLE
Disable file row action drop when there are no actions available

### DIFF
--- a/apps/files/src/components/FileList.vue
+++ b/apps/files/src/components/FileList.vue
@@ -76,6 +76,18 @@
               >
                 <slot name="rowActions" :item="rowItem" />
                 <oc-button
+                  v-if="$_enabledActions(rowItem).length == 0"
+                  :id="actionsDropdownButtonId(rowItem.viewId, active)"
+                  class="files-list-row-show-actions"
+                  disabled
+                  :aria-label="$gettext('Show file actions')"
+                  variation="raw"
+                  :uk-tooltip="$_disabledActionTooltip()"
+                >
+                  <oc-icon name="more_vert" class="uk-text-middle" size="small" />
+                </oc-button>
+                <oc-button
+                  v-else
                   :id="actionsDropdownButtonId(rowItem.viewId, active)"
                   class="files-list-row-show-actions"
                   :disabled="$_actionInProgress(rowItem)"
@@ -249,16 +261,8 @@ export default {
       return this.actionsInProgress.some(itemInProgress => itemInProgress.id === item.id)
     },
 
-    $_disabledActionTooltip(item) {
-      if (this.$_actionInProgress(item)) {
-        if (item.type === 'folder') {
-          return this.$gettext('There is currently an action in progress for this folder')
-        }
-
-        return this.$gettext('There is currently an action in progress for this file')
-      }
-
-      return null
+    $_disabledActionTooltip() {
+      return this.$gettext('There are currently no actions available for this file')
     },
     _rowClasses(item) {
       if (this.highlightedFile && item.id === this.highlightedFile.id) {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Disabled row action dropdown menu when there are no actions available and showed a tooltip informatio instead

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #3761 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is needed especially for public links to not show an empty drop

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- tested by creating a public link with viewer permission (see issue ticket for further details)

## Screenshots (if appropriate):
![Bildschirmfoto von »2020-07-12 17-03-44«](https://user-images.githubusercontent.com/2546997/87250001-9098e600-c462-11ea-811f-a05100374195.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...