### PR TITLE
Revert "[tests-only] skip public link tests on ocis"

### DIFF
--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -1,4 +1,4 @@
-@mailhog @public_link_share-feature-required @ocis-reva-issue-64 @skipOnOCIS @ocis-issue-458
+@mailhog @public_link_share-feature-required @ocis-reva-issue-64
 Feature: Share by public link
   As a user
   I want to share files through a publicly accessible link


### PR DESCRIPTION
Reverts owncloud/phoenix#3954

For https://github.com/owncloud/product/issues/161
So we can use the commit id to confirm.