### PR TITLE
[tests-only] wait for ajax calls when batch deleting

### DIFF
--- a/tests/acceptance/pageObjects/filesPage.js
+++ b/tests/acceptance/pageObjects/filesPage.js
@@ -212,6 +212,7 @@ module.exports = {
         .waitForElementVisible('@dialog')
         .waitForAnimationToFinish()
         .click('@dialogConfirmBtn')
+        .waitForAjaxCallsToStartAndFinish()
         .waitForElementNotPresent('@dialog')
     },
     /**


### PR DESCRIPTION
## Description
make sure we wait for some ajax calls to start and then to finish

## Related Issue
failing tests seen in https://github.com/owncloud/ocis/pulls/409

## Motivation and Context
the popup might be gone, but the DELETE calls are still fired and the DOM is updating

## How Has This Been Tested?
:robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...