### PR TITLE
[tests-only] Add ocis-accounts default admin user to tests

### DIFF
--- a/tests/acceptance/helpers/userSettings.js
+++ b/tests/acceptance/helpers/userSettings.js
@@ -81,6 +81,11 @@ module.exports = {
       displayname: 'Marie Curie',
       password: 'radioactivity',
       email: 'marie@example.org'
+    },
+    Moss: {
+      displayname: 'Maurice Moss',
+      password: 'vista',
+      email: 'moss@example.org'
     }
   },
   createdUsers: {},


### PR DESCRIPTION
This PR adds the default admin user of ocis-accounts to the `userSettings.js` helper.