### PR TITLE
[tests-only] enable sharing permission tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -122,6 +122,14 @@ config = {
 					'webUISharingAcceptShares',
 					'webUISharingAutocompletion',
 				],
+				'webUIOCIS4': [
+					'webUISharingFilePermissionMultipleUsers',
+					'webUISharingFilePermissionsGroups',
+					'webUISharingFolderAdvancedPermissionMultipleUsers',
+					'webUISharingFolderAdvancedPermissionsGroups',
+					'webUISharingFolderPermissionMultipleUsers',
+					'webUISharingFolderPermissionsGroups',
+				],
 			},
 			'extraEnvironment': {
 				'NODE_TLS_REJECT_UNAUTHORIZED': '0',

--- a/tests/acceptance/features/webUISharingFilePermissionMultipleUsers/shareFileWithMultipleUsers.feature
+++ b/tests/acceptance/features/webUISharingFilePermissionMultipleUsers/shareFileWithMultipleUsers.feature
@@ -1,4 +1,3 @@
-@skipOnOCIS @issue-product-203
 Feature: Sharing files with multiple internal users with different permissions
   As a user
   I want to set different permissions on shared files with other users
@@ -12,6 +11,7 @@ Feature: Sharing files with multiple internal users with different permissions
       | user1    |
       | user2    |
 
+  @skipOnOCIS @issue-product-203
   Scenario Outline: share a file with multiple users with different roles and permissions
     Given these users have been created with default attributes:
       | username |
@@ -48,6 +48,61 @@ Feature: Sharing files with multiple internal users with different permissions
       | uid_owner   | user1                |
       | share_with  | user3                |
       | file_target | /Shares/lorem.txt    |
+      | item_type   | file                 |
+      | permissions | <actual-permissions> |
+    But user "Regular User" should not be listed in the collaborators list on the webUI
+    And as "user0" file "/Shares/lorem.txt" should not exist
+    And user "User Four" should not be listed in the collaborators list on the webUI
+    And as "user4" file "/Shares/lorem.txt" should not exist
+    Examples:
+      | role                 | displayed-role | extra-permissions | displayed-permissions | actual-permissions  |
+      | Viewer               | Viewer         | share             | share                 | read, share         |
+      | Viewer               | Viewer         | ,                 | ,                     | read                |
+      | Editor               | Editor         | share             | share                 | share, read, update |
+      | Editor               | Editor         | ,                 | ,                     | read, update        |
+      | Advanced permissions | Viewer         | ,                 | ,                     | read                |
+      | Advanced permissions | Viewer         | share             | share                 | read, share         |
+      | Advanced permissions | Editor         | update            | ,                     | read, update        |
+      | Advanced permissions | Editor         | share, update     | share                 | read, update, share |
+
+  @skipOnOC10 @issue-product-203
+  #after fixing the issue delete this scenario and use the one above by deleting the @skipOnOCIS tag there
+  Scenario Outline: share a file with multiple users with different roles and permissions
+    Given these users have been created with default attributes:
+      | username |
+      | user0    |
+      | user3    |
+      | user4    |
+    And user "user1" has logged in using the webUI
+    When the user opens the share dialog for file "lorem.txt" using the webUI
+    And the user opens the share creation dialog in the webUI
+    And the user selects the following collaborators for the share as "<role>" with "<extra-permissions>" permissions:
+      | collaborator | type |
+      | Regular User | user |
+      | User Two     | user |
+      | User Three   | user |
+      | User Four    | user |
+    And the user removes "User Four" as a collaborator from the share
+    And the user removes "Regular User" as a collaborator from the share
+    And the user shares with the selected collaborators
+    And user "user2" accepts the share "lorem.txt" offered by user "user1" using the sharing API
+    And user "user3" accepts the share "lorem.txt" offered by user "user1" using the sharing API
+    Then custom permissions "<displayed-permissions>" should be set for user "User Two" for file "lorem.txt" on the webUI
+    And custom permissions "<displayed-permissions>" should be set for user "User Three" for file "lorem.txt" on the webUI
+    And user "User Two" should be listed as "<displayed-role>" in the collaborators list for file "lorem.txt" on the webUI
+    And user "User Three" should be listed as "<displayed-role>" in the collaborators list for file "lorem.txt" on the webUI
+    And user "user2" should have received a share with these details:
+      | field       | value                |
+      | uid_owner   | user1                |
+      | share_with  | user2                |
+      | file_target | /lorem.txt           |
+      | item_type   | file                 |
+      | permissions | <actual-permissions> |
+    And user "user3" should have received a share with these details:
+      | field       | value                |
+      | uid_owner   | user1                |
+      | share_with  | user3                |
+      | file_target | /lorem.txt           |
       | item_type   | file                 |
       | permissions | <actual-permissions> |
     But user "Regular User" should not be listed in the collaborators list on the webUI

--- a/tests/acceptance/features/webUISharingFolderAdvancedPermissionMultipleUsers/sharedFolderWithMultipleUsersAdvancedPermissions.feature
+++ b/tests/acceptance/features/webUISharingFolderAdvancedPermissionMultipleUsers/sharedFolderWithMultipleUsersAdvancedPermissions.feature
@@ -1,4 +1,3 @@
-@skipOnOCIS @issue-product-203
 Feature: Sharing folders with multiple internal users using advanced permissions
   As a user
   I want to set advanced permissions on shared folders with other users
@@ -12,6 +11,7 @@ Feature: Sharing folders with multiple internal users using advanced permissions
       | user1    |
       | user2    |
 
+  @skipOnOCIS @issue-product-203
   Scenario Outline: share a folder with multiple users using role as advanced permissions role and different extra permissions
     Given these users have been created with default attributes:
       | username |
@@ -68,3 +68,62 @@ Feature: Sharing folders with multiple internal users using advanced permissions
       | Advanced permissions | Advanced permissions | share, delete, update         | share, delete, update | read, share, delete, update  |
       | Advanced permissions | Advanced permissions | share, create, delete         | share, create, delete | read, share, delete, create  |
       | Advanced permissions | Advanced permissions | share, update, create         | share, update, create | read, share, update, create  |
+
+  @skipOnOC10 @issue-product-203 @issue-ocis-717
+  #after fixing the issue delete this scenario and use the one above by deleting the @skipOnOCIS tag there
+  Scenario Outline: share a folder with multiple users using role as advanced permissions role and different extra permissions
+    Given these users have been created with default attributes:
+      | username |
+      | user0    |
+      | user3    |
+      | user4    |
+    And user "user1" has logged in using the webUI
+    When the user opens the share dialog for folder "simple-folder" using the webUI
+    And the user opens the share creation dialog in the webUI
+    And the user selects the following collaborators for the share as "<role>" with "<extra-permissions>" permissions:
+      | collaborator | type |
+      | Regular User | user |
+      | User Two     | user |
+      | User Three   | user |
+      | User Four    | user |
+    And the user removes "User Four" as a collaborator from the share
+    And the user removes "Regular User" as a collaborator from the share
+    And the user shares with the selected collaborators
+    And user "user2" accepts the share "simple-folder" offered by user "user1" using the sharing API
+    And user "user3" accepts the share "simple-folder" offered by user "user1" using the sharing API
+    Then custom permissions "<displayed-permissions>" should be set for user "User Two" for folder "simple-folder" on the webUI
+    And custom permissions "<displayed-permissions>" should be set for user "User Three" for folder "simple-folder" on the webUI
+    And user "User Two" should be listed as "<displayed-role>" in the collaborators list for folder "simple-folder" on the webUI
+    And user "User Three" should be listed as "<displayed-role>" in the collaborators list for folder "simple-folder" on the webUI
+    And user "user2" should have received a share with these details:
+      | field       | value                |
+      | uid_owner   | user1                |
+      | share_with  | user2                |
+      | file_target | /simple-folder       |
+      | item_type   | folder               |
+      | permissions | <actual-permissions> |
+    And user "user3" should have received a share with these details:
+      | field       | value                |
+      | uid_owner   | user1                |
+      | share_with  | user3                |
+      | file_target | /simple-folder       |
+      | item_type   | folder               |
+      | permissions | <actual-permissions> |
+    But user "Regular User" should not be listed in the collaborators list on the webUI
+    And as "user0" folder "/Shares/simple-folder" should not exist
+    And user "User Four" should not be listed in the collaborators list on the webUI
+    And as "user4" folder "/Shares/simple-folder" should not exist
+    Examples:
+      | role                 | displayed-role       | extra-permissions     | displayed-permissions | actual-permissions                  |
+      | Advanced permissions | Advanced permissions | delete                | delete                | read, delete                        |
+      | Advanced permissions | Advanced permissions | update                | update                | read, update                        |
+      | Advanced permissions | Advanced permissions | create                | create, update        | read, create, update                |
+      | Advanced permissions | Advanced permissions | share, delete         | share, delete         | read, share, delete                 |
+      | Advanced permissions | Advanced permissions | share, update         | share, update         | read, update, share                 |
+      | Advanced permissions | Advanced permissions | share, create         | share, create, update | read, share, create, update         |
+      | Advanced permissions | Advanced permissions | delete, update        | delete, update        | read, delete, update                |
+      | Advanced permissions | Editor               | delete, create        |                       | read, delete, create, update        |
+      | Advanced permissions | Advanced permissions | update, create        | update, create        | read, update, create                |
+      | Advanced permissions | Advanced permissions | share, delete, update | share, delete, update | read, share, delete, update         |
+      | Advanced permissions | Editor               | share, create, delete | share                 | read, share, delete, create, update |
+      | Advanced permissions | Advanced permissions | share, update, create | share, update, create | read, share, update, create         |

--- a/tests/acceptance/features/webUISharingFolderPermissionMultipleUsers/shareFolderWithMultipleUsers.feature
+++ b/tests/acceptance/features/webUISharingFolderPermissionMultipleUsers/shareFolderWithMultipleUsers.feature
@@ -1,4 +1,3 @@
-@skipOnOCIS @issue-product-203
 Feature: Sharing folders with multiple internal users with different permissions
   As a user
   I want to set different permissions on shared folders with other users
@@ -12,6 +11,7 @@ Feature: Sharing folders with multiple internal users with different permissions
       | user1    |
       | user2    |
 
+  @skipOnOCIS @issue-product-203
   Scenario Outline: share a folder with multiple users with different roles and permissions
     Given these users have been created with default attributes:
       | username |
@@ -50,6 +50,61 @@ Feature: Sharing folders with multiple internal users with different permissions
       | file_target | /Shares/simple-folder |
       | item_type   | folder                |
       | permissions | <actual-permissions>  |
+    But user "Regular User" should not be listed in the collaborators list on the webUI
+    And as "user0" folder "simple-folder (2)" should not exist
+    And user "User Four" should not be listed in the collaborators list on the webUI
+    And as "user4" folder "simple-folder (2)" should not exist
+    Examples:
+      | role                 | displayed-role          | extra-permissions             | displayed-permissions | actual-permissions           |
+      | Viewer               | Viewer                  | share                         | share                 | read, share                  |
+      | Viewer               | Viewer                  | ,                             | ,                     | read                         |
+      | Editor               | Editor                  | share                         | share                 | all                          |
+      | Editor               | Editor                  | ,                             | ,                     | read, update, delete, create |
+      | Advanced permissions | Viewer                  | ,                             | ,                     | read                         |
+      | Advanced permissions | Viewer                  | share                         | share                 | read, share                  |
+      | Advanced permissions | Editor                  | delete, update, create        | ,                     | read, delete, update, create |
+      | Advanced permissions | Editor                  | share, delete, update, create | share                 | all                          |
+
+  @skipOnOC10 @issue-product-203
+  #after fixing the issue delete this scenario and use the one above by deleting the @skipOnOCIS tag there
+  Scenario Outline: share a folder with multiple users with different roles and permissions
+    Given these users have been created with default attributes:
+      | username |
+      | user0    |
+      | user3    |
+      | user4    |
+    And user "user1" has logged in using the webUI
+    When the user opens the share dialog for folder "simple-folder" using the webUI
+    And the user opens the share creation dialog in the webUI
+    And the user selects the following collaborators for the share as "<role>" with "<extra-permissions>" permissions:
+      | collaborator | type |
+      | Regular User | user |
+      | User Two     | user |
+      | User Three   | user |
+      | User Four    | user |
+    And the user removes "User Four" as a collaborator from the share
+    And the user removes "Regular User" as a collaborator from the share
+    And the user shares with the selected collaborators
+    And user "user2" accepts the share "simple-folder" offered by user "user1" using the sharing API
+    And user "user3" accepts the share "simple-folder" offered by user "user1" using the sharing API
+    Then custom permissions "<displayed-permissions>" should be set for user "User Two" for folder "simple-folder" on the webUI
+    And custom permissions "<displayed-permissions>" should be set for user "User Three" for folder "simple-folder" on the webUI
+    And user "User Two" should be listed as "<displayed-role>" in the collaborators list for folder "simple-folder" on the webUI
+    And user "User Three" should be listed as "<displayed-role>" in the collaborators list for folder "simple-folder" on the webUI
+    And user "user2" should have received a share with these details:
+      | field       | value                |
+      | uid_owner   | user1                |
+      | share_with  | user2                |
+      | file_target | /simple-folder       |
+      | item_type   | folder               |
+      | permissions | <actual-permissions> |
+    And user "user3" should have received a share with these details:
+      | field       | value                |
+      | uid_owner   | user1                |
+      | share_with  | user3                |
+      | file_target | /simple-folder       |
+      | item_type   | folder               |
+      | permissions | <actual-permissions> |
     But user "Regular User" should not be listed in the collaborators list on the webUI
     And as "user0" folder "simple-folder (2)" should not exist
     And user "User Four" should not be listed in the collaborators list on the webUI


### PR DESCRIPTION
## Description
1. make multiuser / sharing permission tests demonstrate and work despite owncloud/product#203 & owncloud/ocis#717
2. enable sharing permission suites to run in CI (

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
part of owncloud/ocis#518

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
1. make tests work to avoid further regressions
2. have tests that demonstrate the current behaviour
3. even some suites don't have any actual tests, we will not forget them to add to drone when tests are enabled


## How Has This Been Tested?
:robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...