### PR TITLE
[tests-only] add tests demonstrating issue-product-203 in shareWithUsers scenarios

### DIFF
--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -126,30 +126,29 @@ Feature: Sharing files and folders with internal users
 
   Scenario: share a folder with another internal user who uploads, overwrites and deletes files
     Given user "user2" has logged in using the webUI
-    When the user renames folder "simple-folder" to "new-simple-folder" using the webUI
-    And the user shares folder "new-simple-folder" with user "User One" as "Editor" using the webUI
-    And user "user1" accepts the share "new-simple-folder" offered by user "user2" using the sharing API
+    When the user shares folder "simple-folder" with user "User One" as "Editor" using the webUI
+    And user "user1" accepts the share "simple-folder" offered by user "user2" using the sharing API
     And the user re-logs in as "user1" using the webUI
     And the user browses to the folder "Shares" on the files page
-    And the user opens folder "new-simple-folder" using the webUI
-    Then as "user1" the content of "Shares/new-simple-folder/lorem.txt" should not be the same as the local "lorem.txt"
+    And the user opens folder "simple-folder" using the webUI
+    Then as "user1" the content of "Shares/simple-folder/lorem.txt" should not be the same as the local "lorem.txt"
     # overwrite an existing file in the received share
     When the user uploads overwriting file "lorem.txt" using the webUI
     Then file "lorem.txt" should be listed on the webUI
-    And as "user1" the content of "Shares/new-simple-folder/lorem.txt" should be the same as the local "lorem.txt"
+    And as "user1" the content of "Shares/simple-folder/lorem.txt" should be the same as the local "lorem.txt"
     # upload a new file into the received share
     When the user uploads file "new-lorem.txt" using the webUI
-    Then as "user1" the content of "Shares/new-simple-folder/new-lorem.txt" should be the same as the local "new-lorem.txt"
+    Then as "user1" the content of "Shares/simple-folder/new-lorem.txt" should be the same as the local "new-lorem.txt"
     # delete a file in the received share
     When the user deletes file "data.zip" using the webUI
     Then file "data.zip" should not be listed on the webUI
     # check that the file actions by the sharee are visible for the share owner
     When the user re-logs in as "user2" using the webUI
-    And the user opens folder "new-simple-folder" using the webUI
+    And the user opens folder "simple-folder" using the webUI
     Then file "lorem.txt" should be listed on the webUI
-    And as "user2" the content of "new-simple-folder/lorem.txt" should be the same as the local "lorem.txt"
+    And as "user2" the content of "simple-folder/lorem.txt" should be the same as the local "lorem.txt"
     And file "new-lorem.txt" should be listed on the webUI
-    And as "user2" the content of "new-simple-folder/new-lorem.txt" should be the same as the local "new-lorem.txt"
+    And as "user2" the content of "simple-folder/new-lorem.txt" should be the same as the local "new-lorem.txt"
     But file "data.zip" should not be listed on the webUI
 
   @skip @issue-4102

--- a/tests/acceptance/stepDefinitions/provisioningContext.js
+++ b/tests/acceptance/stepDefinitions/provisioningContext.js
@@ -237,7 +237,7 @@ After(async function() {
       })
     })
     await Promise.all(deleteSharePromises).catch(err => {
-      console.log('Error while deleting: ', err)
+      console.log('Error while deleting shares after test: ', err)
     })
   }
   if (client.globals.ldap) {


### PR DESCRIPTION
## Description
1. make sharing with user tests demonstrate and work despite owncloud/product#203
1. adjust one test, so it does not fail because of https://github.com/owncloud/ocis/issues/719 (in that test the renaming is not essential to the test, and the test does not check the renaming)
1. small improvement is error output

## Related Issue
part of owncloud/ocis#518

## Motivation and Context
1. make tests work to avoid further regressions
2. have tests that demonstrate the current behaviour

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...