### PR TITLE
[tests-only] use openid-connect insecure  and not debug setting

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1013,7 +1013,7 @@ def setupGraphapiOIdC():
 			'php occ config:system:set cors.allowed-domains 0 --value="http://phoenix:9100"',
 			'php occ config:system:set memcache.local --value="\\\\OC\\\\Memcache\\\\APCu"',
 			'php occ config:system:set phoenix.baseUrl --value="http://phoenix:9100"',
-			'php occ config:system:set debug --value=true --type=bool',
+			'php occ config:system:set openid-connect insecure --value=true --type=bool',
 			'php occ config:list'
 		]
 	}]

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -388,7 +388,7 @@ Feature: Share by public link
     And the public uses the webUI to access the last public link created by user "user1" with password "qwertyui"
     Then file "lorem.txt" should be listed on the webUI
 
-  @skipOnOCIS
+  @skipOnOCIS @skip @issue-3830
   Scenario: user edits the password of an already existing public link and tries to access with old password
     Given user "user1" has shared folder "simple-folder" with link with "read, update, create, delete" permissions and password "pass123"
     And user "user1" has created a public link with following settings


### PR DESCRIPTION
## Description
https://github.com/owncloud/openidconnect/pull/89 introduced a new setting to accept insecure certificates, so in CI use the new setting and not debug

## Related Issue
should help with https://github.com/owncloud/phoenix/pull/3797

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...