### PR TITLE
[Tests-Only]Fixed failing test on public link share

### DIFF
--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -388,7 +388,7 @@ Feature: Share by public link
     And the public uses the webUI to access the last public link created by user "user1" with password "qwertyui"
     Then file "lorem.txt" should be listed on the webUI
 
-  @skipOnOCIS @skip @issue-3830
+  @skipOnOCIS @issue-3830
   Scenario: user edits the password of an already existing public link and tries to access with old password
     Given user "user1" has shared folder "simple-folder" with link with "read, update, create, delete" permissions and password "pass123"
     And user "user1" has created a public link with following settings


### PR DESCRIPTION
## Description
The test `Scenario: user edits the password of an already existing public link and tries to access with old password` was failing because two shares were created fast with the same `stime`.  So, a new function is created to wait for at least one second between the creation of shares.

## Related Issue
- Fixes https://github.com/owncloud/phoenix/issues/3830

## How Has This Been Tested?
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 