### PR TITLE
Add info about number of selected items and their size

### DIFF
--- a/apps/files/src/components/FilesApp.vue
+++ b/apps/files/src/components/FilesApp.vue
@@ -101,6 +101,7 @@ export default {
   watch: {
     $route() {
       this.setHighlightedFile(null)
+      this.resetFileSelection()
     }
   },
   created() {
@@ -114,7 +115,7 @@ export default {
   },
 
   methods: {
-    ...mapActions('Files', ['dragOver', 'setHighlightedFile']),
+    ...mapActions('Files', ['dragOver', 'setHighlightedFile', 'resetFileSelection']),
     ...mapActions(['openFile', 'showMessage']),
     ...mapMutations('Files', ['SET_CURRENT_SIDEBAR_TAB']),
     ...mapMutations(['SET_SIDEBAR_FOOTER_CONTENT_COMPONENT']),

--- a/changelog/unreleased/multi-select-info
+++ b/changelog/unreleased/multi-select-info
@@ -1,0 +1,6 @@
+Enhancement: Add info about number of selected items and their size
+
+We've added information about the number of selected items and their size above the files list next to batch actions.
+
+https://github.com/owncloud/product/issues/122
+https://github.com/owncloud/phoenix/pull/3850

--- a/tests/acceptance/features/webUIFavorites/favoritesFile.feature
+++ b/tests/acceptance/features/webUIFavorites/favoritesFile.feature
@@ -1,4 +1,4 @@
-@skipOnOCIS @ocis-reva-issue-39
+@skipOnOCIS @ocis-reva-issue-39 @skipOnIphoneResolution @ocis-web=issue-3968
 Feature: Mark file as favorite
 
   As a user
@@ -10,7 +10,7 @@ Feature: Mark file as favorite
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 
-  @smokeTest
+  @smokeTes
   Scenario: mark files as favorites
     When the user marks file "data.tar.gz" as favorite using the webUI
     And the user marks file "data.zip" as favorite using the webUI

--- a/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature
+++ b/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature
@@ -1,4 +1,4 @@
-@skipOnOCIS @ocis-reva-issue-39
+@skipOnOCIS @ocis-reva-issue-39 @skipOnIphoneResolution @ocis-web=issue-3968
 Feature: Unmark file/folder as favorite
 
   As a user

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -457,7 +457,7 @@ module.exports = {
       await this.initAjaxCounters()
       await this.waitForElementVisible('@virtualScrollWrapper')
       await this.api.executeAsync(
-        function({ itemName, scrollWrapperSelector, listHeaderSelector }, done) {
+        function({ itemName, scrollWrapperSelector, listHeaderSelector, listItemSelector }, done) {
           const virtualScrollWrapper = document.querySelector(scrollWrapperSelector)
           const tableHeaderPosition = document
             .querySelector(listHeaderSelector)
@@ -484,7 +484,9 @@ module.exports = {
               return
             }
 
-            scrollDistance += virtualScrollWrapper.clientHeight
+            const listItemHeight = document.querySelector(listItemSelector).clientHeight
+
+            scrollDistance += listItemHeight * 5
             virtualScrollWrapper.scrollTop = scrollDistance
             setTimeout(function() {
               scrollUntilElementVisible()
@@ -497,7 +499,8 @@ module.exports = {
           {
             itemName: itemName,
             scrollWrapperSelector: this.elements.virtualScrollWrapper.selector,
-            listHeaderSelector: this.elements.filesTableHeader.selector
+            listHeaderSelector: this.elements.filesTableHeader.selector,
+            listItemSelector: this.elements.filesListItem.selector
           }
         ]
       )
@@ -797,7 +800,7 @@ module.exports = {
       locateStrategy: 'xpath'
     },
     restoreSelectedButton: {
-      selector: '//span[contains(text(),"Restore selected")]',
+      selector: '//span[contains(text(),"Restore")]',
       locateStrategy: 'xpath'
     },
     linkToPublicLinksTag: {
@@ -834,6 +837,9 @@ module.exports = {
       selector:
         '//span[contains(@class, "oc-file-name") and text()="%s" and not(../span[contains(@class, "oc-file-extension")])]/ancestor::div[@class="files-list-row-disabled" and @data-is-visible="true"]',
       locateStrategy: 'xpath'
+    },
+    filesListItem: {
+      selector: '.vue-recycle-scroller__item-view'
     }
   }
 }


### PR DESCRIPTION
## Description
We've added information about the number of selected items and their size above the files list next to batch actions.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/product/issues/122

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Select multiple resources in different files lists.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/25989331/88724362-9eb95880-d12a-11ea-8a34-abe8a647a5bd.png)
![image](https://user-images.githubusercontent.com/25989331/88724486-de804000-d12a-11ea-8ad0-07d85586e651.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests