### PR TITLE
Change wording of file action for opening PDFs in browser

### DIFF
--- a/apps/files/src/fileactions.js
+++ b/apps/files/src/fileactions.js
@@ -48,7 +48,7 @@ export default {
           icon: 'remove_red_eye',
           handler: file => this.fetchFile(file.path, 'application/pdf'),
           ariaLabel: () => {
-            return this.$gettext('Display PDF')
+            return this.$gettext('Open in browser')
           },
           isEnabled: function(item) {
             return item.extension === 'pdf'

--- a/changelog/unreleased/default-action
+++ b/changelog/unreleased/default-action
@@ -5,3 +5,4 @@ If no file editor or viewer is available, the default action falls back to downl
 
 https://github.com/owncloud/product/issues/234
 https://github.com/owncloud/phoenix/pull/4076
+https://github.com/owncloud/phoenix/pull/4097


### PR DESCRIPTION
## Description
Align wording for opening PDFs with file actions involving extensions (`Open in Mediaviewer` etc).

## Motivation and Context
Consistent naming.

## Screenshots (if appropriate):
<img width="1280" alt="Screenshot 2020-09-22 at 13 55 47" src="https://user-images.githubusercontent.com/3532843/93879058-5b6b0880-fcdb-11ea-91ba-06ced9582745.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
