### PR TITLE
Default external apps for ocis

### DIFF
--- a/changelog/unreleased/default-external-apps-ocis.md
+++ b/changelog/unreleased/default-external-apps-ocis.md
@@ -1,0 +1,5 @@
+Change: Add default external apps for ocis
+
+We are enabling the settings-ui and accounts-ui by default now for ocis.
+
+https://github.com/owncloud/phoenix/pull/3967

--- a/config.json.sample-ocis
+++ b/config.json.sample-ocis
@@ -21,8 +21,12 @@
   ],
   "external_apps": [
     {
+      "id": "accounts",
+      "path": "http://localhost:9200/accounts.js"
+    },
+    {
       "id": "settings",
-      "path": "http://localhost:9190/settings.js"
+      "path": "http://localhost:9200/settings.js"
     }
   ]
 }


### PR DESCRIPTION
## Description
This PR adds the accounts ui as external app for the default ocis config.json sample.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 