### PR TITLE
[tests-only] Improve delete tests

### DIFF
--- a/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
@@ -27,7 +27,8 @@ Feature: deleting files and folders
     And as "user1" file "strängé filename (duplicate #2 &).txt" should not exist
     And as "user1" file "sample,1.txt" should not exist
     And as "user1" folder "Sample,Folder,With,Comma" should not exist
-    Then the deleted elements should not be listed on the webUI
+    And no message should be displayed on the webUI
+    And the deleted elements should not be listed on the webUI
     But folder "simple-empty-folder" should be listed on the webUI
     And file "lorem-big.txt" should be listed on the webUI
     And file "strängé नेपाली folder" should not be listed on the webUI
@@ -60,6 +61,7 @@ Feature: deleting files and folders
     And as "user1" folder "simple-folder" should not exist
     And the deleted elements should not be listed on the webUI
     And the deleted elements should not be listed on the webUI after a page reload
+    And no message should be displayed on the webUI
 
   Scenario: Delete all files at once
     When the user marks all files for batch action using the webUI
@@ -70,6 +72,7 @@ Feature: deleting files and folders
     And as "user1" folder "simple-folder" should not exist
     And the folder should be empty on the webUI
     And the folder should be empty on the webUI after a page reload
+    And no message should be displayed on the webUI
 
   @ocis-reva-issue-106
   Scenario: Delete all except for a few files at once
@@ -87,6 +90,7 @@ Feature: deleting files and folders
     But as "user1" file "data.zip" should not exist
     And file "data.zip" should not be listed on the webUI
     And there should be 2 files/folders listed on the webUI
+    And no message should be displayed on the webUI
 
   @ocis-reva-issue-106
   Scenario: Delete an empty folder
@@ -97,11 +101,13 @@ Feature: deleting files and folders
     And folder "my-other-empty-folder" should be listed on the webUI
     But as "user1" folder "my-empty-folder" should not exist
     And folder "my-empty-folder" should not be listed on the webUI
+    And no message should be displayed on the webUI
 
   Scenario: Delete the last file in a folder
     When the user deletes file "zzzz-must-be-last-file-in-folder.txt" using the webUI
     Then as "user1" file "zzzz-must-be-last-file-in-folder.txt" should not exist
     And file "zzzz-must-be-last-file-in-folder.txt" should not be listed on the webUI
+    And no message should be displayed on the webUI
 
   @skip @yetToImplement
   @public_link_share-feature-required
@@ -142,6 +148,7 @@ Feature: deleting files and folders
     And as "user1" folder "simple-folder/simple-empty-folder" should not exist
     And as "user1" file "simple-folder/strängé filename (duplicate #2 &).txt" should not exist
     And the deleted elements should not be listed on the webUI
+    And no message should be displayed on the webUI
     And the deleted elements should not be listed on the webUI after a page reload
 
   @skipOnOCIS @ocis-reva-issue-64
@@ -167,6 +174,7 @@ Feature: deleting files and folders
       | "double" quotes |
       | question?       |
       | &and#hash       |
+    And no message should be displayed on the webUI
     When the user reloads the current page of the webUI
     Then the following file should not be listed on the webUI
       | name-parts      |
@@ -200,6 +208,7 @@ Feature: deleting files and folders
     And the user deletes file "lorem (2).txt" using the webUI
     Then as "user1" folder "simple-folder (2)" should not exist
     And as "user1" file "lorem (2).txt" should not exist
+    And no message should be displayed on the webUI
 
   @skipOnOCIS @ocis-reva-issue-64
   Scenario: Delete a file and folder in shared with others page
@@ -211,6 +220,7 @@ Feature: deleting files and folders
     And the user deletes file "lorem.txt" using the webUI
     Then file "lorem.txt" should not be listed on the webUI
     And folder "simple-folder" should not be listed on the webUI
+    And no message should be displayed on the webUI
     When the user reloads the current page of the webUI
     Then file "lorem.txt" should not be listed on the webUI
     And folder "simple-folder" should not be listed on the webUI
@@ -236,6 +246,7 @@ Feature: deleting files and folders
     And as "user1" file "lorem.txt" should not exist
     And as "user1" folder "simple-folder" should not exist
     And the deleted elements should not be listed on the webUI
+    And no message should be displayed on the webUI
     And the deleted elements should not be listed on the webUI after a page reload
 
   @skipOnOCIS @ocis-reva-issue-39

--- a/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
@@ -35,10 +35,9 @@ Feature: deleting files and folders
     But the deleted elements should not be listed on the webUI after a page reload
 
   Scenario Outline: Delete a file with problematic characters
-    When the user renames file "lorem.txt" to <file_name> using the webUI
-    And the user reloads the current page of the webUI
-    Then file <file_name> should be listed on the webUI
-    When the user deletes file <file_name> using the webUI
+    Given user "user1" has created file <file_name>
+    When the user reloads the current page of the webUI
+    And the user deletes file <file_name> using the webUI
     Then file <file_name> should not be listed on the webUI
     When the user reloads the current page of the webUI
     Then file <file_name> should not be listed on the webUI


### PR DESCRIPTION
## Description
this PR is on top of #3944

1. check that no error messages are displayed after deleting https://github.com/owncloud/ocis/issues/451
2. create a file via webDAV API, to speed up tests, also no need to check if the file is listed, that is done in other tests

## Motivation and Context
small improvements to the tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...