### PR TITLE
Media viewer video navigation

### DIFF
--- a/apps/media-viewer/src/Mediaviewer.vue
+++ b/apps/media-viewer/src/Mediaviewer.vue
@@ -9,7 +9,7 @@
         <template v-show="!loading && activeMediaFileCached">
           <video
             v-if="medium.isVideo"
-            key="media-video"
+            :key="`media-video-${medium.id}`"
             class="uk-box-shadow-medium media-viewer-player"
             controls
             preload

--- a/apps/media-viewer/src/Mediaviewer.vue
+++ b/apps/media-viewer/src/Mediaviewer.vue
@@ -18,7 +18,7 @@
           </video>
           <img
             v-else
-            key="media-image"
+            :key="`media-image-${medium.id}`"
             :src="medium.url"
             :alt="medium.name"
             :data-id="medium.id"
@@ -130,7 +130,7 @@ export default {
 
       return {
         enter: `uk-animation-slide-${direction[0]}-small`,
-        leave: `uk-animation-slide-${direction[1]}-medium uk-animation-reverse`
+        leave: `uk-animation-slide-${direction[1]}-small uk-animation-reverse`
       }
     },
     thumbDimensions() {

--- a/apps/media-viewer/src/Mediaviewer.vue
+++ b/apps/media-viewer/src/Mediaviewer.vue
@@ -6,7 +6,7 @@
         :enter-active-class="activeClass.enter"
         :leave-active-class="activeClass.leave"
       >
-        <template v-show="!loading && activeMediaFileCached">
+        <div v-show="!loading && activeMediaFileCached">
           <video
             v-if="medium.isVideo"
             :key="`media-video-${medium.id}`"
@@ -24,7 +24,7 @@
             :data-id="medium.id"
             class="uk-box-shadow-medium media-viewer-player"
           />
-        </template>
+        </div>
       </transition>
     </div>
     <oc-spinner
@@ -130,7 +130,7 @@ export default {
 
       return {
         enter: `uk-animation-slide-${direction[0]}-small`,
-        leave: `uk-animation-slide-${direction[1]}-small uk-animation-reverse`
+        leave: `uk-animation-slide-${direction[1]} uk-animation-reverse`
       }
     },
     thumbDimensions() {

--- a/changelog/unreleased/media-viewer-video-playback
+++ b/changelog/unreleased/media-viewer-video-playback
@@ -5,3 +5,4 @@ We've added a capability to the media viewer extension to play videos.
 https://github.com/owncloud/phoenix/pull/3803
 https://github.com/owncloud/phoenix/pull/3833
 https://github.com/owncloud/phoenix/pull/3844
+https://github.com/owncloud/phoenix/pull/3848


### PR DESCRIPTION
## Description
This PR fixes the navigation between video elements in media viewer. When navigating back and forth between two videos, the shown video stayed the same before. Now it actually switches to the desired video.

As a bonus, this PR fixes animations. There were glitches during switching from one medium to the next/previous, where the loaded medium was shown at the bottom of the screen and then jumped back up after load. That is solved by switching the `template` to a `div` tag. Also, the animations need each element to have a unique key, otherwise the animation will not appear at all. That is solved by adding the file-id to the respective key (which was needed for videos anyway).

## Related Issue
- Fixes https://github.com/owncloud/phoenix/issues/3831

## Motivation and Context
Fixing bugs...

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
