### PR TITLE
Customizable user menu

### DIFF
--- a/apps/files/src/components/FileList.vue
+++ b/apps/files/src/components/FileList.vue
@@ -34,7 +34,7 @@
       </oc-grid>
       <div v-if="loading" id="files-list-loading-message" class="uk-position-center">
         <div class="uk-text-center">
-          <oc-spinner id="files-list-progress" size="large" :aria-hidden="true" />
+          <oc-spinner id="files-list-progress" size="large" :aria-hidden="true" aria-label="" />
           <div class="uk-text-muted uk-text-large">
             <slot name="loadingMessage" />
           </div>

--- a/apps/files/src/default.js
+++ b/apps/files/src/default.js
@@ -87,10 +87,7 @@ const navItems = [
       name: 'files-favorites'
     },
     enabled(capabilities) {
-      if (capabilities.files) {
-        return capabilities.files.favorites
-      }
-      return false
+      return capabilities.files && capabilities.files.favorites
     }
   },
   {
@@ -113,10 +110,7 @@ const navItems = [
     name: $gettext('Deleted files'),
     iconMaterial: 'delete',
     enabled(capabilities) {
-      if (capabilities.dav) {
-        return capabilities.dav.trashbin === '1.0'
-      }
-      return false
+      return capabilities.dav && capabilities.dav.trashbin === '1.0'
     },
     route: {
       name: 'files-trashbin'

--- a/apps/files/src/default.js
+++ b/apps/files/src/default.js
@@ -87,7 +87,10 @@ const navItems = [
       name: 'files-favorites'
     },
     enabled(capabilities) {
-      return capabilities.files && capabilities.files.favorites
+      if (capabilities.files) {
+        return capabilities.files.favorites
+      }
+      return false
     }
   },
   {
@@ -110,7 +113,7 @@ const navItems = [
     name: $gettext('Deleted files'),
     iconMaterial: 'delete',
     enabled(capabilities) {
-      if (capabilities && capabilities.dav) {
+      if (capabilities.dav) {
         return capabilities.dav.trashbin === '1.0'
       }
       return false

--- a/changelog/unreleased/user-menu.md
+++ b/changelog/unreleased/user-menu.md
@@ -1,0 +1,5 @@
+Change: Customizable menu association
+
+We now allow the redirect navItems and links into the user menu. This can be done by simply assigning the `"menu": "user"` to the respective navItem. It works for both extensions and external links (`applications` key in config.json).
+
+https://github.com/owncloud/phoenix/pull/4133

--- a/src/Phoenix.vue
+++ b/src/Phoenix.vue
@@ -13,7 +13,7 @@
             class="oc-app-navigation"
             :logo-img="logoImage"
             :product-name="productName"
-            :nav-items="navItems"
+            :nav-items="sidebarNavItems"
             :hide-nav="sidebar.navigationHidden"
             :class="sidebarClasses"
             :fixed="isSidebarFixed"
@@ -31,7 +31,7 @@
           <top-bar
             v-if="!publicPage() && !$route.meta.verbose"
             class="uk-width-expand"
-            :applications-list="$_applicationsList"
+            :applications-list="applicationsList"
             :active-notifications="activeNotifications"
             :user-id="user.username || user.id"
             :user-display-name="user.displayname"
@@ -100,21 +100,29 @@ export default {
       'capabilities',
       'apps',
       'getSettingsValue',
-      'getNavItems',
+      'getNavItemsByExtension',
       'getExtensionsWithNavItems'
     ]),
-    $_applicationsList() {
+    applicationsList() {
       const list = []
 
       // Get extensions which have at least one nav item
       this.getExtensionsWithNavItems.forEach(extensionId => {
-        list.push(this.apps[extensionId])
+        list.push({
+          ...this.apps[extensionId],
+          type: 'extension'
+        })
       })
 
       // Get extensions manually added into config
-      list.push(this.configuration.applications)
+      this.configuration.applications.forEach(application => {
+        list.push({
+          ...application,
+          type: 'link'
+        })
+      })
 
-      return list.flat()
+      return list
     },
 
     showHeader() {
@@ -132,12 +140,12 @@ export default {
       return this.configuration.theme.general.name
     },
 
-    navItems() {
+    sidebarNavItems() {
       if (this.publicPage()) {
         return []
       }
 
-      const items = this.getNavItems(this.currentExtension)
+      const items = this.getNavItemsByExtension(this.currentExtension)
       if (!items) {
         return []
       }

--- a/src/components/ApplicationsMenu.vue
+++ b/src/components/ApplicationsMenu.vue
@@ -20,13 +20,13 @@
       close-on-click
     >
       <div class="uk-grid-small uk-text-center" uk-grid>
-        <div v-for="(n, nid) in $_applicationsList" :key="nid" class="uk-width-1-3">
-          <a v-if="n.url" key="external-link" :target="n.target" :href="n.url">
+        <div v-for="(n, nid) in menuItems" :key="`apps-menu-${nid}`" class="uk-width-1-3">
+          <a v-if="n.url" key="apps-menu-external-link" :target="n.target" :href="n.url">
             <oc-icon v-if="n.iconMaterial" :name="n.iconMaterial" size="xlarge" />
             <oc-icon v-if="n.iconUrl" :url="n.iconUrl" size="xlarge" />
             <div>{{ n.title }}</div>
           </a>
-          <router-link v-else key="internal-link" :to="n.path">
+          <router-link v-else key="apps-menu-internal-link" :to="n.path">
             <oc-icon v-if="n.iconMaterial" :name="n.iconMaterial" size="xlarge" />
             <oc-icon v-if="n.iconUrl" :url="n.iconUrl" size="xlarge" />
             <div v-text="n.title" />
@@ -38,7 +38,10 @@
 </template>
 
 <script>
+import NavigationMixin from '../mixins/navigationMixin'
+
 export default {
+  mixins: [NavigationMixin],
   props: {
     visible: {
       type: Boolean,
@@ -48,54 +51,15 @@ export default {
     applicationsList: {
       type: Array,
       required: false,
-      default: () => null
+      default: () => []
     }
   },
   computed: {
+    menuItems() {
+      return this.navigation_getMenuItems([null, 'apps', 'appSwitcher'])
+    },
     applicationSwitcherLabel() {
       return this.$gettext('Application Switcher')
-    },
-
-    $_applicationsList() {
-      return this.applicationsList.map(item => {
-        const lang = this.$language.current
-        // TODO: move language resolution to a common function
-        // FIXME: need to handle logic for variants like en_US vs en_GB
-        let title = item.title ? item.title.en : item.name
-        let iconMaterial
-        let iconUrl
-        if (item.title && item.title[lang]) {
-          title = item.title[lang]
-        }
-
-        if (!item.icon) {
-          iconMaterial = 'deprecated' // broken icon
-        } else if (item.icon.indexOf('.') < 0) {
-          // not a file name or URL, treat as a material icon name instead
-          iconMaterial = item.icon
-        } else {
-          iconUrl = item.icon
-        }
-
-        const app = {
-          iconMaterial: iconMaterial,
-          iconUrl: iconUrl,
-          title: title
-        }
-
-        if (item.url) {
-          app.url = item.url
-          app.target = ['_blank', '_self', '_parent', '_top'].includes(item.target)
-            ? item.target
-            : '_blank'
-        } else if (item.path) {
-          app.path = item.path
-        } else {
-          app.path = `/${item.id}`
-        }
-
-        return app
-      })
     }
   },
   watch: {

--- a/src/components/Top-Bar.vue
+++ b/src/components/Top-Bar.vue
@@ -21,7 +21,11 @@
     >
       <notifications v-if="activeNotifications.length" />
       <applications-menu v-if="applicationsList.length > 0" :applications-list="applicationsList" />
-      <user-menu :user-id="userId" :user-display-name="userDisplayName" />
+      <user-menu
+        :user-id="userId"
+        :user-display-name="userDisplayName"
+        :applications-list="applicationsList"
+      />
     </oc-grid>
   </header>
 </template>
@@ -56,7 +60,7 @@ export default {
     applicationsList: {
       type: Array,
       required: false,
-      default: () => null
+      default: () => []
     },
     hasAppNavigation: {
       type: Boolean,

--- a/src/components/UserMenu.vue
+++ b/src/components/UserMenu.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="userId">
     <oc-button
       id="_userMenuButton"
       ref="menuButton"
@@ -31,18 +31,56 @@
     >
       <ul class="uk-list">
         <li class="uk-text-nowrap">
-          <router-link id="oc-topbar-account-manage" v-translate to="/account"
-            >Manage your account</router-link
+          <oc-button
+            id="oc-topbar-account-manage"
+            type="router-link"
+            :to="{ path: '/account' }"
+            variation="raw"
+            gap-size="xsmall"
+            justify-content="left"
           >
+            <oc-icon name="portrait" />
+            <translate>Profile</translate>
+          </oc-button>
+        </li>
+        <li v-for="(n, nid) in menuItems" :key="`user-menu-${nid}`">
+          <oc-button
+            v-if="n.url"
+            type="a"
+            variation="raw"
+            gap-size="xsmall"
+            justify-content="left"
+            :target="n.target"
+            :href="n.url"
+          >
+            <oc-icon v-if="n.iconMaterial" :name="n.iconMaterial" />
+            <oc-icon v-if="n.iconUrl" :url="n.iconUrl" />
+            <span>{{ n.title }}</span>
+          </oc-button>
+          <oc-button
+            v-else
+            type="router-link"
+            variation="raw"
+            gap-size="xsmall"
+            justify-content="left"
+            :to="{ path: n.path }"
+          >
+            <oc-icon v-if="n.iconMaterial" :name="n.iconMaterial" />
+            <oc-icon v-if="n.iconUrl" :url="n.iconUrl" />
+            <span v-text="n.title" />
+          </oc-button>
         </li>
         <li>
-          <router-link
+          <oc-button
             id="oc-topbar-account-logout"
-            v-translate
-            to="/"
-            @click.native.prevent="logout"
-            >Log out</router-link
+            variation="raw"
+            gap-size="xsmall"
+            justify-content="left"
+            @click="logout"
           >
+            <oc-icon name="exit_to_app" />
+            <translate>Log out</translate>
+          </oc-button>
         </li>
       </ul>
     </oc-drop>
@@ -51,8 +89,10 @@
 
 <script>
 import appVersionJson from '../../build/version.json'
+import NavigationMixin from '../mixins/navigationMixin'
 
 export default {
+  mixins: [NavigationMixin],
   props: {
     userId: {
       type: String,
@@ -66,11 +106,21 @@ export default {
       type: String,
       required: false,
       default: null
+    },
+    applicationsList: {
+      type: Array,
+      required: false,
+      default: () => []
     }
   },
   data() {
     return {
       appVersion: appVersionJson
+    }
+  },
+  computed: {
+    menuItems() {
+      return this.navigation_getMenuItems(['user'])
     }
   },
   watch: {
@@ -86,14 +136,6 @@ export default {
     logout() {
       this.visible = false
       this.$store.dispatch('logout')
-    },
-    openItem(url) {
-      if (url) {
-        const win = window.open(url, '_blank')
-        if (win) {
-          win.focus()
-        }
-      }
     },
     focusFirstLink() {
       /*

--- a/src/mixins/navigationMixin.js
+++ b/src/mixins/navigationMixin.js
@@ -1,0 +1,78 @@
+import { mapGetters } from 'vuex'
+
+export default {
+  computed: {
+    ...mapGetters(['getNavItemsByExtension'])
+  },
+  methods: {
+    /**
+     * Returns well formed menuItem objects by a list of extensions.
+     * The following properties must be accessible in the wrappping code:
+     * - applicationsList
+     * - $language
+     *
+     * @param permittedMenus
+     * @returns {*}
+     */
+    navigation_getMenuItems(permittedMenus) {
+      return this.applicationsList
+        .filter(app => {
+          if (app.type === 'extension') {
+            // check if the extension has at least one navItem with a matching menuId
+            return (
+              this.getNavItemsByExtension(app.id).filter(navItem =>
+                isNavItemPermitted(permittedMenus, navItem)
+              ).length > 0
+            )
+          }
+          return isNavItemPermitted(permittedMenus, app)
+        })
+        .map(item => {
+          const lang = this.$language.current
+          // TODO: move language resolution to a common function
+          // FIXME: need to handle logic for variants like en_US vs en_GB
+          let title = item.title ? item.title.en : item.name
+          let iconMaterial
+          let iconUrl
+          if (item.title && item.title[lang]) {
+            title = item.title[lang]
+          }
+
+          if (!item.icon) {
+            iconMaterial = 'deprecated' // "broken" icon
+          } else if (item.icon.indexOf('.') < 0) {
+            // not a file name or URL, treat as a material icon name instead
+            iconMaterial = item.icon
+          } else {
+            iconUrl = item.icon
+          }
+
+          const app = {
+            iconMaterial: iconMaterial,
+            iconUrl: iconUrl,
+            title: title
+          }
+
+          if (item.url) {
+            app.url = item.url
+            app.target = ['_blank', '_self', '_parent', '_top'].includes(item.target)
+              ? item.target
+              : '_blank'
+          } else if (item.path) {
+            app.path = item.path
+          } else {
+            app.path = `/${item.id}`
+          }
+
+          return app
+        })
+    }
+  }
+}
+
+function isNavItemPermitted(permittedMenus, navItem) {
+  if (navItem.menu) {
+    return permittedMenus.includes(navItem.menu)
+  }
+  return permittedMenus.includes(null)
+}

--- a/src/pages/account.vue
+++ b/src/pages/account.vue
@@ -4,9 +4,13 @@
     <div v-if="!loading" class="uk-width-3-4@m uk-container oc-p">
       <div class="uk-flex uk-flex-between uk-flex-middle">
         <h1 id="account-page-title" v-translate class="oc-page-title">Account</h1>
-        <oc-button class="account-logout-button" @click="$_oc_settingsAccount_logout">
-          <oc-icon name="exit_to_app" aria-hidden="true" />
-          <translate>Log out</translate>
+        <oc-button v-if="editUrl" variation="primary" type="a" :href="editUrl">
+          <oc-icon name="edit" aria-hidden="true" />
+          <translate>Edit</translate>
+        </oc-button>
+        <oc-button v-else-if="editRoute" variation="primary" type="router-link" :to="editRoute">
+          <oc-icon name="edit" aria-hidden="true" />
+          <translate>Edit</translate>
         </oc-button>
       </div>
       <hr />
@@ -47,7 +51,7 @@
 </template>
 
 <script>
-import { mapGetters, mapActions } from 'vuex'
+import { mapGetters } from 'vuex'
 export default {
   name: 'Personal',
   data() {
@@ -57,21 +61,30 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(['user'])
+    ...mapGetters(['user', 'configuration', 'getNavItemsByExtension']),
+    editUrl() {
+      if (this.user.version.edition === 'reva') {
+        return null
+      }
+      return this.configuration.server.replace(/\/$/, '') + '/index.php/settings/personal'
+    },
+    editRoute() {
+      const navItems = this.getNavItemsByExtension('settings')
+      if (navItems.length > 0) {
+        return navItems[0].route || {}
+      }
+      return null
+    }
   },
   mounted() {
     this.$_oc_settingsAccount_getGroup()
   },
   methods: {
-    ...mapActions(['logout']),
     $_oc_settingsAccount_getGroup() {
       this.$client.users.getUserGroups(this.user.id).then(groups => {
         this.groups = groups
         this.loading = false
       })
-    },
-    $_oc_settingsAccount_logout() {
-      this.logout()
     }
   }
 }

--- a/src/store/user.js
+++ b/src/store/user.js
@@ -10,7 +10,7 @@ const state = {
   email: null,
   isAuthenticated: false,
   capabilities: [],
-  version: [],
+  version: {},
   groups: []
 }
 

--- a/tests/acceptance/features/webUIAccount/logout.feature
+++ b/tests/acceptance/features/webUIAccount/logout.feature
@@ -8,5 +8,5 @@ Feature: Logout users
     Given user "user1" has been created with default attributes
     And user "user1" has logged in using the webUI
     When the user browses to the account page
-    And the user logs out using the webUI
+    And the user logs out of the webUI
     Then the authentication page should be visible

--- a/tests/acceptance/pageObjects/accountPage.js
+++ b/tests/acceptance/pageObjects/accountPage.js
@@ -42,9 +42,6 @@ module.exports = {
       }
       return actualAccInfo
     },
-    logout: function() {
-      return this.waitForElementVisible('@logoutButton').click('@logoutButton')
-    },
     isPageVisible: async function() {
       let isVisible = true
 
@@ -62,9 +59,6 @@ module.exports = {
     accountInformationElements: {
       selector: '//div/span[.="Account Information"]/../../div[@class="uk-flex uk-flex-wrap"]/div',
       locateStrategy: 'xpath'
-    },
-    logoutButton: {
-      selector: '.account-logout-button'
     }
   }
 }

--- a/tests/acceptance/stepDefinitions/accountContext.js
+++ b/tests/acceptance/stepDefinitions/accountContext.js
@@ -31,7 +31,3 @@ Then('the user should have following details displayed on the account informatio
     }
   }
 })
-
-When('the user logs out using the webUI', function() {
-  return client.page.accountPage().logout()
-})


### PR DESCRIPTION
## Description
This PR makes navigation items customizable with regard to which menu they appear in. By default, anything appears in the app switcher. You can define a `menu: "user"` in applications in config.json or in the exported navItems of applications. With a separate PR for ocis, the settings and accounts UI will appear in the user menu by default.
Also:
- We took the chance to add icons to menu items and rename the `Manager your account` menu item to `Profile` - which is a better fit, because it just shows read only information.
- We replaced the `Logout` button on the profile page with an `Edit` button which links to the oc10 personal settings if those are available and to the settings UI if that is available.

In case you want to add a nav item to the user menu manually, you can do so via the config.json file:
```
"applications": [
          {
                "title": {"en": "Settings"},
                "icon": "application",
                "url": "http://host.docker.internal/px1/index.php/settings/personal",
                "target": "_self",
                "menu": "user"
          }
]
```

## Motivation and Context
Improve navigation UX and bridge setup.

## Screenshots (if appropriate):
<img width="238" alt="Screenshot 2020-10-06 at 13 05 46" src="https://user-images.githubusercontent.com/3532843/95212430-fb518780-07ed-11eb-9dc2-cd7cda53ce1e.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 