### PR TITLE
[tests-only]  add webUISharingAutocompletion to drone-CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -120,6 +120,7 @@ config = {
 					'webUIRestrictSharing',
 					'webUIResharing',
 					'webUISharingAcceptShares',
+					'webUISharingAutocompletion',
 				],
 			},
 			'extraEnvironment': {

--- a/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletion.feature
@@ -1,4 +1,4 @@
-@skipOnOCIS @ocis-reva-issue-64
+@skipOnOCIS @ocis-reva-issue-34 @ocis-reva-issue-194
 Feature: Autocompletion of share-with names
   As a user
   I want to share files, with minimal typing, to the right people or groups

--- a/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletionSpecialChars.feature
+++ b/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletionSpecialChars.feature
@@ -1,4 +1,4 @@
-@skipOnOCIS @ocis-reva-issue-64
+@skipOnOCIS @ocis-reva-issue-34 @ocis-reva-issue-194
 Feature: Autocompletion of share-with names
   As a user
   I want to share files, with minimal typing, to the right people or groups


### PR DESCRIPTION
## Description
- tag the tests with the correct issue id (the main reason these tests will not run is the lack of group sharing)
- still add the tests to the CI pipeline, so they don't get forgotten when they will be enabled one day

## Related Issue
part of https://github.com/owncloud/ocis/issues/518

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...