### PR TITLE
Media viewer video fixes

### DIFF
--- a/apps/media-viewer/src/Mediaviewer.vue
+++ b/apps/media-viewer/src/Mediaviewer.vue
@@ -8,20 +8,20 @@
       >
         <template v-show="!loading && activeMediaFileCached">
           <video
-            v-if="image.isVideo"
+            v-if="medium.isVideo"
             key="media-video"
             class="uk-box-shadow-medium media-viewer-player"
             controls
             preload
           >
-            <source :src="image.url" :type="`video/${image.ext}`" />
+            <source :src="medium.url" :type="`video/${medium.ext}`" />
           </video>
           <img
             v-else
             key="media-image"
-            :src="image.url"
-            :alt="image.name"
-            :data-id="image.id"
+            :src="medium.url"
+            :alt="medium.name"
+            :data-id="medium.id"
             class="uk-box-shadow-medium media-viewer-player"
           />
         </template>
@@ -45,7 +45,7 @@
       <div
         class="uk-overlay uk-overlay-default uk-padding-small uk-text-center uk-text-meta uk-text-truncate"
       >
-        {{ image.name }}
+        {{ medium.name }}
       </div>
       <div class="uk-overlay uk-overlay-primary uk-light uk-padding-small">
         <div
@@ -74,7 +74,7 @@
             role="button"
             class="oc-cursor-pointer"
             name="file_download"
-            @click="downloadImage"
+            @click="downloadMedium"
           />
           <oc-icon role="button" class="oc-cursor-pointer" name="close" @click="closeApp" />
         </div>
@@ -97,8 +97,8 @@ export default {
       activeIndex: null,
       direction: 'rtl',
 
-      image: {},
-      images: [],
+      medium: {},
+      media: [],
 
       // Milliseconds
       animationDuration: 1000
@@ -118,7 +118,7 @@ export default {
       return this.mediaFiles[this.activeIndex]
     },
     activeMediaFileCached() {
-      const cached = this.images.find(i => i.id === this.activeMediaFile.id)
+      const cached = this.media.find(i => i.id === this.activeMediaFile.id)
       return cached !== undefined ? cached : false
     },
     activeClass() {
@@ -173,7 +173,7 @@ export default {
   watch: {
     activeIndex(o, n) {
       if (o !== n) {
-        this.loadImage()
+        this.loadMedium()
       }
     }
   },
@@ -194,8 +194,8 @@ export default {
 
     window.removeEventListener('popstate', this.handleLocalHistoryEvent)
 
-    this.images.forEach(image => {
-      window.URL.revokeObjectURL(image.url)
+    this.media.forEach(medium => {
+      window.URL.revokeObjectURL(medium.url)
     })
   },
 
@@ -221,7 +221,7 @@ export default {
       history.pushState({}, document.title, this.$router.resolve(this.$route).href)
     },
 
-    loadImage() {
+    loadMedium() {
       this.loading = true
 
       // TODO: Implement caching also with signed URLs
@@ -229,7 +229,7 @@ export default {
       if (!this.isUrlSigningEnabled && this.activeMediaFileCached) {
         setTimeout(
           () => {
-            this.image = this.activeMediaFileCached
+            this.medium = this.activeMediaFileCached
             this.loading = false
           },
           // Delay to animate
@@ -238,7 +238,7 @@ export default {
         return
       }
 
-      // Fetch image
+      // Fetch media
       const url = this.$client.helpers._webdavUrl + this.activeMediaFile.path
       const promise = this.isUrlSigningEnabled
         ? this.$client.signUrl(url, 86400) // Timeout of the signed URL = 24 hours
@@ -246,14 +246,14 @@ export default {
 
       promise
         .then(mediaUrl => {
-          this.images.push({
+          this.media.push({
             id: this.activeMediaFile.id,
             name: this.activeMediaFile.name,
             url: mediaUrl,
             ext: this.activeMediaFile.extension,
             isVideo: this.videoExtensions.includes(this.activeMediaFile.extension)
           })
-          this.image = this.activeMediaFileCached
+          this.medium = this.activeMediaFileCached
           this.loading = false
           this.failed = false
         })
@@ -264,7 +264,7 @@ export default {
         })
     },
 
-    downloadImage() {
+    downloadMedium() {
       if (this.loading) {
         return
       }

--- a/apps/media-viewer/src/Mediaviewer.vue
+++ b/apps/media-viewer/src/Mediaviewer.vue
@@ -225,7 +225,7 @@ export default {
       this.loading = true
 
       // TODO: Implement caching also with signed URLs
-      // Don't bother loading if files are chached
+      // Don't bother loading if files are cached
       if (!this.isUrlSigningEnabled && this.activeMediaFileCached) {
         setTimeout(
           () => {

--- a/apps/media-viewer/src/app.js
+++ b/apps/media-viewer/src/app.js
@@ -9,7 +9,7 @@ const routes = [
     components: {
       app: Mediaviewer
     },
-    name: 'mediaviewer/image',
+    name: 'mediaviewer/media',
     meta: { auth: false }
   }
 ]
@@ -21,31 +21,31 @@ const appInfo = {
   extensions: [
     {
       extension: 'png',
-      routeName: 'image'
+      routeName: 'media'
     },
     {
       extension: 'jpg',
-      routeName: 'image'
+      routeName: 'media'
     },
     {
       extension: 'jpeg',
-      routeName: 'image'
+      routeName: 'media'
     },
     {
       extension: 'gif',
-      routeName: 'image'
+      routeName: 'media'
     },
     {
       extension: 'mp4',
-      routeName: 'image'
+      routeName: 'media'
     },
     {
       extension: 'webn',
-      routeName: 'image'
+      routeName: 'media'
     },
     {
       extension: 'ogg',
-      routeName: 'image'
+      routeName: 'media'
     }
   ]
 }

--- a/apps/media-viewer/src/app.js
+++ b/apps/media-viewer/src/app.js
@@ -40,7 +40,7 @@ const appInfo = {
       routeName: 'media'
     },
     {
-      extension: 'webn',
+      extension: 'webm',
       routeName: 'media'
     },
     {

--- a/changelog/unreleased/media-viewer-video-playback
+++ b/changelog/unreleased/media-viewer-video-playback
@@ -3,3 +3,4 @@ Enhancement: Enable playing videos in media viewer
 We've added a capability to the media viewer extension to play videos.
 
 https://github.com/owncloud/phoenix/pull/3803
+https://github.com/owncloud/phoenix/pull/3833


### PR DESCRIPTION
## Description
This PR fixes a typo in a video file extension (`webn` instead of `webm`) and renames all occurrences of `image` and `images` as variable names to `medium` and `media`, since the mediaviewer is actually about multiple media types now (images and videos).

## Motivation and Context
Code readability

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 