### PR TITLE
[Tests-Only] refactor federation sharing tests for shares folder

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -58,6 +58,7 @@ config = {
 		'webUIFederation': {
 			'suites': {
 				'webUISharingExternal': 'SharingExternal',
+				'webUISharingExternalToRoot': 'SharingExternalRoot',
 			},
 			'extraEnvironment': {
 				'OPENID_LOGIN': 'true',

--- a/tests/acceptance/features/webUISharingExternalToRoot/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternalToRoot/federationSharing.feature
@@ -6,12 +6,8 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   Background:
     Given app "notifications" has been enabled
-    And the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "no" on remote server
+    And the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes" on remote server
     And the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "no"
-    And the setting "shareapi_auto_accept_share" of app "core" has been set to "no" on remote server
-    And the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
-    And the administrator has set the default folder for received shares to "Shares"
-    And the administrator has set the default folder for received shares to "Shares" on remote server
     And server "%remote_backend_url%" has been added as trusted server
     And server "%backend_url%" has been added as trusted server
     And server "%backend_url%" has been added as trusted server on remote server
@@ -22,12 +18,10 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   Scenario: test the single steps of sharing a folder to a remote server
     When the user shares folder "simple-folder" with remote user "user1" as "Editor" using the webUI
-    And user "user1" from server "REMOTE" accepts the last pending share using the sharing API
     And the user shares folder "simple-empty-folder" with remote user "user1" as "Editor" using the webUI
-    And user "user1" from server "REMOTE" accepts the last pending share using the sharing API
-    Then as "user1" folder "Shares/simple-folder" should exist on remote server
-    And as "user1" file "Shares/simple-folder/lorem.txt" should exist on remote server
-    And as "user1" folder "Shares/simple-empty-folder" should exist on remote server
+    Then as "user1" folder "/simple-folder (2)" should exist on remote server
+    And as "user1" file "/simple-folder (2)/lorem.txt" should exist on remote server
+    And as "user1" folder "/simple-empty-folder (2)" should exist on remote server
 
   @issue-2510 @yetToImplement
   Scenario: test the single steps of receiving a federation share
@@ -44,70 +38,81 @@ Feature: Federation Sharing - sharing with users on other cloud storages
       | "user3@%remote_backend_url%" shared "lorem.txt" with you           |
     When the user accepts all shares displayed in the notifications on the webUI
     And the user reloads the current page of the webUI
-    And the user opens folder "Shares" using the webUI
+    Then file "lorem (2).txt" should be listed on the webUI
+    And as "user1" the content of "lorem (2).txt" should be the same as the original "lorem.txt"
+    And folder "simple-folder (2)" should be listed on the webUI
+    And folder "simple-folder (2)" should be listed on the webUI
+    When the user opens folder "simple-folder (2)" using the webUI
     Then file "lorem.txt" should be listed on the webUI
-    And as "user1" the content of "Shares/lorem.txt" should be the same as the original "lorem.txt"
-    And folder "simple-folder" should be listed on the webUI
-    And the user opens folder "simple-folder" using the webUI
-    Then file "lorem.txt" should be listed on the webUI
-    And as "user1" the content of "Shares/simple-folder/lorem.txt" should be the same as the original "simple-folder/lorem.txt"
+    And as "user1" the content of "simple-folder (2)/lorem.txt" should be the same as the original "simple-folder/lorem.txt"
     #    When the user browses to the shared-with-me page
-    #    Then file "Shares/lorem.txt" should be listed on the webUI
-    #    And folder "Shares/simple-folder" should be listed on the webUI
-    #    And folder "Shares/simple-empty-folder" should be listed on the webUI
+    #    Then file "lorem (2).txt" should be listed on the webUI
+    #    And folder "simple-folder (2)" should be listed on the webUI
+    #    And folder "simple-empty-folder (2)" should be listed on the webUI
 
   Scenario: declining a federation share on the webUI
     Given user "user1" from remote server has shared "/lorem.txt" with user "user1" from local server
     And the user has reloaded the current page of the webUI
     When the user declines all shares displayed in the notifications on the webUI
-    Then folder "Shares" should not be listed on the webUI
+    Then file "lorem (2).txt" should not be listed on the webUI
     When the user browses to the shared-with-me page
     And the user reloads the current page of the webUI
-    Then file "lorem.txt" should not be listed on the webUI
+    Then file "lorem (2).txt" should not be listed on the webUI
+
+  @issue-2510 @yetToImplement
+  Scenario: automatically accept a federation share when it is allowed by the config
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "user1" from remote server has shared "simple-folder" with user "user1" from local server
+    When the user reloads the current page of the webUI
+    Then folder "simple-folder" should be listed on the webUI
+    When the user opens folder "simple-folder" directly on the webUI
+    Then file "lorem.txt" should be listed on the webUI
+    When the user browses to the shared-with-me page
+    And the user reloads the current page of the webUI
+    Then folder "simple-folder" should not be listed on the webUI
 
   Scenario: share a folder with an remote user with "Viewer" role
     When the user shares folder "simple-empty-folder" with remote user "user1" as "Viewer" using the webUI
-    And user "user1" from server "REMOTE" accepts the last pending share using the sharing API
     Then user "user1" should have shared a folder "simple-empty-folder" with these details:
       | field       | value                      |
       | uid_owner   | user1                      |
       | share_with  | user1@%remote_backend_url% |
       | item_type   | folder                     |
       | permissions | read                       |
-    And as "user1" folder "Shares/simple-empty-folder" should exist on remote server
+    And as "user1" folder "simple-empty-folder" should exist on remote server
 
   @issue-3309
   Scenario: share a folder with an remote user and prohibit deleting - remote server shares - local server receives
     Given user "user1" from remote server has shared "simple-folder" with user "user1" from local server with "read" permissions
     When the user reloads the current page of the webUI
     And the user accepts all shares displayed in the notifications on the webUI
-    And the user opens folder "Shares%2Fsimple-folder" directly on the webUI
+    And the user opens folder "simple-folder (2)" directly on the webUI
     And the user reloads the current page of the webUI
     Then it should not be possible to delete file "lorem.txt" using the webUI
 
   @issue-3309
   Scenario: overwrite a file in a received share - remote server shares - local server receives
-    Given user "user1" from remote server has shared "simple-folder" with user "user1" from local server
-    And user "user1" from server "LOCAL" has accepted the last pending share
-    When the user opens folder "Shares%2Fsimple-folder" directly on the webUI
-    When the user reloads the current page of the webUI
-    And the user uploads overwriting file "lorem.txt" using the webUI
-    Then as "user1" the content of "Shares/simple-folder/lorem.txt" should be the same as the local "lorem.txt"
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "user1" from remote server has shared "simple-folder" with user "user1" from local server
+    And the user opens folder "simple-folder (2)" directly on the webUI
+    And the user reloads the current page of the webUI
+    When the user uploads overwriting file "lorem.txt" using the webUI
+    Then as "user1" the content of "simple-folder (2)/lorem.txt" should be the same as the local "lorem.txt"
 
   @issue-3309
   Scenario: upload a new file in a received share - remote server shares - local server receives
-    Given user "user1" from remote server has shared "simple-folder" with user "user1" from local server
-    And user "user1" from server "LOCAL" has accepted the last pending share
-    When the user opens folder "Shares%2Fsimple-folder" directly on the webUI
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "user1" from remote server has shared "simple-folder" with user "user1" from local server
+    When the user opens folder "simple-folder (2)" directly on the webUI
     And the user reloads the current page of the webUI
     And the user uploads file "new-lorem.txt" using the webUI
     Then as "user1" file "simple-folder/new-lorem.txt" should exist on remote server
 
   @issue-3309
   Scenario: rename a file in a received share - remote server shares - local server receives
-    Given user "user1" from remote server has shared "simple-folder" with user "user1" from local server
-    And user "user1" from server "LOCAL" has accepted the last pending share
-    When the user opens folder "Shares%2Fsimple-folder" directly on the webUI
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "user1" from remote server has shared "simple-folder" with user "user1" from local server
+    When the user opens folder "simple-folder (2)" directly on the webUI
     And the user reloads the current page of the webUI
     And the user renames file "lorem.txt" to "new-lorem.txt" using the webUI
     Then as "user1" file "simple-folder/new-lorem.txt" should exist on remote server
@@ -115,22 +120,20 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @issue-3309
   Scenario: delete a file in a received share - remote server shares - local server receives
-    Given user "user1" from remote server has shared "simple-folder" with user "user1" from local server
-    And user "user1" from server "LOCAL" has accepted the last pending share
-    When the user opens folder "Shares%2Fsimple-folder" directly on the webUI
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "user1" from remote server has shared "simple-folder" with user "user1" from local server
+    When the user opens folder "simple-folder (2)" directly on the webUI
     And the user reloads the current page of the webUI
     And the user deletes file "lorem.txt" using the webUI
     Then as "user1" file "simple-folder/lorem.txt" should not exist on remote server
 
-  @skip @issue-4102
   Scenario: unshare a federation share
-    Given user "user1" from remote server has shared "lorem.txt" with user "user1" from local server
-    And user "user1" from server "LOCAL" has accepted the last pending share
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "user1" from remote server has shared "lorem.txt" with user "user1" from local server
     When the user reloads the current page of the webUI
-    And the user opens folder "Shares" using the webUI
-    And the user deletes file "lorem.txt" using the webUI
-    Then file "lorem.txt" should not be listed on the webUI
-    And as "user1" file "Shares/lorem.txt" should not exist
+    And the user deletes file "lorem (2).txt" using the webUI
+    Then file "lorem (2).txt" should not be listed on the webUI
+    And as "user1" file "lorem (2).txt" should not exist
     And as "user1" file "lorem.txt" should exist on remote server
 
   @issue-2510 @skip @yetToImplement
@@ -143,14 +146,12 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And file "lorem (2).txt" should not be listed in the files page on the webUI
 
   Scenario: test resharing folder with "Viewer" role
-    Given user "user2" has been created with default attributes
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "user2" has been created with default attributes
     And user "user1" from remote server has shared "simple-folder" with user "user1" from local server
-    And user "user1" from server "LOCAL" has accepted the last pending share
     And the user has reloaded the current page of the webUI
-    And the user opens folder "Shares" using the webUI
-    When the user shares folder "simple-folder" with user "User Two" as "Viewer" using the webUI
-    And user "user2" accepts the share "Shares/simple-folder" offered by user "user1" using the sharing API
-    Then as "user2" folder "Shares/simple-folder/lorem.txt" should exist
+    When the user shares folder "simple-folder (2)" with user "User Two" as "Viewer" using the webUI
+    Then as "user2" folder "simple-folder (2)/lorem.txt" should exist
     And user "user2" should have received a share with these details:
       | field       | value                      |
       | uid_owner   | user1                      |
@@ -159,41 +160,36 @@ Feature: Federation Sharing - sharing with users on other cloud storages
       | permissions | read                       |
 
   Scenario: test resharing a federated server to remote again
-    Given user "user2" has been created with default attributes on remote server
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "user2" has been created with default attributes on remote server
     And user "user1" from remote server has shared "simple-folder" with user "user1" from local server with "read, share" permissions
-    And user "user1" from server "LOCAL" has accepted the last pending share
     And the user has reloaded the current page of the webUI
-    When the user opens folder "Shares" using the webUI
-    And the user shares folder "simple-folder" with remote user "user2" as "Viewer" using the webUI
-    And user "user2" from server "REMOTE" accepts the last pending share using the sharing API
-    Then user "user1" should have shared a folder "Shares/simple-folder" with these details:
+    When the user shares folder "simple-folder (2)" with remote user "user2" as "Viewer" using the webUI
+    Then user "user1" should have shared a folder "simple-folder (2)" with these details:
       | field       | value                      |
       | uid_owner   | user1                      |
       | share_with  | user2@%remote_backend_url% |
       | item_type   | folder                     |
       | permissions | read                       |
-    And as "user2" folder "Shares/simple-folder" should exist on remote server
+    And as "user2" folder "simple-folder (2)" should exist on remote server
 
   Scenario: try resharing a folder with read-only permissions
-    Given user "user1" from remote server has shared "simple-folder" with user "user1" from local server with "read" permissions
-    And user "user1" from server "LOCAL" has accepted the last pending share
-    And the user reloads the current page of the webUI
-    And the user opens folder "Shares" using the webUI
-    Then the user should not be able to share folder "simple-folder" using the webUI
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "user1" from remote server has shared "simple-folder" with user "user1" from local server with "read" permissions
+    When the user reloads the current page of the webUI
+    Then the user should not be able to share folder "simple-folder (2)" using the webUI
 
   Scenario: test sharing long file names with federation share
     When user "user1" has uploaded file with content "secret" to "averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt"
     And the user has reloaded the current page of the webUI
     When the user shares file "averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" with remote user "user1" as "Viewer" using the webUI
-    And user "user1" from server "REMOTE" accepts the last pending share using the sharing API
-    Then as "user1" file "Shares/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" should exist on remote server
+    Then as "user1" file "averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" should exist on remote server
 
   Scenario: sharee should be able to access the files/folders inside other folder
-    Given user "user1" from remote server has shared "'single'quotes" with user "user1" from local server
-    And user "user1" from server "LOCAL" has accepted the last pending share
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "user1" from remote server has shared "'single'quotes" with user "user1" from local server
     And the user has reloaded the current page of the webUI
-    When the user opens folder "Shares" using the webUI
-    And the user opens folder "'single'quotes" using the webUI
+    When the user opens folder "'single'quotes (2)" using the webUI
     Then as "user1" these resources should be listed on the webUI
      | entry_name          |
      | simple-empty-folder |
@@ -205,37 +201,37 @@ Feature: Federation Sharing - sharing with users on other cloud storages
      | for-git-commit |
     When the user downloads file "for-git-commit" using the webUI
     Then no message should be displayed on the webUI
-    And as "user1" the content of "Shares/'single'quotes/lorem.txt" should be the same as the original "'single'quotes/lorem.txt"
-    And as "user1" the content of "Shares/'single'quotes/simple-empty-folder/for-git-commit" should be the same as the original "'single'quotes/simple-empty-folder/for-git-commit"
+    And as "user1" the content of "'single'quotes (2)/lorem.txt" should be the same as the original "'single'quotes/lorem.txt"
+    And as "user1" the content of "'single'quotes (2)/simple-empty-folder/for-git-commit" should be the same as the original "'single'quotes/simple-empty-folder/for-git-commit"
 
   Scenario: uploading a file inside a folder of a folder
-    Given user "user1" from remote server has shared "simple-folder" with user "user1" from local server
-    And user "user1" from server "LOCAL" has accepted the last pending share
-    When the user opens folder "Shares%2Fsimple-folder/simple-empty-folder" directly on the webUI
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "user1" from remote server has shared "simple-folder" with user "user1" from local server
+    When the user opens folder "simple-folder (2)/simple-empty-folder" directly on the webUI
     And the user uploads file "new-lorem.txt" using the webUI
     Then file "new-lorem.txt" should be listed on the webUI
     And as "user1" file "simple-folder/simple-empty-folder/new-lorem.txt" should exist on remote server
-    And as "user1" file "Shares/simple-folder/simple-empty-folder/new-lorem.txt" should exist
+    And as "user1" file "simple-folder (2)/simple-empty-folder/new-lorem.txt" should exist
 
   Scenario: rename a file in a folder inside a shared folder
-    Given user "user1" from remote server has shared "'single'quotes" with user "user1" from local server
-    And user "user1" from server "LOCAL" has accepted the last pending share
-    When the user opens folder "Shares%2F'single'quotes/simple-empty-folder" directly on the webUI
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "user1" from remote server has shared "'single'quotes" with user "user1" from local server
+    When the user opens folder "/'single'quotes (2)/simple-empty-folder" directly on the webUI
     And the user renames file "for-git-commit" to "not-for-git-commit" using the webUI
     Then file "for-git-commit" should not be listed on the webUI
-    And as "user1" file "Shares/'single'quotes/simple-empty-folder/for-git-commit" should not exist
+    And as "user1" file "'single'quotes (2)/simple-empty-folder/for-git-commit" should not exist
     And as "user1" file "'single'quotes/simple-empty-folder/for-git-commit" should not exist on remote server
     But file "not-for-git-commit" should be listed on the webUI
-    And as "user1" file "Shares/'single'quotes/simple-empty-folder/not-for-git-commit" should exist
+    And as "user1" file "'single'quotes (2)/simple-empty-folder/not-for-git-commit" should exist
     And as "user1" file "'single'quotes/simple-empty-folder/not-for-git-commit" should exist on remote server
 
   Scenario: delete a file in a folder inside a shared folder
-    Given user "user1" from remote server has shared "'single'quotes" with user "user1" from local server
-    And user "user1" from server "LOCAL" has accepted the last pending share
-    When the user opens folder "Shares/'single'quotes/simple-empty-folder" directly on the webUI
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "user1" from remote server has shared "'single'quotes" with user "user1" from local server
+    When the user opens folder "/'single'quotes (2)/simple-empty-folder" directly on the webUI
     And the user deletes file "for-git-commit" using the webUI
     Then file "for-git-commit" should not be listed on the webUI
-    And as "user1" file "Shares/'single'quotes/simple-empty-folder/for-git-commit" should not exist
+    And as "user1" file "'single'quotes (2)/simple-empty-folder/for-git-commit" should not exist
     And as "user1" file "'single'quotes/simple-empty-folder/for-git-commit" should not exist on remote server
 
   @issue-2060
@@ -243,7 +239,6 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Given user "user1" has created folder "/simple-folder/simple-empty-folder/new-folder"
     And user "user1" has uploaded file with content "test" to "/simple-folder/simple-empty-folder/lorem.txt"
     And the user shares folder "simple-folder" with remote user "user1" as "Editor" using the webUI
-    And user "user1" from server "REMOTE" has accepted the last pending share
     When the user opens folder "/" directly on the webUI
     Then the following resources should have share indicators on the webUI
       | fileName            | expectedIndicators |
@@ -263,18 +258,15 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Given user "user2" has been created with default attributes
     And user "user3" has been created with default attributes
     And user "user1" has shared folder "simple-folder" with user "user2"
-    And user "user2" has accepted the share "simple-folder" offered by user "user1"
     And the user re-logs in as "user2" using the webUI
-    And user "user2" has shared folder "Shares/simple-folder" with user "user3"
-    And the user opens folder "Shares" using the webUI
-    And the user opens folder "simple-folder" using the webUI
+    And user "user2" has shared folder "simple-folder (2)" with user "user3"
+    And the user opens folder "simple-folder (2)" using the webUI
     And the user shares folder "simple-empty-folder" with remote user "user1" as "Editor" using the webUI
-    And user "user1" from server "REMOTE" has accepted the last pending share
-    When the user opens folder "/Shares" directly on the webUI
+    When the user opens folder "/" directly on the webUI
     Then the following resources should have share indicators on the webUI
       | fileName            | expectedIndicators |
-      | simple-folder   | user-direct        |
-    When the user opens folder "simple-folder" using the webUI
+      | simple-folder (2)   | user-direct        |
+    When the user opens folder "simple-folder (2)" using the webUI
     Then the following resources should have share indicators on the webUI
       | fileName            | expectedIndicators |
       | simple-empty-folder | user-direct        |
@@ -284,16 +276,14 @@ Feature: Federation Sharing - sharing with users on other cloud storages
   Scenario: sharing indicator of items inside a re-shared subfolder
     Given user "user2" has been created with default attributes
     And user "user1" has shared folder "simple-folder" with user "user2"
-    And user "user2" has accepted the share "simple-folder" offered by user "user1"
     And the user re-logs in as "user2" using the webUI
-    And the user opens folder "Shares" using the webUI
-    And the user opens folder "simple-folder" using the webUI
+    And the user opens folder "simple-folder (2)" using the webUI
     And the user shares folder "simple-empty-folder" with remote user "user1" as "Editor" using the webUI
-    When the user opens folder "/Shares" directly on the webUI
+    When the user opens folder "/" directly on the webUI
     Then the following resources should have share indicators on the webUI
       | fileName            | expectedIndicators |
-      | simple-folder   | user-indirect      |
-    When the user opens folder "simple-folder" using the webUI
+      | simple-folder (2)   | user-indirect      |
+    When the user opens folder "simple-folder (2)" using the webUI
     Then the following resources should have share indicators on the webUI
       | fileName            | expectedIndicators |
       | simple-empty-folder | user-direct        |
@@ -302,7 +292,6 @@ Feature: Federation Sharing - sharing with users on other cloud storages
   @issue-2060
   Scenario: sharing indicator for file uploaded inside a shared folder
     Given the user shares folder "simple-empty-folder" with remote user "user1" as "Editor" using the webUI
-    And user "user1" from server "REMOTE" has accepted the last pending share
     When the user opens folder "simple-empty-folder" using the webUI
     And the user uploads file "new-lorem.txt" using the webUI
     Then the following resources should have share indicators on the webUI
@@ -312,7 +301,6 @@ Feature: Federation Sharing - sharing with users on other cloud storages
   @issue-2060
   Scenario: sharing indicator for folder created inside a shared folder
     Given the user shares folder "simple-empty-folder" with remote user "user1" as "Editor" using the webUI
-    And user "user1" from server "REMOTE" has accepted the last pending share
     When the user opens folder "simple-empty-folder" using the webUI
     And the user creates a folder with the name "sub-folder" using the webUI
     Then the following resources should have share indicators on the webUI
@@ -322,7 +310,6 @@ Feature: Federation Sharing - sharing with users on other cloud storages
   @issue-2939
   Scenario: sharing indicator for federated shares stays up to date
     When the user shares folder "simple-folder" with remote user "user1" as "Editor" using the webUI
-    And user "user1" from server "REMOTE" accepts the last pending share using the sharing API
     Then the following resources should have share indicators on the webUI
       | fileName      | expectedIndicators |
       | simple-folder | user-direct        |
@@ -335,7 +322,6 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Given user "user1" has created folder "/simple-folder/sub-folder"
     And user "user1" has uploaded file with content "test" to "/simple-folder/textfile.txt"
     And the user shares folder "simple-folder" with remote user "user1" as "Editor" using the webUI
-    And user "user1" from server "REMOTE" has accepted the last pending share
     When the user opens folder "simple-folder" using the webUI
     And the user opens the share dialog for folder "sub-folder" using the webUI
     Then remote user "user1" should be listed as "Editor" via "simple-folder" in the collaborators list on the webUI

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -1256,6 +1256,28 @@ When(
   }
 )
 
+Given('user {string} from server {string} has accepted the last pending share', function(
+  user,
+  server
+) {
+  if (server === backendHelper.BACKENDS.remote) {
+    return backendHelper.runOnRemoteBackend(() => sharingHelper.acceptLastPendingShare(user))
+  } else {
+    return sharingHelper.acceptLastPendingShare(user)
+  }
+})
+
+When(
+  'user {string} from server {string} accepts the last pending share using the sharing API',
+  function(user, server) {
+    if (server === backendHelper.BACKENDS.remote) {
+      return backendHelper.runOnRemoteBackend(() => sharingHelper.acceptLastPendingShare(user))
+    } else {
+      return sharingHelper.acceptLastPendingShare(user)
+    }
+  }
+)
+
 Then('the file {string} shared by {string} should not be in {string} state', async function(
   filename,
   sharer,
@@ -1398,3 +1420,18 @@ Given('the administrator has set the default folder for received shares to {stri
   }
   return runOcc([`config:system:set share_folder --value=${folder}`])
 })
+
+Given(
+  'the administrator has set the default folder for received shares to {string} on remote server',
+  function(folder) {
+    if (client.globals.ocis) {
+      if (folder === 'Shares') {
+        return
+      }
+      throw Error(`Cannot set ${folder} as default share received folder in OCIS`)
+    }
+    return backendHelper.runOnRemoteBackend(runOcc, [
+      [`config:system:set share_folder --value=${folder}`]
+    ])
+  }
+)


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Refactor webui test scenarios for using the Shares folder and root folder for shares.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Related https://github.com/owncloud/ocis/issues/518

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Shares in ocis are received in Shares folder by default. To test that we need this refactor.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
:robot:

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...