### PR TITLE
[Tests-Only]Added test for the existing enabled + New button on public link in OCIS

### DIFF
--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -932,3 +932,31 @@ Feature: Share by public link
       Public link created
       Public link has been successfully created and copied into your clipboard.
       """
+
+  @skipOnOCIS @issue-product-130
+  Scenario: User can attempt to upload a file in public link
+    Given user "user1" has created a public link with following settings
+      | path        | lorem.txt   |
+      | name        | public link |
+      | permissions | read        |
+    When the public uses the webUI to access the last public link created by user "user1"
+    Then file "lorem.txt" should be listed on the webUI
+    And it should not be possible to create files using the webUI
+
+  @skipOnOC10 @issue-product-130
+  # When this issue is fixed delete this scenario and use the one above
+  Scenario: User can attempt to upload a file in public link
+    Given user "user1" has created a public link with following settings
+      | path        | lorem.txt   |
+      | name        | public link |
+      | permissions | read        |
+    When the public uses the webUI to access the last public link created by user "user1"
+    Then file "lorem.txt" should be listed on the webUI
+    And it should be possible to create files using the webUI
+#    And it should not be possible to create files using the webUI
+    When the public uploads file "textfile.txt" using the webUI
+    Then the following error message should be displayed on the webUI
+      """
+      File upload failed…
+      Unknown error
+      """

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -235,7 +235,7 @@ Given('the following files/folders/resources have been deleted by user {string}'
   return client
 })
 
-When('the user uploads file {string} using the webUI', function(element) {
+When('the user/public uploads file {string} using the webUI', function(element) {
   const uploadPath = path.join(client.globals.mountedUploadDir, element)
   return client.page.filesPage().uploadFile(uploadPath)
 })
@@ -308,6 +308,12 @@ When(
 Then('it should not be possible to create files using the webUI', function() {
   return client.page.filesPage().canCreateFiles(isDisabled => {
     client.assert.strictEqual(isDisabled, true, 'Create action must not be enabled')
+  })
+})
+
+Then('it should be possible to create files using the webUI', function() {
+  return client.page.filesPage().canCreateFiles(isDisabled => {
+    client.assert.strictEqual(isDisabled, false, 'Create action must be enabled')
   })
 })
 


### PR DESCRIPTION
## Description
Added Acceptance test for the enabled `+ New` button on OCIS. This behavior is different than that of OC10.

## Related Issue
- https://github.com/owncloud/product/issues/130

## How Has This Been Tested?
- :robot: 
- https://github.com/owncloud/ocis/pull/447

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 