### PR TITLE
[tests-only] make sure userId is used as string

### DIFF
--- a/tests/acceptance/stepDefinitions/provisioningContext.js
+++ b/tests/acceptance/stepDefinitions/provisioningContext.js
@@ -178,7 +178,7 @@ Given('these users have been created with default attributes but not initialized
 ) {
   return Promise.all(
     dataTable.rows().map(userId => {
-      return deleteUser(userId).then(() => createDefaultUser(userId))
+      return deleteUser(userId.toString()).then(() => createDefaultUser(userId.toString()))
     })
   )
 })


### PR DESCRIPTION
## Description
`userId` is a single value array e.g. `[user1]`, to transform it into a string before sending it to the next function

## Motivation and Context
`join()` function fails with `TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received an instance of Array`

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...