### PR TITLE
Remove %{type} from translation strings and use explicit strings for …

### DIFF
--- a/apps/files/src/components/FileList.vue
+++ b/apps/files/src/components/FileList.vue
@@ -174,7 +174,6 @@ export default {
   data() {
     return {
       labelSelectAllItems: this.$gettext('Select all items'),
-      labelSelectSingleItemText: this.$gettext('Select %{type} %{name}'),
       rowActions: [],
       rowActionsDisplayed: false,
       rowActionsItem: {}
@@ -219,9 +218,12 @@ export default {
     ]),
 
     labelSelectSingleItem(item) {
+      const labelSelectSingleFileText = this.$gettext('Select file %{name}')
+      const labelSelectSingleFolderText = this.$gettext('Select folder %{name}')
+
       return this.$gettextInterpolate(
-        this.labelSelectSingleItemText,
-        { name: item.name, type: item.type },
+        item.type === 'file' ? labelSelectSingleFileText : labelSelectSingleFolderText,
+        { name: item.name },
         true
       )
     },

--- a/apps/files/src/components/FileSharingSidebar.vue
+++ b/apps/files/src/components/FileSharingSidebar.vue
@@ -297,8 +297,9 @@ export default {
       return this.highlightedFile.canShare()
     },
     noResharePermsMessage() {
-      const translated = this.$gettext("You don't have permission to share this %{type}.")
-      return this.$gettextInterpolate(translated, { type: this.highlightedFile.type }, false)
+      const translatedFile = this.$gettext("You don't have permission to share this file.")
+      const translatedFolder = this.$gettext("You don't have permission to share this folder.")
+      return this.highlightedFile.type === 'file' ? translatedFile : translatedFolder
     },
 
     currentUsersPermissions() {

--- a/apps/files/src/components/LocationPicker/LocationPicker.vue
+++ b/apps/files/src/components/LocationPicker/LocationPicker.vue
@@ -394,10 +394,18 @@ export default {
 
         if (this.currentAction === 'move') {
           title = this.$gettext('An error occurred while moving several resources')
-          desc = this.$gettext('%{count} resources could not be moved')
+          desc = this.$ngettext(
+            '%{count} resource could not be moved',
+            '%{count} resources could not be moved',
+            errors.length
+          )
         } else if (this.currentAction === 'copy') {
           title = this.$gettext('An error occurred while copying several resources')
-          desc = this.$gettext('%{count} resources could not be copied')
+          desc = this.$ngettext(
+            '%{count} resource could not be copied',
+            '%{count} resources could not be copied',
+            errors.length
+          )
         }
 
         this.showMessage({

--- a/apps/files/src/mixins/deleteResources.js
+++ b/apps/files/src/mixins/deleteResources.js
@@ -25,14 +25,18 @@ export default {
       let title = null
 
       if (resources.length === 1) {
-        title = this.$_deleteResources_isInTrashbin
-          ? this.$gettext('Permanently delete %{type} %{name}')
-          : this.$gettext('Delete %{type} %{name}')
-
+        if (isFolder) {
+          title = this.$_deleteResources_isInTrashbin
+            ? this.$gettext('Permanently delete folder %{name}')
+            : this.$gettext('Delete folder %{name}')
+        } else {
+          title = this.$_deleteResources_isInTrashbin
+            ? this.$gettext('Permanently delete file %{name}')
+            : this.$gettext('Delete file %{name}')
+        }
         return this.$gettextInterpolate(
           title,
           {
-            type: isFolder ? this.$gettext('folder') : this.$gettext('file'),
             name: resources[0].name
           },
           true
@@ -40,8 +44,16 @@ export default {
       }
 
       title = this.$_deleteResources_isInTrashbin
-        ? this.$gettext('Permanently delete %{amount} selected resources?')
-        : this.$gettext('Delete %{amount} selected resources')
+        ? this.$ngettext(
+            'Permanently delete %{amount} selected resource?',
+            'Permanently delete %{amount} selected resources?',
+            resources.length
+          )
+        : this.$ngettext(
+            'Delete %{amount} selected resource?',
+            'Delete %{amount} selected resources?',
+            resources.length
+          )
 
       return this.$gettextInterpolate(title, { amount: resources.length }, false)
     },
@@ -49,20 +61,20 @@ export default {
     $_deleteResources_dialogMessage() {
       const resources = this.$_deleteResources_resources
       const isFolder = resources[0].type === 'folder'
-      let message = null
 
       if (resources.length === 1) {
-        message = this.$_deleteResources_isInTrashbin
+        if (isFolder) {
+          return this.$_deleteResources_isInTrashbin
+            ? this.$gettext(
+                'Are you sure you want to delete this folder? All it’s content will be permanently removed. This action cannot be undone.'
+              )
+            : this.$gettext('Are you sure you want to delete this folder?')
+        }
+        return this.$_deleteResources_isInTrashbin
           ? this.$gettext(
-              'Are you sure you want to delete this %{type}? All it’s content will be permanently removed. This action cannot be undone.'
+              'Are you sure you want to delete this file? All it’s content will be permanently removed. This action cannot be undone.'
             )
-          : this.$gettext('Are you sure you want to delete this %{type}?')
-
-        return this.$gettextInterpolate(
-          message,
-          { type: isFolder ? this.$gettext('folder') : this.$gettext('file') },
-          true
-        )
+          : this.$gettext('Are you sure you want to delete this file?')
       }
 
       return this.$_deleteResources_isInTrashbin

--- a/changelog/unreleased/3769
+++ b/changelog/unreleased/3769
@@ -1,0 +1,6 @@
+Bugfix: Fix translations string
+
+Allow better translations of various strings.
+
+https://github.com/owncloud/phoenix/pull/3766
+https://github.com/owncloud/phoenix/pull/3769


### PR DESCRIPTION
…file and folder

And use proper ngettext function for plural translation

## Description
Fix some non-optimal translations ....

## Related Issue
- Fixes #3766 

## How Has This Been Tested?
- :hand: 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...