### PR TITLE
[tests-only] Skip a test that blows up the environment on ocis

### DIFF
--- a/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
@@ -62,6 +62,7 @@ Feature: deleting files and folders
     And the deleted elements should not be listed on the webUI after a page reload
     And no message should be displayed on the webUI
 
+  @skipOnOCIS @ocis-issue-532
   Scenario: Delete all files at once
     When the user marks all files for batch action using the webUI
     And the user batch deletes the marked files using the webUI


### PR DESCRIPTION
This test blows up a test pipeline in ocis. Skipping for now to unblock merging features. Needs to be fixed soon (as in this or next sprint), as other people are reporting in the chat that they experience the same issues in real environments.
Tracked in this ticket: https://github.com/owncloud/ocis/issues/532