### PR TITLE
Improve oc10 link

### DIFF
--- a/changelog/unreleased/external-links
+++ b/changelog/unreleased/external-links
@@ -1,0 +1,5 @@
+Change: Improve external links in app switcher
+
+We have added an option to set the link target in external application links (defaults to `_blank`). The app switcher now shows all native extensions first and items based on application links last.
+
+https://github.com/owncloud/phoenix/pull/4092

--- a/src/Phoenix.vue
+++ b/src/Phoenix.vue
@@ -106,13 +106,13 @@ export default {
     $_applicationsList() {
       const list = []
 
-      // Get extensions manually added into config
-      list.push(this.configuration.applications)
-
       // Get extensions which have at least one nav item
       this.getExtensionsWithNavItems.forEach(extensionId => {
         list.push(this.apps[extensionId])
       })
+
+      // Get extensions manually added into config
+      list.push(this.configuration.applications)
 
       return list.flat()
     },

--- a/src/components/ApplicationsMenu.vue
+++ b/src/components/ApplicationsMenu.vue
@@ -85,7 +85,9 @@ export default {
 
         if (item.url) {
           app.url = item.url
-          app.target = item.target || '_blank'
+          app.target = ['_blank', '_self', '_parent', '_top'].includes(item.target)
+            ? item.target
+            : '_blank'
         } else if (item.path) {
           app.path = item.path
         } else {

--- a/src/components/ApplicationsMenu.vue
+++ b/src/components/ApplicationsMenu.vue
@@ -21,7 +21,7 @@
     >
       <div class="uk-grid-small uk-text-center" uk-grid>
         <div v-for="(n, nid) in $_applicationsList" :key="nid" class="uk-width-1-3">
-          <a v-if="n.url" key="external-link" target="_blank" :href="n.url">
+          <a v-if="n.url" key="external-link" :target="n.target" :href="n.url">
             <oc-icon v-if="n.iconMaterial" :name="n.iconMaterial" size="large" />
             <oc-icon v-if="n.iconUrl" :url="n.iconUrl" size="large" />
             <div>{{ n.title }}</div>
@@ -85,6 +85,7 @@ export default {
 
         if (item.url) {
           app.url = item.url
+          app.target = item.target || '_blank'
         } else if (item.path) {
           app.path = item.path
         } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6907,9 +6907,9 @@ os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
 owncloud-design-system@^1.9.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/owncloud-design-system/-/owncloud-design-system-1.11.0.tgz#cdeac879c7292e4520087913cb3b83425254d438"
-  integrity sha512-oQcgNDRB1fvq6wSQiApFu0nRI2j1SmLurOngG8dgXlABm9ArOA3K4crcjT/YdUjlFL0JnC64v5MUYWEQhQxTrA==
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/owncloud-design-system/-/owncloud-design-system-1.11.1.tgz#8afa0117d2d7d86bec6fb0e3198c17c10328fa79"
+  integrity sha512-ULrf/LOkHhRaBX3VoprHRg69n51Gu8AaOiu1jzIAJzRxE40XM+kv8sXNBvjoxeiZZBX6WHVQCmXCyysKI5Yatg==
   dependencies:
     luxon "^1.22.0"
     mini-css-extract-plugin "^0.9.0"


### PR DESCRIPTION
## Description
We have added an option to set the link target in external application links (defaults to `_blank`). The app switcher now shows all native extensions first and items based on application links last.

## Related Issue
- Fixes https://github.com/owncloud/product/issues/227

## Motivation and Context
Make switch between classic and new frontend as easy as possible.

## How Has This Been Tested?
✋ 

## Screenshots (if appropriate):
<img width="1427" alt="Screenshot 2020-09-21 at 14 29 24" src="https://user-images.githubusercontent.com/3532843/93771793-41b7bb80-fc1e-11ea-9eb5-096424c22abf.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
