### PR TITLE
Default apps in example configs

### DIFF
--- a/changelog/unreleased/default-apps-in-example-configs
+++ b/changelog/unreleased/default-apps-in-example-configs
@@ -1,0 +1,5 @@
+Change: Sensible default apps in example configs
+
+We adapted the example configs for oc10 and owncloud so that the files and media-viewer apps are enabled by default.
+
+https://github.com/owncloud/phoenix/pull/4155

--- a/config.json.sample-oc10
+++ b/config.json.sample-oc10
@@ -7,7 +7,10 @@
     "url": "https://demo.owncloud.com/index.php/apps/oauth2/api/v1/token",
     "authUrl": "https://demo.owncloud.com/index.php/apps/oauth2/authorize"
   },
-  "apps" : ["files"],
+  "apps": [
+    "files",
+    "media-viewer"
+  ],
   "applications": [
     {
       "title": {

--- a/config.json.sample-ocis
+++ b/config.json.sample-ocis
@@ -14,18 +14,16 @@
   },
   "apps": [
     "files",
-    "draw-io",
-    "markdown-editor",
     "media-viewer"
   ],
   "external_apps": [
     {
-      "id": "accounts",
-      "path": "https://localhost:9200/accounts.js"
-    },
-    {
       "id": "settings",
       "path": "https://localhost:9200/settings.js"
+    },
+    {
+      "id": "accounts",
+      "path": "https://localhost:9200/accounts.js"
     }
   ]
 }


### PR DESCRIPTION
## Description
We only want to have "files" and "media-viewer" as default apps in the example configs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
