### PR TITLE
Update ODS to v1.10.0

### DIFF
--- a/apps/files/src/components/FileSharingSidebar.vue
+++ b/apps/files/src/components/FileSharingSidebar.vue
@@ -10,10 +10,10 @@
         <div v-if="$_ocCollaborators_canShare" class="uk-margin-small-top uk-margin-small-bottom">
           <oc-button
             variation="primary"
-            icon="add"
             class="files-collaborators-open-add-share-dialog-button"
             @click="$_ocCollaborators_addShare"
           >
+            <oc-icon name="add" aria-hidden="true" />
             <translate>Share</translate>
           </oc-button>
         </div>

--- a/apps/files/src/components/FilesAppBar.vue
+++ b/apps/files/src/components/FilesAppBar.vue
@@ -10,15 +10,8 @@
       @progress="onFileProgress"
     />
     <div>
-      <div>
-        <div class="uk-flex uk-margin-small-bottom">
-          <oc-breadcrumb
-            v-if="showBreadcrumb"
-            id="files-breadcrumb"
-            :items="breadcrumbs"
-            home
-          ></oc-breadcrumb>
-        </div>
+      <div class="uk-margin-small-bottom">
+        <oc-breadcrumb v-if="showBreadcrumb" id="files-breadcrumb" :items="breadcrumbs" home />
         <span v-if="!showBreadcrumb" class="uk-flex uk-flex-middle uk-margin-small-bottom">
           <oc-icon v-if="pageIcon" :name="pageIcon" class="uk-margin-small-right" />
           <h1 class="oc-page-title" v-text="pageTitle" />
@@ -34,11 +27,12 @@
               id="new-file-menu-btn"
               key="new-file-menu-btn-enabled"
               variation="primary"
-              icon="add"
               :uk-tooltip="_cannotCreateDialogText"
               :disabled="isNewBtnDisabled"
-              ><translate>New</translate></oc-button
             >
+              <oc-icon name="add" aria-hidden="true" />
+              <translate>New</translate>
+            </oc-button>
             <oc-drop
               drop-id="new-file-menu-drop"
               toggle="#new-file-menu-btn"
@@ -112,21 +106,21 @@
           <oc-button
             v-if="selectedFiles.length > 0"
             key="restore-btn"
-            icon="restore"
             class="uk-margin-small-right"
             @click="$_ocTrashbin_restoreFiles()"
           >
+            <oc-icon name="restore" aria-hidden="true" />
             <translate>Restore</translate>
           </oc-button>
           <oc-button
             id="delete-selected-btn"
             key="delete-btn"
-            icon="delete"
             :disabled="files.length === 0"
             @click="
               selectedFiles.length < 1 ? $_ocTrashbin_empty() : $_deleteResources_displayDialog()
             "
           >
+            <oc-icon name="delete" aria-hidden="true" />
             {{ $_ocAppBar_clearTrashbinButtonText }}
           </oc-button>
         </template>
@@ -135,9 +129,9 @@
             <oc-button
               id="delete-selected-btn"
               key="delete-selected-btn"
-              icon="delete"
               @click="$_deleteResources_displayDialog()"
             >
+              <oc-icon name="delete" aria-hidden="true" />
               <translate>Delete</translate>
             </oc-button>
           </div>
@@ -145,10 +139,10 @@
             <oc-button
               id="move-selected-btn"
               key="move-selected-btn"
-              icon="folder-move"
               :disabled="!canMove"
-              @click.native="triggerLocationPicker('move')"
+              @click="triggerLocationPicker('move')"
             >
+              <oc-icon name="folder-move" aria-hidden="true" />
               <translate>Move</translate>
             </oc-button>
           </div>
@@ -156,10 +150,10 @@
             <oc-button
               id="copy-selected-btn"
               key="copy-selected-btn"
-              icon="file_copy"
               :disabled="!canCopy"
-              @click.native="triggerLocationPicker('copy')"
+              @click="triggerLocationPicker('copy')"
             >
+              <oc-icon name="file_copy" aria-hidden="true" />
               <translate>Copy</translate>
             </oc-button>
           </div>

--- a/apps/files/src/components/FilesLists/Indicators.vue
+++ b/apps/files/src/components/FilesLists/Indicators.vue
@@ -1,6 +1,10 @@
 <template>
   <span>
-    <div v-if="displayDefaultIndicators" :class="{ 'uk-margin-xsmall-right': customIndicators }">
+    <div
+      v-if="displayDefaultIndicators"
+      :class="{ 'uk-margin-xsmall-right': customIndicators }"
+      class="uk-flex"
+    >
       <template v-if="areIndicatorsClickable">
         <oc-button
           v-for="(indicator, index) in defaultIndicators"
@@ -9,7 +13,7 @@
           :class="{ 'uk-margin-xsmall-left': index > 0, 'uk-invisible': !indicator.visible }"
           :aria-label="indicator.label"
           variation="raw"
-          @click.native.stop="indicator.handler(item, indicator.id)"
+          @click.stop="indicator.handler(item, indicator.id)"
         >
           <oc-icon :name="indicator.icon" class="uk-text-middle" size="small" variation="system" />
         </oc-button>

--- a/apps/files/src/components/FilesLists/QuickActions.vue
+++ b/apps/files/src/components/FilesLists/QuickActions.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="uk-flex">
     <oc-button
       v-for="action in filteredActions"
       :id="`files-quick-action-${action.id}`"
@@ -7,7 +7,7 @@
       :aria-label="$gettext(action.label)"
       variation="raw"
       class="uk-margin-xsmall-right"
-      @click.native.stop="action.handler({ item, client: $client, store: $store })"
+      @click.stop="action.handler({ item, client: $client, store: $store })"
     >
       <oc-icon :name="action.icon" aria-hidden="true" size="small" class="uk-flex" />
     </oc-button>

--- a/apps/files/src/components/FilesLists/RowActionsDropdown.vue
+++ b/apps/files/src/components/FilesLists/RowActionsDropdown.vue
@@ -12,13 +12,13 @@
       <li v-for="action in actions" :key="action.ariaLabel(item)">
         <oc-button
           class="uk-width-1-1"
-          :icon="action.icon"
           :aria-Label="action.ariaLabel(item)"
-          @click.native.stop="
+          @click.stop="
             action.handler(item, action.handlerData)
             actionClicked()
           "
         >
+          <oc-icon :name="action.icon" aria-hidden="true" />
           {{ action.ariaLabel(item) }}
         </oc-button>
       </li>

--- a/apps/files/src/components/LocationPicker/LocationPicker.vue
+++ b/apps/files/src/components/LocationPicker/LocationPicker.vue
@@ -259,18 +259,21 @@ export default {
     this.originalLocation = this.target
 
     if (this.currentAction === 'move') {
+      this.SET_NAVIGATION_HIDDEN(true)
       this.SET_MAIN_CONTENT_COMPONENT(MoveSidebarMainContent)
     } else if (this.currentAction === 'copy') {
+      this.SET_NAVIGATION_HIDDEN(true)
       this.SET_MAIN_CONTENT_COMPONENT(CopySidebarMainContent)
     }
   },
 
   beforeDestroy() {
+    this.SET_NAVIGATION_HIDDEN(false)
     this.SET_MAIN_CONTENT_COMPONENT(null)
   },
 
   methods: {
-    ...mapMutations(['SET_MAIN_CONTENT_COMPONENT']),
+    ...mapMutations(['SET_NAVIGATION_HIDDEN', 'SET_MAIN_CONTENT_COMPONENT']),
     ...mapActions('Files', ['loadFolder']),
     ...mapActions(['showMessage']),
 

--- a/apps/files/src/components/LocationPicker/LocationPicker.vue
+++ b/apps/files/src/components/LocationPicker/LocationPicker.vue
@@ -6,14 +6,14 @@
     </h1>
     <hr class="uk-margin-remove-top" />
     <div class="uk-margin-bottom">
-      <oc-button @click.native="leaveLocationPicker(originalLocation)">
+      <oc-button @click="leaveLocationPicker(originalLocation)">
         <translate>Cancel</translate>
       </oc-button>
       <oc-button
         id="location-picker-btn-confirm"
         variation="primary"
         :disabled="!canConfirm"
-        @click.native="confirmAction"
+        @click="confirmAction"
       >
         <span v-text="confirmBtnText" />
       </oc-button>

--- a/apps/files/src/components/PublicLinks/PublicLink.vue
+++ b/apps/files/src/components/PublicLinks/PublicLink.vue
@@ -28,7 +28,7 @@
         <oc-button
           variation="primary"
           class="oc-login-authorize-button"
-          @click.native="resolvePublicLink()"
+          @click="resolvePublicLink()"
         >
           <translate>Continue</translate>
         </oc-button>

--- a/apps/files/src/default.js
+++ b/apps/files/src/default.js
@@ -92,7 +92,7 @@ const navItems = [
   },
   {
     name: $gettext('Shared with me'),
-    iconMaterial: 'group',
+    iconMaterial: 'shared-with-me',
     route: {
       name: 'files-shared-with-me',
       path: `/${appInfo.id}/shared-with-me`
@@ -100,7 +100,7 @@ const navItems = [
   },
   {
     name: $gettext('Shared with others'),
-    iconMaterial: 'group',
+    iconMaterial: 'shared-with-others',
     route: {
       name: 'files-shared-with-others',
       path: `/${appInfo.id}/shared-with-others`

--- a/apps/files/src/quickActions.js
+++ b/apps/files/src/quickActions.js
@@ -61,14 +61,14 @@ export default {
   collaborators: {
     id: 'collaborators',
     label: $gettext('Add people'),
-    icon: 'group',
+    icon: 'group-add',
     handler: openNewCollaboratorsPanel,
     displayed: canShare
   },
   publicLink: {
     id: 'public-link',
     label: $gettext('Create and copy public link'),
-    icon: 'link',
+    icon: 'link-add',
     handler: createPublicLink,
     displayed: canShare
   }

--- a/apps/markdown-editor/src/MarkdownEditorAppBar.vue
+++ b/apps/markdown-editor/src/MarkdownEditorAppBar.vue
@@ -2,14 +2,18 @@
   <div id="markdown-editor-app-bar" class="oc-app-bar">
     <oc-grid flex gutter="small">
       <div class="uk-width-auto">
-        <oc-button icon="save" :disabled="!isTouched" @click="saveContent"></oc-button>
+        <oc-button :disabled="!isTouched" @click="saveContent">
+          <oc-icon name="save" aria-hidden="true" />
+        </oc-button>
         <oc-spinner v-if="isLoading"></oc-spinner>
       </div>
       <div class="uk-width-expand uk-text-center">
         <span>{{ activeFile.path.substr(1) }}</span>
       </div>
       <div class="uk-width-auto uk-text-right">
-        <oc-button icon="close" @click="closeApp"></oc-button>
+        <oc-button @click="closeApp">
+          <oc-icon name="close" aria-hidden="true" />
+        </oc-button>
       </div>
     </oc-grid>
   </div>

--- a/src/Phoenix.vue
+++ b/src/Phoenix.vue
@@ -14,6 +14,7 @@
             :logo-img="logoImage"
             :product-name="productName"
             :nav-items="navItems"
+            :hide-nav="sidebar.navigationHidden"
             :class="sidebarClasses"
             :fixed="isSidebarFixed"
             @close="toggleAppNavigationVisibility"

--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -13,10 +13,11 @@
       id="files-open-search-btn"
       key="mobile-search-button"
       class="uk-hidden@m"
-      icon="search"
       :aria-label="displaySearchButtonLabel"
       @click="focusMobileSearchInput"
-    />
+    >
+      <oc-icon name="search" aria-hidden="true" />
+    </oc-button>
     <oc-drop
       drop-id="oc-topbar-search-mobile"
       toggle="#files-open-search-btn"

--- a/src/pages/account.vue
+++ b/src/pages/account.vue
@@ -4,12 +4,10 @@
     <div v-if="!loading" class="uk-width-3-4@m uk-container uk-padding">
       <div class="uk-flex uk-flex-between uk-flex-middle">
         <h1 id="account-page-title" v-translate class="oc-page-title">Account</h1>
-        <oc-button
-          class="account-logout-button"
-          icon="exit_to_app"
-          @click="$_oc_settingsAccount_logout"
-          ><translate>Log out</translate></oc-button
-        >
+        <oc-button class="account-logout-button" @click="$_oc_settingsAccount_logout">
+          <oc-icon name="exit_to_app" aria-hidden="true" />
+          <translate>Log out</translate>
+        </oc-button>
       </div>
       <hr />
       <div class="uk-text-bold uk-margin-bottom"><translate>Account Information</translate></div>

--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -18,7 +18,7 @@
           size="large"
           variation="primary"
           class="oc-login-authorize-button"
-          @click.native="login()"
+          @click="login()"
         >
           <translate>Login</translate>
         </oc-button>

--- a/src/store/sidebar.js
+++ b/src/store/sidebar.js
@@ -1,9 +1,14 @@
 const state = {
+  navigationHidden: false,
   mainContentComponent: null,
   sidebarFooterContentComponent: null
 }
 
 const mutations = {
+  SET_NAVIGATION_HIDDEN(state, hidden) {
+    state.navigationHidden = hidden
+  },
+
   SET_MAIN_CONTENT_COMPONENT(state, component) {
     state.mainContentComponent = component
   },


### PR DESCRIPTION
## Description
This PR updates ODS to v1.10.0 and makes use of new icons and a new prop for the sidebar.
AS v1.10.0 introduces breaking changes, this PR also brings in a lot of adjustments in the layout and use of buttons. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>
TODO: add links to product issues

## Screenshots (if appropriate):

#### Accounts UI (not part of phoenix) has only one nav item at the moment. In the old ODS version this was hidden, now it's shown.
<img width="2170" alt="Screenshot 2020-09-16 at 13 58 45" src="https://user-images.githubusercontent.com/3532843/93336561-36345100-f828-11ea-9661-f73ab6da097a.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] fix button icons
- [ ] check alignments of buttons (were inline before, are block elements now)