### PR TITLE
[Tests-Only] Refactor restrict sharing and auto completion tests

### DIFF
--- a/tests/acceptance/features/webUIRestrictSharing/disableSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/disableSharing.feature
@@ -5,6 +5,8 @@ Feature: disable sharing
   So that users cannot share files
 
   Background:
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And the administrator has set the default folder for received shares to "Shares"
     Given user "user1" has been created with default attributes
 
   @smokeTest
@@ -26,15 +28,18 @@ Feature: disable sharing
   Scenario: Check file presence in shared-with-me page when sharing is disabled
     Given user "user2" has been created with default attributes
     And user "user2" has shared file "lorem.txt" with user "user1"
+    And user "user1" has accepted the share "lorem.txt" offered by user "user2"
     And user "user2" has shared folder "simple-folder" with user "user1"
+    And user "user1" has accepted the share "simple-folder" offered by user "user2"
     And the setting "shareapi_enabled" of app "core" has been set to "no"
     When user "user1" logs in using the webUI
-    Then file "lorem (2).txt" should be listed on the webUI
-    And folder "simple-folder (2)" should be listed on the webUI
+    When the user opens folder "Shares" using the webUI
+    Then file "lorem.txt" should be listed on the webUI
+    And folder "simple-folder" should be listed on the webUI
 #    And the link for "shared-with-me" page should not be available in files page menu
     When the user browses to the shared-with-me page
-    Then file "lorem (2).txt" should not be listed on the webUI
-    And folder "simple-folder (2)" should not be listed on the webUI
+    Then file "lorem.txt" should not be listed on the webUI
+    And folder "simple-folder" should not be listed on the webUI
 
   @issue-2459
   Scenario: Check file presence in shared-with-others page when Sharing is disabled

--- a/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature
@@ -6,6 +6,8 @@ Feature: restrict resharing
   I want to be able to forbid a user that received a share from me to share it further
 
   Background:
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And the administrator has set the default folder for received shares to "Shares"
     Given these users have been created with default attributes:
       | username |
       | user1    |
@@ -22,22 +24,28 @@ Feature: restrict resharing
   Scenario: disable resharing and check if the received resource can be reshared
     Given the setting "shareapi_allow_resharing" of app "core" has been set to "no"
     And user "user2" has shared folder "simple-folder" with user "user1"
-    And user "user1" has favorited element "simple-folder (2)"
+    And user "user1" has accepted the share "simple-folder" offered by user "user2"
+    And user "user1" has favorited element "/Shares/simple-folder"
     When user "user1" logs in using the webUI
-    Then the user should not be able to share folder "simple-folder (2)" using the webUI
+    And the user opens folder "Shares" using the webUI
+    Then the user should not be able to share folder "simple-folder" using the webUI
     When the user browses to the shared-with-me page
 #    Then the user should not be able to share folder "simple-folder (2)" using the webUI
-    And the user shares folder "simple-folder (2)" with user "User Three" as "Editor" using the webUI
+    And the user shares folder "simple-folder" with user "User Three" as "Editor" using the webUI
     Then the error message with header "Error while sharing." should be displayed on the webUI
-    And as "user3" folder "simple-folder (2)" should not exist
+    And as "user3" folder "simple-folder" should not exist
     When the user browses to the favorites page
-    Then the user should not be able to share folder "simple-folder (2)" using the webUI
+    Then the user should not be able to share folder "Shares/simple-folder" using the webUI
 
   @smokeTest
   Scenario: disable resharing and check if the received resource from group share can be reshared
     Given the setting "shareapi_allow_resharing" of app "core" has been set to "no"
     And user "user3" has shared file "lorem.txt" with group "grp1"
+    And user "user1" has accepted the share "lorem.txt" offered by user "user3"
+    And user "user2" has accepted the share "lorem.txt" offered by user "user3"
     When user "user1" logs in using the webUI
-    Then the user should not be able to share file "lorem (2).txt" using the webUI
+    And the user opens folder "Shares" using the webUI
+    Then the user should not be able to share file "lorem.txt" using the webUI
     When the user re-logs in as "user2" using the webUI
-    Then the user should not be able to share file "lorem (2).txt" using the webUI
+    And the user opens folder "Shares" using the webUI
+    Then the user should not be able to share file "lorem.txt" using the webUI

--- a/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
@@ -42,7 +42,7 @@ Feature: restrict Sharing
   Scenario: Do not restrict users to only share with groups they are member of
     Given the setting "shareapi_only_share_with_membership_groups" of app "core" has been set to "no"
     When the user shares folder "simple-folder" with group "grp2" as "Viewer" using the webUI
-    And user "user3" has accepted the share "simple-folder" offered by user "user2"
+    And user "user3" accepts the share "simple-folder" offered by user "user2" using the sharing API
     Then as "user3" folder "/Shares/simple-folder" should exist
 
   @smokeTest

--- a/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
@@ -5,6 +5,8 @@ Feature: restrict Sharing
   So that users can only share files with specific users and groups
 
   Background:
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And the administrator has set the default folder for received shares to "Shares"
     Given these users have been created with default attributes:
       | username |
       | user1    |
@@ -40,7 +42,8 @@ Feature: restrict Sharing
   Scenario: Do not restrict users to only share with groups they are member of
     Given the setting "shareapi_only_share_with_membership_groups" of app "core" has been set to "no"
     When the user shares folder "simple-folder" with group "grp2" as "Viewer" using the webUI
-    Then as "user3" folder "simple-folder (2)" should exist
+    And user "user3" has accepted the share "simple-folder" offered by user "user2"
+    Then as "user3" folder "/Shares/simple-folder" should exist
 
   @smokeTest
   Scenario: Forbid sharing with groups

--- a/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletion.feature
@@ -5,8 +5,10 @@ Feature: Autocompletion of share-with names
   So that I can efficiently share my files with other users or groups
 
   Background:
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And the administrator has set the default folder for received shares to "Shares"
     # Users that are in the special known users already
-    Given these users have been created with default attributes but not initialized:
+    And these users have been created with default attributes but not initialized:
       | username    |
       | user1       |
       | user3       |

--- a/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletionSpecialChars.feature
+++ b/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletionSpecialChars.feature
@@ -5,7 +5,9 @@ Feature: Autocompletion of share-with names
   So that I can efficiently share my files with other users or groups
 
 Background:
-  Given these users have been created with default attributes but not initialized:
+  Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+  And the administrator has set the default folder for received shares to "Shares"
+  And these users have been created with default attributes but not initialized:
     | username    |
     | regularuser |
   And these users have been created but not initialized:


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Refactor webui test scenarios for using the Shares folder and root folder for shares.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Related https://github.com/owncloud/ocis/issues/518

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Shares in ocis are received in Shares folder by default. To test that we need this refactor.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
:robot:

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...