### PR TITLE
Remove head request

### DIFF
--- a/src/plugins/phoenix.js
+++ b/src/plugins/phoenix.js
@@ -26,34 +26,28 @@ export default {
             const url = this.$client.helpers._webdavUrl + file.path
 
             return this.$client.signUrl(url).then(signedUrl => {
-              fetch(signedUrl, {
-                method: 'HEAD',
-                headers: { Authorization: 'Bearer ' + this.getToken }
-              }).then(res => {
-                if (res.status === 200) {
-                  const a = document.createElement('a')
-                  a.style.display = 'none'
-                  document.body.appendChild(a)
+              try {
+                const a = document.createElement('a')
+                a.style.display = 'none'
+                document.body.appendChild(a)
 
-                  a.href = signedUrl
+                a.href = signedUrl
 
-                  console.log(file)
-                  // Use download attribute to set desired file name
-                  a.setAttribute('download', file.name)
+                // Use download attribute to set desired file name
+                a.setAttribute('download', file.name)
 
-                  // Trigger the download by simulating click
-                  a.click()
+                // Trigger the download by simulating click
+                a.click()
 
-                  // Cleanup
-                  document.body.removeChild(a)
-                } else if (res.status === 404) {
-                  this.showMessage({
-                    title: this.$gettext('Download failed'),
-                    desc: this.$gettext('File could not be located'),
-                    status: 'danger'
-                  })
-                }
-              })
+                // Cleanup
+                document.body.removeChild(a)
+              } catch (e) {
+                this.showMessage({
+                  title: this.$gettext('Download failed'),
+                  desc: this.$gettext('File could not be located'),
+                  status: 'danger'
+                })
+              }
             })
           }
 


### PR DESCRIPTION
Same as https://github.com/owncloud/phoenix/pull/3797, but without the HEAD request. If a download fails, it just fails. No need to determine beforehand if it could fail.