### PR TITLE
[tests-only] don't run DB & oC service when testing ocis

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -473,6 +473,7 @@ def acceptance():
 										databaseServiceForFederation(db, federationDbSuffix) if params['federatedServerNeeded'] else []
 									) +
 									owncloudService()
+								if not params['runningOnOCIS'] else []
 								),
 							'depends_on': [],
 							'trigger': {


### PR DESCRIPTION
## Description
MySQL and oc10 are not needed for the ocis related tests

## Related Issue
- Fixes  #4148

## Motivation and Context
use less :electric_plug: , safe the :earth_asia: 

## How Has This Been Tested?
:robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...