### PR TITLE
Move folder loading switch outside of finally method

### DIFF
--- a/apps/files/src/store/actions.js
+++ b/apps/files/src/store/actions.js
@@ -394,12 +394,13 @@ export default {
           if (context.getters.searchTerm !== '') {
             context.dispatch('resetSearch')
           }
+          context.commit('UPDATE_FOLDER_LOADING', false)
         })
         .catch(error => {
+          context.commit('UPDATE_FOLDER_LOADING', false)
           reject(error)
         })
         .finally(() => {
-          context.commit('UPDATE_FOLDER_LOADING', false)
           client.users.getUser(context.rootGetters.user.id).then(res => {
             const quota = res.quota
 
@@ -452,6 +453,7 @@ export default {
         }
         context.dispatch('resetFileSelection')
         context.dispatch('setHighlightedFile', null)
+        context.commit('UPDATE_FOLDER_LOADING', false)
       })
       .catch(e => {
         context.dispatch(
@@ -463,8 +465,6 @@ export default {
           },
           { root: true }
         )
-      })
-      .finally(() => {
         context.commit('UPDATE_FOLDER_LOADING', false)
       })
   },
@@ -489,6 +489,7 @@ export default {
           const files = json.ocs.data
           const uniqueFiles = _aggregateFileShares(files, false)
           context.dispatch('buildFilesSharedFromMe', uniqueFiles)
+          context.commit('UPDATE_FOLDER_LOADING', false)
         })
       })
       .catch(e => {
@@ -501,8 +502,6 @@ export default {
           },
           { root: true }
         )
-      })
-      .finally(() => {
         context.commit('UPDATE_FOLDER_LOADING', false)
       })
   },
@@ -527,6 +526,7 @@ export default {
           const files = json.ocs.data
           const uniqueFiles = _aggregateFileShares(files, true)
           context.dispatch('buildFilesSharedFromMe', uniqueFiles)
+          context.commit('UPDATE_FOLDER_LOADING', false)
         })
       })
       .catch(e => {
@@ -539,8 +539,6 @@ export default {
           },
           { root: true }
         )
-      })
-      .finally(() => {
         context.commit('UPDATE_FOLDER_LOADING', false)
       })
   },

--- a/changelog/unreleased/flashy-messages-when-loading-folders
+++ b/changelog/unreleased/flashy-messages-when-loading-folders
@@ -1,0 +1,6 @@
+Bugfix: Do not display "empty folder" message when there is any content
+
+We've fixed that when some of the file/share lists were being loaded, the "empty folder" message sometimes briefly appeared even though the list wasn't empty.
+
+https://github.com/owncloud/product/issues/263
+https://github.com/owncloud/phoenix/pull/4162


### PR DESCRIPTION
## Description
It seems that the `finally` method was being called too early. Moving the switch of loading into `then` and `catch` solved the flashy empty folder messages.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/product/issues/263