### PR TITLE
Adjust behavior of public link password field

### DIFF
--- a/changelog/unreleased/fix-public-link-password-field
+++ b/changelog/unreleased/fix-public-link-password-field
@@ -1,0 +1,8 @@
+Bugfix: Adjust behavior of public link password field
+
+The UX of the public link password field has been improved.
+The field is focussed automatically and the enter key submits the password.
+Also, in case of wrong password, an error message is now displayed.
+
+https://github.com/owncloud/phoenix/pull/4077
+https://github.com/owncloud/product/issues/231


### PR DESCRIPTION
## Description
The UX of the public link password field has been improved.
The field is focussed automatically and the enter key submits the password.
Also, in case of wrong password, an error message is now displayed.

## Related Issue
Part 8a of https://github.com/owncloud/product/issues/231

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manual test

## Screenshots (if appropriate):


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...