### PR TITLE
[Tests-Only]Add acceptance tests for breadcrumbs with double quotes

### DIFF
--- a/tests/acceptance/features/webUIFiles/breadcrumb.feature
+++ b/tests/acceptance/features/webUIFiles/breadcrumb.feature
@@ -49,3 +49,12 @@ Feature: access breadcrumb
     And the user reloads the current page of the webUI
     Then the error message with header "Loading folder failed…" should be displayed on the webUI
 #    Then no message should be displayed on the webUI
+
+  Scenario: breadcrumb for double quotes
+    Given user "user1" has created folder "\'single-double quotes\""
+    And user "user1" has created folder "\'single-double quotes\"/\"inner\" double quotes"
+    And user "user1" has logged in using the webUI
+    When the user opens folder "\'single-double quotes\"" using the webUI
+    And the user opens folder "\"inner\" double quotes" using the webUI
+    Then clickable breadcrumb for folder "\'single-double quotes\"" should be displayed on the webUI
+    And non-clickable breadcrumb for folder "\"inner\" double quotes" should be displayed on the webUI

--- a/tests/acceptance/features/webUIFiles/copy.feature
+++ b/tests/acceptance/features/webUIFiles/copy.feature
@@ -49,11 +49,11 @@ Feature: copy files and folders
     Then breadcrumb for folder <folder_name> should be displayed on the webUI
     And file <file_name> should be listed on the webUI
     Examples:
-      | file_name           | folder_name                      |
-      | "'single'"          | "folder-with-'single'"           |
-      # | "\"double\" quotes" | "folder-with\"double\" quotes" | FIXME: Needs a way to access breadcrumbs with double quotes issue-3734
-      | "question?"         | "folder-with-question?"          |
-      | "&and#hash"         | "folder-with-&and#hash"          |
+      | file_name           | folder_name                    |
+      | "'single'"          | "folder-with-'single'"         |
+      | "\"double\" quotes" | "folder-with\"double\" quotes" |
+      | "question?"         | "folder-with-question?"        |
+      | "&and#hash"         | "folder-with-&and#hash"        |
 
   @skipOnOCIS @issue-3755
   Scenario: copy files on a public share

--- a/tests/acceptance/pageObjects/filesPage.js
+++ b/tests/acceptance/pageObjects/filesPage.js
@@ -1,5 +1,6 @@
 const util = require('util')
 const navigationHelper = require('../helpers/navigationHelper')
+const xpathHelper = require('../helpers/xpath')
 const { join, normalize } = require('../helpers/path')
 const { client } = require('nightwatch-api')
 
@@ -37,7 +38,10 @@ module.exports = {
      */
     navigateToBreadcrumb: function(resource) {
       const breadcrumbElement = this.elements.resourceBreadcrumbClickable
-      const resourceXpath = util.format(breadcrumbElement.selector, resource)
+      const resourceXpath = util.format(
+        breadcrumbElement.selector,
+        xpathHelper.buildXpathLiteral(resource)
+      )
       return this.useStrategy(breadcrumbElement)
         .waitForElementVisible(resourceXpath)
         .click(resourceXpath)
@@ -348,20 +352,19 @@ module.exports = {
       selector: '#files-breadcrumb li:nth-of-type(2)'
     },
     breadcrumbMobile: {
-      selector: '//span[@class="oc-breadcrumb-drop-label-text" and text()="%s"]',
+      selector: '//span[@class="oc-breadcrumb-drop-label-text" and text()=%s]',
       locateStrategy: 'xpath'
     },
     resourceBreadcrumb: {
-      selector:
-        '//div[@id="files-breadcrumb"]//*[(self::a or self::span) and contains(text(),"%s")]',
+      selector: '//div[@id="files-breadcrumb"]//*[(self::a or self::span) and contains(text(),%s)]',
       locateStrategy: 'xpath'
     },
     resourceBreadcrumbClickable: {
-      selector: '//div[@id="files-breadcrumb"]//a[contains(text(),"%s")]',
+      selector: '//div[@id="files-breadcrumb"]//a[contains(text(),%s)]',
       locateStrategy: 'xpath'
     },
     resourceBreadcrumbNonClickable: {
-      selector: '//div[@id="files-breadcrumb"]//span[contains(text(),"%s")]',
+      selector: '//div[@id="files-breadcrumb"]//span[contains(text(),%s)]',
       locateStrategy: 'xpath'
     },
     fileUploadButton: {

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -5,6 +5,7 @@ const { Given, When, Then, Before } = require('cucumber')
 const webdav = require('../helpers/webdavHelper')
 const _ = require('lodash')
 const loginHelper = require('../helpers/loginHelper')
+const xpathHelper = require('../helpers/xpath')
 const { move } = require('../helpers/webdavHelper')
 const path = require('../helpers/path')
 const util = require('util')
@@ -597,7 +598,10 @@ const assertBreadCrumbIsNotDisplayed = function() {
  */
 const assertBreadcrumbIsDisplayedFor = async function(resource, clickable, nonClickable) {
   const breadcrumbElement = client.page.filesPage().getBreadcrumbSelector(clickable, nonClickable)
-  const resourceBreadcrumbXpath = util.format(breadcrumbElement.selector, resource)
+  const resourceBreadcrumbXpath = util.format(
+    breadcrumbElement.selector,
+    xpathHelper.buildXpathLiteral(resource)
+  )
   let isBreadcrumbVisible = false
 
   // Check if the breadcrumb is visible
@@ -611,7 +615,7 @@ const assertBreadcrumbIsDisplayedFor = async function(resource, clickable, nonCl
   if (!isBreadcrumbVisible) {
     const mobileBreadcrumbMobileXpath = util.format(
       client.page.filesPage().elements.breadcrumbMobile.selector,
-      resource
+      xpathHelper.buildXpathLiteral(resource)
     )
 
     await client.element('xpath', mobileBreadcrumbMobileXpath, result => {


### PR DESCRIPTION
## Description
This PR adds acceptance tests for breadcrumbs with double quotes and edits selector accordingly

## Related Issue
- Fixes https://github.com/owncloud/phoenix/issues/3734

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...