### PR TITLE
[Tests-Only] Add acceptance tests to move files/folders into a folder with no change permissions

### DIFF
--- a/tests/acceptance/features/webUIFiles/copy.feature
+++ b/tests/acceptance/features/webUIFiles/copy.feature
@@ -64,3 +64,32 @@ Feature: copy files and folders
     And file "data.zip" should be listed on the webUI
     And as "user1" file "simple-folder/simple-empty-folder/data.zip" should exist
     And as "user1" file "simple-folder/data.zip" should exist
+
+  @skipOnOCIS @issue-ocis-reva-243
+  Scenario: copy a file into another folder with no change permission
+    Given user "user2" has been created with default attributes
+    And user "user2" has shared folder "simple-folder" with user "user1" with "read" permissions
+    And user "user1" has logged in using the webUI
+    When the user tries to copy file "lorem.txt" into folder "simple-folder (2)" using the webUI
+    Then it should not be possible to copy into folder "simple-folder (2)" using the webUI
+
+  @skipOnOCIS @issue-ocis-reva-243
+  Scenario: copy a folder into another folder with no change permission
+    Given user "user2" has been created with default attributes
+    And user "user2" has shared folder "simple-folder" with user "user1" with "read" permissions
+    And user "user1" has logged in using the webUI
+    When the user tries to copy folder "simple-empty-folder" into folder "simple-folder (2)" using the webUI
+    Then it should not be possible to copy into folder "simple-folder (2)" using the webUI
+
+  Scenario: copy a folder into the same folder
+    And user "user1" has logged in using the webUI
+    When the user tries to copy folder "simple-empty-folder" into folder "simple-empty-folder" using the webUI
+    Then it should not be possible to copy into folder "simple-empty-folder" using the webUI
+
+  Scenario: copy a folder into another folder with same name
+    And user "user1" has logged in using the webUI
+    When the user copies folder "simple-empty-folder" into folder "folder with space/simple-empty-folder" using the webUI
+    Then breadcrumb for folder "simple-empty-folder" should be displayed on the webUI
+    And folder "simple-empty-folder" should be listed on the webUI
+    And as "user1" folder "folder with space/simple-empty-folder/simple-empty-folder" should exist
+    And as "user1" folder "simple-empty-folder" should exist

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -78,3 +78,11 @@ Feature: move files
     And file "data.zip" should be listed on the webUI
     And as "user1" file "simple-folder/simple-empty-folder/data.zip" should exist
     But as "user1" file "simple-folder/data.zip" should not exist
+
+  @skipOnOCIS @issue-ocis-reva-243
+  Scenario: move a file into another folder with no change permission
+    Given user "user2" has been created with default attributes
+    And user "user2" has shared folder "simple-folder" with user "user1" with "read" permissions
+    And user "user1" has logged in using the webUI
+    When the user tries to move file "lorem.txt" into folder "simple-folder (2)" using the webUI
+    Then it should not be possible to move into folder "simple-folder (2)" using the webUI

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature
@@ -59,3 +59,24 @@ Feature: move folders
       # | "\"double\" quotes" | "target-folder-with\"double\" quotes" | FIXME: Needs a way to access breadcrumbs with double quotes issue-3734
       | "question?"         | "target-folder-with-question?"          |
       | "&and#hash"         | "target-folder-with-&and#hash"          |
+
+  @skipOnOCIS @issue-ocis-reva-243
+  Scenario: move a folder into another folder with no change permission
+    Given user "user2" has been created with default attributes
+    And user "user2" has shared folder "simple-folder" with user "user1" with "read" permissions
+    And user "user1" has logged in using the webUI
+    When the user tries to move folder "simple-empty-folder" into folder "simple-folder (2)" using the webUI
+    Then it should not be possible to move into folder "simple-folder (2)" using the webUI
+
+  Scenario: move a folder into the same folder
+    And user "user1" has logged in using the webUI
+    When the user tries to move folder "simple-empty-folder" into folder "simple-empty-folder" using the webUI
+    Then it should not be possible to move into folder "simple-empty-folder" using the webUI
+
+  Scenario: move a folder into another folder with same name
+    And user "user1" has logged in using the webUI
+    When the user moves folder "simple-empty-folder" into folder "folder with space/simple-empty-folder" using the webUI
+    Then breadcrumb for folder "simple-empty-folder" should be displayed on the webUI
+    And folder "simple-empty-folder" should be listed on the webUI
+    And as "user1" folder "folder with space/simple-empty-folder/simple-empty-folder" should exist
+    And as "user1" folder "simple-empty-folder" should not exist

--- a/tests/acceptance/pageObjects/locationPicker.js
+++ b/tests/acceptance/pageObjects/locationPicker.js
@@ -3,9 +3,19 @@ const { client } = require('nightwatch-api')
 module.exports = {
   commands: {
     selectFolderAndConfirm: async function(target) {
-      await client.page.FilesPageElement.filesList().navigateToFolder(target)
+      const targetSplitted = target.split('/')
+      for (let i = 0; i < targetSplitted.length; i++) {
+        await client.page.FilesPageElement.filesList().navigateToFolder(targetSplitted[i])
+      }
 
       return this.waitForElementVisible('@confirmBtn').click('@confirmBtn')
+    },
+    selectFolder: async function(target) {
+      const targetSplitted = target.split('/')
+      for (let i = 0; i < targetSplitted.length; i++) {
+        await client.page.FilesPageElement.filesList().navigateUptoFolder(targetSplitted[i])
+      }
+      return this
     }
   },
   elements: {

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -1089,6 +1089,19 @@ When('the user moves file/folder {string} into folder {string} using the webUI',
   return client.page.FilesPageElement.filesList().moveResource(resource, target)
 })
 
+When('the user tries to move file/folder {string} into folder {string} using the webUI', function(
+  resource,
+  target
+) {
+  return client.page.FilesPageElement.filesList().attemptToMoveResource(resource, target)
+})
+
+Then('it should not be possible to copy/move into folder {string} using the webUI', function(
+  target
+) {
+  return client.page.FilesPageElement.filesList().navigationNotAllowed(target)
+})
+
 When(
   'the user batch moves these files/folders into folder {string} using the webUI',
   async function(target, resources) {
@@ -1105,6 +1118,13 @@ When('the user copies file/folder {string} into folder {string} using the webUI'
   target
 ) {
   return client.page.FilesPageElement.filesList().copyResource(resource, target)
+})
+
+When('the user tries to copy file/folder {string} into folder {string} using the webUI', function(
+  resource,
+  target
+) {
+  return client.page.FilesPageElement.filesList().attemptToCopyResource(resource, target)
 })
 
 When(


### PR DESCRIPTION
##  Description
This PR adds acceptance tests to move/copy to a folder where a user does not have enough permissions.

## Related Issue
- https://github.com/owncloud/phoenix/issues/3750

## How Has This Been Tested?
CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...