### PR TITLE
Remember public link password on page refresh (alternative)

### DIFF
--- a/apps/files/src/components/FileList.vue
+++ b/apps/files/src/components/FileList.vue
@@ -210,7 +210,6 @@ export default {
     ...mapActions('Files', [
       'loadFolder',
       'setHighlightedFile',
-      'setPublicLinkPassword',
       'resetFileSelection',
       'addFileSelection',
       'removeFileSelection',

--- a/apps/files/src/components/PublicLinks/PublicLink.vue
+++ b/apps/files/src/components/PublicLinks/PublicLink.vue
@@ -60,7 +60,7 @@ export default {
   },
   computed: {
     ...mapGetters(['configuration']),
-    ...mapGetters('Files', ['davProperties']),
+    ...mapGetters('Files', ['davProperties', 'publicLinkPassword']),
     passwordFieldLabel() {
       return this.$gettext('Enter password for public link')
     },
@@ -77,6 +77,7 @@ export default {
   methods: {
     ...mapActions('Files', ['setPublicLinkPassword']),
     resolvePublicLink() {
+      const password = this.password || this.publicLinkPassword
       this.loading = true
       this.inputErrorMessage = null
       const properties = this.davProperties.concat([
@@ -87,10 +88,10 @@ export default {
         this.$client.publicFiles.PUBLIC_LINK_SHARE_OWNER
       ])
       this.$client.publicFiles
-        .list(this.$route.params.token, this.password, properties, '0')
+        .list(this.$route.params.token, password, properties, '0')
         .then(files => {
           this.passwordRequired = false
-          this.setPublicLinkPassword(this.password)
+          this.setPublicLinkPassword(password)
           if (files[0].getProperty(this.$client.publicFiles.PUBLIC_LINK_PERMISSION) === '4') {
             this.$router.push({
               name: 'public-files-drop',

--- a/apps/files/src/store/getters.js
+++ b/apps/files/src/store/getters.js
@@ -88,7 +88,21 @@ export default {
     return state.highlightedFile
   },
   publicLinkPassword: state => {
-    return state.publicLinkPassword
+    // we need to use the state for reactivity
+    if (state.publicLinkPassword) {
+      return state.publicLinkPassword
+    }
+
+    let password = sessionStorage.getItem('publicLinkInfo')
+    if (password) {
+      try {
+        password = atob(password)
+      } catch (e) {
+        sessionStorage.removeItem('publicLinkInfo')
+      }
+    }
+
+    return password
   },
   uploaded: state => state.uploaded,
   actionsInProgress: state => state.actionsInProgress

--- a/apps/files/src/store/mutations.js
+++ b/apps/files/src/store/mutations.js
@@ -226,7 +226,13 @@ export default {
     state.highlightedFile = file
   },
   SET_PUBLIC_LINK_PASSWORD(state, password) {
+    // cache into state for reactivity
     state.publicLinkPassword = password
+    if (password) {
+      sessionStorage.setItem('publicLinkInfo', btoa(password))
+    } else {
+      sessionStorage.removeItem('publicLinkInfo')
+    }
   },
 
   ADD_ACTION_TO_PROGRESS(state, item) {

--- a/changelog/unreleased/public-link-remember-password-on-refresh
+++ b/changelog/unreleased/public-link-remember-password-on-refresh
@@ -1,0 +1,8 @@
+Enhancement: Remember public link password on page refresh
+
+When refreshing the page in the file list of a public link share,
+the user doesn't need to enter the password again. This only applies for the current page
+and the password is forgotten by the browser again upon closing or switching to another site.
+
+https://github.com/owncloud/phoenix/pull/4083
+https://github.com/owncloud/product/issues/231


### PR DESCRIPTION
Simpler alternative to https://github.com/owncloud/phoenix/pull/4083

## Description
When refreshing the page in the file list of a public link share,
the user doesn't need to enter the password again. This only applies for the current page
and the password is forgotten by the browser again upon closing or switching to another site.

## Related Issue
Part 8b of owncloud/product#231

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
After entering password on public link page:

- [x] TEST: refresh the page doesn't ask for password again
- [x] TEST: closing page and opening the URL again asks for the URL again (so password is forgotten correctly)
- [x] TEST: change public link password to create a discrepancy with saved one: password is asked again

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...