### PR TITLE
Shortened button label for creating public links

### DIFF
--- a/apps/files/src/components/FileLinkSidebar.vue
+++ b/apps/files/src/components/FileLinkSidebar.vue
@@ -55,6 +55,7 @@
               id="files-file-link-add"
               icon="add"
               variation="primary"
+              :aria-label="$_addButtonAriaLabel"
               @click="$_addPublicLink"
               >{{ $_addButtonLabel }}</oc-button
             >
@@ -212,7 +213,10 @@ export default {
       }
     },
     $_addButtonLabel() {
-      return this.$gettext('Add public link')
+      return this.$gettext('Public link')
+    },
+    $_addButtonAriaLabel() {
+      return this.$gettext('Create new nublic link')
     },
     $_privateLinkCopyLabel() {
       return this.$gettext('Copy private link url')

--- a/changelog/unreleased/wording-create-public-link
+++ b/changelog/unreleased/wording-create-public-link
@@ -1,0 +1,7 @@
+Change: Shortened button label for creating public links
+
+The label of the button for creating public links in the links panel has been shortened to "Public link" instead of "Add public link"
+since the plus sign already implies adding. An Aria label has been added for clarification when using screen readers.
+
+https://github.com/owncloud/phoenix/pull/4072
+https://github.com/owncloud/phoenix/issues/231


### PR DESCRIPTION

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
The label of the button for creating public links in the links panel has been shortened to "Public link" instead of "Add public link"
since the plus sign already implies adding. An Aria label has been added for clarification when using screen readers.


## Related Issue
Part 4b of https://github.com/owncloud/product/issues/231

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...