### PR TITLE
Differentiate between username and user-id

### DIFF
--- a/changelog/unreleased/differentiate-between-id-and-username
+++ b/changelog/unreleased/differentiate-between-id-and-username
@@ -1,0 +1,8 @@
+Change: Differentiate between user-id and username
+
+With oCIS user-id and username are not the same as is the case in ownCloud 10.
+We've started differentiating between them to correctly display all information in the accounts page.
+If the username is not available (oC10), we fall back to using user-id as the username.
+
+https://github.com/owncloud/ocis/issues/440
+https://github.com/owncloud/phoenix/pull/3938

--- a/changelog/unreleased/fix-displayname
+++ b/changelog/unreleased/fix-displayname
@@ -1,0 +1,6 @@
+Bugfix: Fix display name when using oCIS as backend
+
+We've fixed the display name when running ocis-web with oCIS as backend.
+The display name is now again displayed in the top bar and in the account page.
+
+https://github.com/owncloud/phoenix/pull/3938

--- a/src/Phoenix.vue
+++ b/src/Phoenix.vue
@@ -32,7 +32,7 @@
             class="uk-width-expand"
             :applications-list="$_applicationsList"
             :active-notifications="activeNotifications"
-            :user-id="user.id"
+            :user-id="user.username || user.id"
             :user-display-name="user.displayname"
             @toggleAppNavigationVisibility="toggleAppNavigationVisibility"
           />

--- a/src/pages/account.vue
+++ b/src/pages/account.vue
@@ -16,6 +16,10 @@
       <div class="uk-flex uk-flex-wrap">
         <div class="uk-width-1-2@s uk-margin-bottom">
           <div class="uk-text-meta"><translate>Username:</translate></div>
+          {{ user.username || user.id }}
+        </div>
+        <div v-if="user.username && user.id" class="uk-width-1-2@s uk-margin-bottom">
+          <div class="uk-text-meta"><translate>User ID:</translate></div>
           {{ user.id }}
         </div>
         <div class="uk-width-1-2@s uk-margin-bottom">

--- a/src/store/user.js
+++ b/src/store/user.js
@@ -77,7 +77,8 @@ const actions = {
                 context.commit('SET_CAPABILITIES', cap)
                 context.commit('SET_USER', {
                   id: res.id,
-                  displayname: res['display-name'],
+                  username: res.username,
+                  displayname: res.displayname || res['display-name'],
                   email: !Object.keys(res.email).length ? '' : res.email,
                   token,
                   isAuthenticated: true,
@@ -170,6 +171,7 @@ const mutations = {
   SET_USER(state, user) {
     state.displayname = user.displayname
     state.id = user.id
+    state.username = user.username
     state.email = user.email
     state.isAuthenticated = user.isAuthenticated
     state.token = user.token


### PR DESCRIPTION
## Description
With oCIS user-id and username are not the same as is the case in ownCloud 10.
We've started differentiating between them to correctly display all information in the accounts page.
If the username is not available (oC10), we fall back to using user-id as the username.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/ocis/issues/440

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: oC10 and oCIS

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/25989331/89889870-ae2cad00-dbd2-11ea-93f0-5ffa7130744c.png)