### PR TITLE
Remember public link password on refresh

### DIFF
--- a/apps/files/src/store/mutations.js
+++ b/apps/files/src/store/mutations.js
@@ -227,6 +227,11 @@ export default {
   },
   SET_PUBLIC_LINK_PASSWORD(state, password) {
     state.publicLinkPassword = password
+    if (password) {
+      sessionStorage.setItem('publicLinkInfo', btoa(password))
+    } else {
+      sessionStorage.removeItem('publicLinkInfo')
+    }
   },
 
   ADD_ACTION_TO_PROGRESS(state, item) {

--- a/changelog/unreleased/public-link-remember-password-on-refresh
+++ b/changelog/unreleased/public-link-remember-password-on-refresh
@@ -1,0 +1,8 @@
+Enhancement: Remember public link password on page refresh
+
+When refreshing the page in the file list of a public link share,
+the user doesn't need to enter the password again. This only applies for the current page
+and the password is forgotten by the browser again upon closing or switching to another site.
+
+https://github.com/owncloud/phoenix/pull/4083
+https://github.com/owncloud/product/issues/231


### PR DESCRIPTION
## Description
Stores the public link password in sessionStorage so that it survives
page refresh. Closing the browser tab or to another tab doesn't preserve
it.

## Related Issue
Part 8b of https://github.com/owncloud/product/issues/231

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
After entering password on public link page:

- [x] TEST: refresh the page doesn't ask for password again
- [x] TEST: closing page and opening the URL again asks for the URL again (so password is forgotten correctly)
- [x] TEST: change public link password to create a discrepancy with saved one: password is asked again

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
