### PR TITLE
[tests-only] make rename function in tests async

### DIFF
--- a/tests/acceptance/pageObjects/FilesPageElement/fileActionsMenu.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/fileActionsMenu.js
@@ -73,8 +73,8 @@ module.exports = {
      * @param {boolean} expectToSucceed
      * @return {*}
      */
-    rename: function(toName, expectToSucceed = true) {
-      this.initAjaxCounters()
+    rename: async function(toName, expectToSucceed = true) {
+      await this.initAjaxCounters()
         .useXpath()
         .performFileAction(this.FileAction.rename)
         .waitForElementVisible('@dialog')
@@ -86,7 +86,7 @@ module.exports = {
         .useCss()
 
       if (expectToSucceed) {
-        this.waitForElementNotPresent('@dialog')
+        await this.waitForElementNotPresent('@dialog')
       }
 
       return this


### PR DESCRIPTION
## Description
make the fuction to rename a file work async as other are already

## Related Issue
https://github.com/owncloud/ocis/issues/450

## Motivation and Context
nightwatch would crash ugly when `waitForElementNotVisible` fails and the reported error would not be helpful

## How Has This Been Tested?
:robot: 
trying failing test with https://github.com/owncloud/ocis/pull/409

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...