### PR TITLE
Enable autoredirect to IdP

### DIFF
--- a/changelog/unreleased/login-autoredirect
+++ b/changelog/unreleased/login-autoredirect
@@ -1,0 +1,6 @@
+Change: Enable autoredirect to the IdP
+
+We've added a key into the theme to enable autoredirect to the IdP when entering ocis-web instead of displaying the login page first.
+The default value is set to true.
+
+https://github.com/owncloud/phoenix/pull/4138

--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="oc-login" uk-height-viewport>
+  <div v-if="initialized" class="oc-login" uk-height-viewport>
     <div class="oc-login-card uk-position-center">
       <h1 v-translate class="oc-login-logo">
         ownCloud
@@ -38,7 +38,8 @@ export default {
   name: 'LoginPage',
   data() {
     return {
-      loading: false
+      loading: false,
+      initialized: false
     }
   },
   computed: {
@@ -48,6 +49,15 @@ export default {
       return this.configuration.theme.general.name
     }
   },
+
+  created() {
+    if (this.configuration.theme.loginPage.autoRedirect) {
+      this.login()
+    } else {
+      this.initialized = true
+    }
+  },
+
   methods: {
     ...mapActions(['login'])
   }

--- a/src/phoenix.js
+++ b/src/phoenix.js
@@ -87,7 +87,7 @@ const supportedLanguages = {
   gl: 'Galego'
 }
 
-function loadApps () {
+async function loadApps () {
   let plugins = []
   let translations = coreTranslations
 
@@ -168,6 +168,9 @@ function loadApps () {
     silent: true
   })
 
+  // inject custom theme config into vuex
+  await fetchTheme()
+
   const OC = new Vue({
     el: '#owncloud',
     data: {
@@ -181,13 +184,18 @@ function loadApps () {
 
   // externalize Vue - this is not the Vue instance but the class
   window.Vue = Vue
+}
 
-  // inject custom theme config into vuex
-  fetch(`themes/${config.theme}.json`)
-    .then(res => res.json())
-    .then(res => {
-      store.dispatch('loadTheme', { theme: res, name: config.theme })
-    })
+function fetchTheme() {
+  return new Promise((resolve, reject) => {
+    fetch(`themes/${config.theme}.json`)
+      .then(res => res.json())
+      .then(res => {
+        store.dispatch('loadTheme', { theme: res, name: config.theme })
+        resolve(true)
+      })
+      .catch(err => reject(err))
+  })
 }
 
 function registerStoreModule (app) {

--- a/src/store/config.js
+++ b/src/store/config.js
@@ -28,6 +28,9 @@ const state = {
     },
     filesList: {
       hideDefaultStatusIndicators: false
+    },
+    loginPage: {
+      autoRedirect: true
     }
   },
   options: {
@@ -63,7 +66,7 @@ const mutations = {
     }
   },
   LOAD_THEME(state, theme) {
-    state.theme = theme
+    state.theme = { ...state.theme, ...theme }
   }
 }
 

--- a/tests/acceptance/features/webUILogin/login.feature
+++ b/tests/acceptance/features/webUILogin/login.feature
@@ -24,7 +24,7 @@ Feature: login users
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
     When the user logs out of the webUI
-    Then the authentication page should be visible
+    Then the user should be redirected to the IdP login page
 
   @ocisSmokeTest
   Scenario: logging out redirects to the url with state attribute
@@ -43,7 +43,6 @@ Feature: login users
         | username |
         | user1    |
       And the user has browsed to the login page
-      And the user has clicked the authenticate button
       When the user tries to log in with username "invalid" and password "1234" using the webUI
       Then the warning 'Logon failed. Please verify your credentials and try again.' should be displayed on the login page
 
@@ -53,7 +52,6 @@ Feature: login users
         | username |
         | user1    |
       And the user has browsed to the login page
-      And the user has clicked the authenticate button
       When the user tries to log in with username "user1" and password "invalid" using the webUI
       Then the files table should be displayed
 #      Then the warning 'Logon failed. Please verify your credentials and try again.' should be displayed on the login page

--- a/tests/acceptance/features/webUILogin/login.feature
+++ b/tests/acceptance/features/webUILogin/login.feature
@@ -34,7 +34,7 @@ Feature: login users
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
     When the user logs out of the webUI
-    Then the user should be on page with the url containing "/#/login?state="
+    Then the user should be on page with the url containing "state="
     When user "user1" logs in using the webUI
     Then the files table should be displayed
 

--- a/tests/acceptance/features/webUIPrivateLinks/accessingPrivateLinks.feature
+++ b/tests/acceptance/features/webUIPrivateLinks/accessingPrivateLinks.feature
@@ -15,7 +15,8 @@ Feature: Access private link
 
   @smokeTest
   Scenario: Access private link before authorisation
-    Given the user navigates to the private link created by user "user1" for file "lorem.txt"
+    When the user tries to navigate to the private link created by user "user1" for file "lorem.txt"
+    Then the user should be redirected to the IdP login page
     When user "user1" has logged in using the webUI
     Then the app-sidebar for file "lorem.txt" should be visible on the webUI
     And the "versions" details panel should be visible

--- a/tests/acceptance/features/webUIPrivateLinks/accessingPrivateLinks.feature
+++ b/tests/acceptance/features/webUIPrivateLinks/accessingPrivateLinks.feature
@@ -46,4 +46,4 @@ Feature: Access private link
 
   Scenario: Access the private link anonymously
     When the user tries to navigate to the private link created by user "user1" for file "lorem.txt"
-    Then the user should be redirected to the login page
+    Then the user should be redirected to the IdP login page

--- a/tests/acceptance/helpers/loginHelper.js
+++ b/tests/acceptance/helpers/loginHelper.js
@@ -14,10 +14,7 @@ module.exports = {
    * @param {password} [password=null] - If not passed, default password for given `userId` will be used
    */
   loginAsUser: async function(userId, password = null) {
-    await client.page
-      .loginPage()
-      .navigate()
-      .authenticate()
+    await client.page.loginPage().navigate()
 
     password = password || userSettings.getPasswordForUser(userId)
     if (client.globals.openid_login) {

--- a/tests/acceptance/pageObjects/ocisLoginPage.js
+++ b/tests/acceptance/pageObjects/ocisLoginPage.js
@@ -45,6 +45,9 @@ module.exports = {
           })
           .useCss()
         return errorMessage
+      },
+      waitForPage: function() {
+        return this.waitForElementVisible('@loginSubmitButton')
       }
     }
   ]

--- a/tests/acceptance/pageObjects/ownCloudAuthorizePage.js
+++ b/tests/acceptance/pageObjects/ownCloudAuthorizePage.js
@@ -29,6 +29,9 @@ module.exports = {
               }
             }
           )
+      },
+      waitForPage: function() {
+        return this.waitForElementVisible('@authorizeButton')
       }
     }
   ]

--- a/tests/acceptance/pageObjects/ownCloudAuthorizePage.js
+++ b/tests/acceptance/pageObjects/ownCloudAuthorizePage.js
@@ -3,9 +3,15 @@ module.exports = {
     return this.api.launchUrl
   },
   elements: {
-    body: 'body',
+    body: {
+      selector: '#body-login'
+    },
     authorizeButton: {
       selector: 'button[type=submit]'
+    },
+    inputUsername: {
+      selector: '//input[@id="user"]',
+      locateStrategy: 'xpath'
     }
   },
   commands: [
@@ -30,8 +36,21 @@ module.exports = {
             }
           )
       },
-      waitForPage: function() {
-        return this.waitForElementVisible('@authorizeButton')
+      waitForPage: async function() {
+        let isLoginPageVisible = false
+
+        await this.waitForElementVisible('@body')
+        await this.api.element('@inputUsername', result => {
+          if (result.status > -1) {
+            isLoginPageVisible = true
+          }
+        })
+
+        if (isLoginPageVisible) {
+          return this.assert.ok(isLoginPageVisible)
+        }
+
+        return this.api.expect.element(this.elements.authorizeButton.selector).to.be.visible
       }
     }
   ]

--- a/tests/acceptance/stepDefinitions/loginContext.js
+++ b/tests/acceptance/stepDefinitions/loginContext.js
@@ -101,3 +101,11 @@ Then('the accounts page should be visible in the webUI', async function() {
 Then('the user should be redirected to the login page', function() {
   return client.page.loginPage().waitForPage()
 })
+
+Then('the user should be redirected to the IdP login page', function() {
+  if (client.globals.openid_login) {
+    return client.page.ocisLoginPage().waitForPage()
+  }
+
+  return client.page.ownCloudAuthorizePage().waitForPage()
+})

--- a/tests/acceptance/stepDefinitions/loginContext.js
+++ b/tests/acceptance/stepDefinitions/loginContext.js
@@ -60,7 +60,7 @@ Then('the authentication page should be visible', () => {
 })
 
 Then('the user should be on page with the url containing {string}', function(urlContent) {
-  return client.assert.urlEquals(client.launchUrl + urlContent)
+  return client.assert.urlContains(urlContent)
 })
 
 // combined step

--- a/themes/owncloud.json
+++ b/themes/owncloud.json
@@ -9,5 +9,8 @@
   },
   "filesList": {
     "hideDefaultStatusIndicators": false
+  },
+  "loginPage": {
+    "autoRedirect": true
   }
 }


### PR DESCRIPTION
We've added a key into the theme to enable auto-redirect to the IdP when entering ocis-web instead of displaying the login page first. The default value is set to true.