### PR TITLE
[tests-only] small fixes in the tests

### DIFF
--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -8,7 +8,7 @@ const LOCAL_LAUNCH_URL = withHttp(
   process.env.SERVER_HOST || (RUN_ON_OCIS ? 'https://localhost:9200' : 'http://localhost:8300')
 )
 const LOCAL_BACKEND_URL = withHttp(
-  process.env.BACKEND_HOST || (RUN_ON_OCIS ? 'http://localhost:9140' : 'http://localhost:8080')
+  process.env.BACKEND_HOST || (RUN_ON_OCIS ? 'https://localhost:9200' : 'http://localhost:8080')
 )
 const REMOTE_BACKEND_URL = process.env.REMOTE_BACKEND_HOST
   ? withHttp(process.env.REMOTE_BACKEND_HOST || 'http://localhost:8080')

--- a/tests/acceptance/features/webUIFavorites/favoritesFile.feature
+++ b/tests/acceptance/features/webUIFavorites/favoritesFile.feature
@@ -10,7 +10,7 @@ Feature: Mark file as favorite
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 
-  @smokeTes
+  @smokeTest
   Scenario: mark files as favorites
     When the user marks file "data.tar.gz" as favorite using the webUI
     And the user marks file "data.zip" as favorite using the webUI


### PR DESCRIPTION
1. by default use port 9200 as `BACKEND_HOST` for OCIS, otherwise users will not get created
2. typo in tag name