### PR TITLE
[Tests-Only] Changed wording of "there should be x files/folders listed on the webUI" test step

### DIFF
--- a/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
@@ -88,7 +88,7 @@ Feature: deleting files and folders
     # Check just an example of a file that should not exist any more
     But as "user1" file "data.zip" should not exist
     And file "data.zip" should not be listed on the webUI
-    And there should be 2 files/folders listed on the webUI
+    And the count of files and folders shown on the webUI should be 2
     And no message should be displayed on the webUI
 
   @ocis-reva-issue-106

--- a/tests/acceptance/features/webUIFavorites/favoritesFile.feature
+++ b/tests/acceptance/features/webUIFavorites/favoritesFile.feature
@@ -19,7 +19,7 @@ Feature: Mark file as favorite
     And as user "user1" file "data.zip" should be marked as favorite
     And file "data.zip" should be marked as favorite on the webUI
     When the user browses to the favorites page
-    Then there should be 2 files/folders listed on the webUI
+    Then the count of files and folders shown on the webUI should be 2
     And file "data.zip" should be listed on the webUI
     And file "data.tar.gz" should be listed on the webUI
 
@@ -31,7 +31,7 @@ Feature: Mark file as favorite
     And as user "user1" folder "strängé नेपाली folder" should be marked as favorite
     And folder "strängé नेपाली folder" should be marked as favorite on the webUI
     When the user browses to the favorites page
-    Then there should be 2 files/folders listed on the webUI
+    Then the count of files and folders shown on the webUI should be 2
     And folder "simple-folder" should be listed on the webUI
     And folder "strängé नेपाली folder" should be listed on the webUI
 
@@ -52,13 +52,13 @@ Feature: Mark file as favorite
   Scenario: navigate to the favorites page using the menu
     Given user "user1" has favorited element "data.zip"
     When the user browses to the favorites page using the webUI
-    Then there should be 1 files/folders listed on the webUI
+    Then the count of files and folders shown on the webUI should be 1
     And file "data.zip" should be listed on the webUI
 
   Scenario: navigate to the favorites page and back to files page using the menu
     Given the user has browsed to the favorites page using the webUI
     When the user browses to the files page using the webUI
-    Then there should be 31 files/folders listed on the webUI
+    Then the count of files and folders shown on the webUI should be 31
 
   @issue-1910
   Scenario: favorites list appears empty when no favorites are defined
@@ -111,6 +111,6 @@ Feature: Mark file as favorite
       And as user "user1" folder "Sample,Folder,With,Comma" should be marked as favorite
       And folder "Sample,Folder,With,Comma" should be marked as favorite on the webUI
       When the user browses to the favorites page
-      Then there should be 2 files/folders listed on the webUI
+      Then the count of files and folders shown on the webUI should be 2
       And folder "Sample,Folder,With,Comma" should be listed on the webUI
       And file "sample,1.txt" should be listed on the webUI

--- a/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature
+++ b/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature
@@ -23,7 +23,7 @@ Feature: Unmark file/folder as favorite
     And as user "user1" file "lorem.txt" should be marked as favorite
     And file "lorem.txt" should be marked as favorite on the webUI
     When the user browses to the favorites page
-    Then there should be 2 files/folders listed on the webUI
+    Then the count of files and folders shown on the webUI should be 2
     But file "data.zip" should not be listed on the webUI
 
   Scenario: unmark a folder as favorite from files page
@@ -39,7 +39,7 @@ Feature: Unmark file/folder as favorite
     And as user "user1" folder "0" should be marked as favorite
     And folder "0" should be marked as favorite on the webUI
     When the user browses to the favorites page
-    Then there should be 2 files/folders listed on the webUI
+    Then the count of files and folders shown on the webUI should be 2
     But folder "simple-folder" should not be listed on the webUI
 
   @smokeTest

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -744,7 +744,9 @@ Then('file/folder {string} should not be marked as favorite on the webUI', async
   return client
 })
 
-Then(/there should be (\d+) files\/folders listed on the webUI/, async function(noOfItems) {
+Then(/the count of files and folders shown on the webUI should be (\d+)/, async function(
+  noOfItems
+) {
   const itemsCount = await client.page.FilesPageElement.filesList().countFilesAndFolders()
   return client.assert.equal(itemsCount, noOfItems)
 })


### PR DESCRIPTION
## Description
Changed the test step `Then there should be N files/folders listed on the webUI` to `Then the count of files and folders shown on the webUI should be N`

## Related Issue
- Fixes https://github.com/owncloud/phoenix/issues/3950

## How Has This Been Tested?
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 