### PR TITLE
Attach share permission to roles

### DIFF
--- a/apps/files/src/components/Collaborators/CollaboratorsEditOptions.vue
+++ b/apps/files/src/components/Collaborators/CollaboratorsEditOptions.vue
@@ -6,14 +6,16 @@
       :selected-role="role"
       @roleSelected="selectRole"
     />
-    <label v-if="$_ocCollaborators_hasAdditionalPermissions" class="oc-label">
-      <translate>Additional permissions:</translate>
-    </label>
-    <additional-permissions
-      :available-permissions="role.additionalPermissions"
-      :collaborators-permissions="collaboratorsPermissions"
-      @permissionChecked="checkAdditionalPermissions"
-    />
+    <template v-if="$_ocCollaborators_hasAdditionalPermissions">
+      <label v-if="selectedRole.name !== 'advnacedRole'" class="oc-label">
+        <translate>Additional permissions:</translate>
+      </label>
+      <additional-permissions
+        :available-permissions="role.additionalPermissions"
+        :collaborators-permissions="collaboratorsPermissions"
+        @permissionChecked="checkAdditionalPermissions"
+      />
+    </template>
     <div v-if="expirationSupported">
       <label for="files-collaborators-collaborator-expiration-input">
         <translate>Expiration date:</translate>
@@ -106,7 +108,7 @@ export default {
     },
 
     $_ocCollaborators_hasAdditionalPermissions() {
-      if (this.selectedRole && this.selectedRole.name !== 'advancedRole') {
+      if (this.selectedRole && this.selectedRole.additionalPermissions) {
         return Object.keys(this.selectedRole.additionalPermissions).length > 0
       }
       return false

--- a/apps/files/src/components/Collaborators/CollaboratorsEditOptions.vue
+++ b/apps/files/src/components/Collaborators/CollaboratorsEditOptions.vue
@@ -7,7 +7,7 @@
       @roleSelected="selectRole"
     />
     <template v-if="$_ocCollaborators_hasAdditionalPermissions">
-      <label v-if="selectedRole.name !== 'advnacedRole'" class="oc-label">
+      <label v-if="selectedRole.name !== 'advancedRole'" class="oc-label">
         <translate>Additional permissions:</translate>
       </label>
       <additional-permissions
@@ -108,10 +108,7 @@ export default {
     },
 
     $_ocCollaborators_hasAdditionalPermissions() {
-      if (this.selectedRole && this.selectedRole.additionalPermissions) {
-        return Object.keys(this.selectedRole.additionalPermissions).length > 0
-      }
-      return false
+      return this.selectedRole && this.selectedRole.additionalPermissions
     },
 
     role() {

--- a/apps/files/src/components/Collaborators/EditCollaborator.vue
+++ b/apps/files/src/components/Collaborators/EditCollaborator.vue
@@ -95,7 +95,7 @@ export default {
   },
   computed: {
     ...mapGetters('Files', ['highlightedFile']),
-    ...mapGetters(['user']),
+    ...mapGetters(['user', 'isOcis']),
 
     collaboratorType() {
       const collaboratorShareType = this.collaborator.shareType
@@ -177,11 +177,7 @@ export default {
         client: this.$client,
         share: this.collaborator,
         // Map bitmask to role to get the correct role in case the advanced role was mapped to existing role
-        role: bitmaskToRole(
-          bitmask,
-          this.highlightedFile.type === 'folder',
-          this.user.version.edition !== 'reva'
-        ),
+        role: bitmaskToRole(bitmask, this.highlightedFile.type === 'folder', !this.isOcis),
         permissions: bitmask,
         expirationDate: this.expirationDate
       })

--- a/apps/files/src/components/Collaborators/EditCollaborator.vue
+++ b/apps/files/src/components/Collaborators/EditCollaborator.vue
@@ -177,7 +177,11 @@ export default {
         client: this.$client,
         share: this.collaborator,
         // Map bitmask to role to get the correct role in case the advanced role was mapped to existing role
-        role: bitmaskToRole(bitmask, this.highlightedFile.type === 'folder'),
+        role: bitmaskToRole(
+          bitmask,
+          this.highlightedFile.type === 'folder',
+          this.user.version.edition !== 'reva'
+        ),
         permissions: bitmask,
         expirationDate: this.expirationDate
       })

--- a/apps/files/src/components/FileSharingSidebar.vue
+++ b/apps/files/src/components/FileSharingSidebar.vue
@@ -133,6 +133,7 @@ export default {
       'currentFileOutgoingSharesLoading',
       'sharesTreeLoading'
     ]),
+    ...mapGetters(['isOcis']),
     ...mapState('Files', [
       'incomingShares',
       'incomingSharesLoading',
@@ -174,7 +175,7 @@ export default {
       let role = { name: '' }
 
       if (permissions > 0) {
-        role = bitmaskToRole(permissions, isFolder, this.user.version.edition !== 'reva')
+        role = bitmaskToRole(permissions, isFolder, !this.isOcis)
       } else {
         role.name = 'owner'
       }

--- a/apps/files/src/components/FileSharingSidebar.vue
+++ b/apps/files/src/components/FileSharingSidebar.vue
@@ -174,7 +174,7 @@ export default {
       let role = { name: '' }
 
       if (permissions > 0) {
-        role = bitmaskToRole(permissions, isFolder)
+        role = bitmaskToRole(permissions, isFolder, this.user.version.edition !== 'reva')
       } else {
         role.name = 'owner'
       }

--- a/apps/files/src/helpers/collaboratorRolesDefinition.js
+++ b/apps/files/src/helpers/collaboratorRolesDefinition.js
@@ -8,34 +8,29 @@ function returnOriginal(string) {
  * Returns object with collaborator roles
  * @param {boolean} isFolder  Defines if the item is folder
  * @param {function} $gettext  Function to translate neccessary strings
+ * @param {boolean} allowSharePerm Asserts whether share permission is allowed
  * @returns {object}  Collaborator roles
  */
-export default ({ isFolder = false, $gettext = returnOriginal }) => {
+export default ({ isFolder = false, $gettext = returnOriginal, allowSharePerm = false }) => {
   if (isFolder) {
     return {
       viewer: {
         name: 'viewer',
         label: $gettext('Viewer'),
-        description: $gettext('Download and preview'),
-        permissions: ['read'],
-        additionalPermissions: {
-          share: {
-            name: 'share',
-            description: $gettext('Allow re-Sharing')
-          }
-        }
+        description: allowSharePerm
+          ? $gettext('Download, preview and share')
+          : $gettext('Download and preview'),
+        permissions: allowSharePerm ? ['read', 'share'] : ['read']
       },
       editor: {
         name: 'editor',
         label: $gettext('Editor'),
-        description: $gettext('Upload, edit, delete, download and preview'),
-        permissions: ['read', 'update', 'create', 'delete'],
-        additionalPermissions: {
-          share: {
-            name: 'share',
-            description: $gettext('Allow re-Sharing')
-          }
-        }
+        description: allowSharePerm
+          ? $gettext('Upload, edit, delete, download, preview and share')
+          : $gettext('Upload, edit, delete, download and preview'),
+        permissions: allowSharePerm
+          ? ['read', 'update', 'create', 'delete', 'share']
+          : ['read', 'update', 'create', 'delete']
       }
     }
   }
@@ -44,26 +39,18 @@ export default ({ isFolder = false, $gettext = returnOriginal }) => {
     viewer: {
       name: 'viewer',
       label: $gettext('Viewer'),
-      description: $gettext('Download and preview'),
-      permissions: ['read'],
-      additionalPermissions: {
-        share: {
-          name: 'share',
-          description: $gettext('Allow re-Sharing')
-        }
-      }
+      description: allowSharePerm
+        ? $gettext('Download, preview and share')
+        : $gettext('Download and preview'),
+      permissions: allowSharePerm ? ['read', 'share'] : ['read']
     },
     editor: {
       name: 'editor',
       label: $gettext('Editor'),
-      description: $gettext('Edit, download and preview'),
-      permissions: ['read', 'update'],
-      additionalPermissions: {
-        share: {
-          name: 'share',
-          description: $gettext('Allow re-Sharing')
-        }
-      }
+      description: allowSharePerm
+        ? $gettext('Edit, download, preview and share')
+        : $gettext('Edit, download and preview'),
+      permissions: allowSharePerm ? ['read', 'update', 'share'] : ['read', 'update']
     }
   }
 }

--- a/apps/files/src/helpers/collaborators.js
+++ b/apps/files/src/helpers/collaborators.js
@@ -42,10 +42,10 @@ export function roleToBitmask(role, additionalPermissions = []) {
  * @param {boolean} isFolder Defines if the item is folder
  * @returns {object} Role mapped to the bitmask
  */
-export function bitmaskToRole(bitmask, isFolder) {
+export function bitmaskToRole(bitmask, isFolder, allowSharePerm) {
   // TODO: inject the result of "roles()" in the function header and have the caller of bitmaskToRole call roles() with appropriate arguments including translation
   // Not passing in translation as we don't need it
-  const currentRoles = roles({ isFolder: isFolder })
+  const currentRoles = roles({ isFolder: isFolder, allowSharePerm })
   bitmask = parseInt(bitmask, 10)
 
   for (const role in currentRoles) {

--- a/apps/files/src/helpers/collaborators.js
+++ b/apps/files/src/helpers/collaborators.js
@@ -40,6 +40,7 @@ export function roleToBitmask(role, additionalPermissions = []) {
  * Maps bitmask to role
  * @param {number} bitmask Permissions which are to be mapped to role
  * @param {boolean} isFolder Defines if the item is folder
+ * @param {boolean} allowSharePerm Asserts if the share permission is allowed
  * @returns {object} Role mapped to the bitmask
  */
 export function bitmaskToRole(bitmask, isFolder, allowSharePerm) {

--- a/apps/files/src/helpers/collaborators.js
+++ b/apps/files/src/helpers/collaborators.js
@@ -27,11 +27,13 @@ export function roleToBitmask(role, additionalPermissions = []) {
 
   if (additionalPermissions) {
     for (const additionalPermission of additionalPermissions) {
-      if (role.additionalPermissions[additionalPermission]) {
+      if (role.additionalPermissions && role.additionalPermissions[additionalPermission]) {
         bitmask |= permissionsBitmask[additionalPermission]
       }
     }
   }
+
+  console.log(bitmask)
 
   return bitmask
 }

--- a/apps/files/src/mixins/collaborators.js
+++ b/apps/files/src/mixins/collaborators.js
@@ -3,7 +3,7 @@ import roles from '../helpers/collaboratorRolesDefinition'
 
 export default {
   computed: {
-    ...mapGetters(['getToken']),
+    ...mapGetters(['getToken', 'user']),
     ...mapGetters('Files', ['highlightedFile']),
 
     ownerRole() {
@@ -29,7 +29,7 @@ export default {
         additionalPermissions: {
           share: {
             name: 'share',
-            description: this.$gettext('Allow re-Sharing')
+            description: this.$gettext('Allow sharing')
           },
           update: {
             name: 'update',
@@ -56,7 +56,11 @@ export default {
     roles() {
       const isFolder = this.highlightedFile.type === 'folder'
       const $gettext = this.$gettext
-      const collaboratorRoles = roles({ $gettext, isFolder: isFolder })
+      const collaboratorRoles = roles({
+        $gettext,
+        isFolder: isFolder,
+        allowSharePerm: this.user.version.edition !== 'reva'
+      })
       collaboratorRoles.advancedRole = this.advancedRole
 
       return collaboratorRoles

--- a/apps/files/src/mixins/collaborators.js
+++ b/apps/files/src/mixins/collaborators.js
@@ -3,7 +3,7 @@ import roles from '../helpers/collaboratorRolesDefinition'
 
 export default {
   computed: {
-    ...mapGetters(['getToken', 'user']),
+    ...mapGetters(['getToken', 'user', 'isOcis']),
     ...mapGetters('Files', ['highlightedFile']),
 
     ownerRole() {
@@ -46,7 +46,7 @@ export default {
         }
       }
 
-      if (this.user.version.edition !== 'reva') {
+      if (!this.isOcis) {
         advancedRole.additionalPermissions.share = {
           name: 'share',
           description: this.$gettext('Allow sharing')
@@ -62,7 +62,7 @@ export default {
       const collaboratorRoles = roles({
         $gettext,
         isFolder: isFolder,
-        allowSharePerm: this.user.version.edition !== 'reva'
+        allowSharePerm: !this.isOcis
       })
       collaboratorRoles.advancedRole = this.advancedRole
 

--- a/apps/files/src/mixins/collaborators.js
+++ b/apps/files/src/mixins/collaborators.js
@@ -27,10 +27,6 @@ export default {
         description: this.$gettext('Set detailed permissions'),
         permissions: ['read'],
         additionalPermissions: {
-          share: {
-            name: 'share',
-            description: this.$gettext('Allow sharing')
-          },
           update: {
             name: 'update',
             description: this.$gettext('Allow editing')
@@ -47,6 +43,13 @@ export default {
         permissions.delete = {
           name: 'delete',
           description: this.$gettext('Allow deleting')
+        }
+      }
+
+      if (this.user.version.edition !== 'reva') {
+        advancedRole.additionalPermissions.share = {
+          name: 'share',
+          description: this.$gettext('Allow sharing')
         }
       }
 

--- a/apps/files/src/store/actions.js
+++ b/apps/files/src/store/actions.js
@@ -496,11 +496,7 @@ export default {
           }
 
           const files = json.ocs.data
-          const uniqueFiles = _aggregateFileShares(
-            files,
-            false,
-            context.rootGetters.user.version.edition !== 'reva'
-          )
+          const uniqueFiles = _aggregateFileShares(files, false, !context.rootGetters.isOcis)
           context.dispatch('buildFilesSharedFromMe', uniqueFiles)
           context.commit('UPDATE_FOLDER_LOADING', false)
         })
@@ -540,11 +536,7 @@ export default {
             return
           }
           const files = json.ocs.data
-          const uniqueFiles = _aggregateFileShares(
-            files,
-            true,
-            context.rootGetters.user.version.edition !== 'reva'
-          )
+          const uniqueFiles = _aggregateFileShares(files, true, !context.rootGetters.isOcis)
           context.dispatch('buildFilesSharedFromMe', uniqueFiles)
           context.commit('UPDATE_FOLDER_LOADING', false)
         })
@@ -738,7 +730,7 @@ export default {
               element.shareInfo,
               context.getters.highlightedFile,
               $gettext,
-              context.rootGetters.user.version.edition !== 'reva'
+              !context.rootGetters.isOcis
             )
           })
         )
@@ -767,7 +759,7 @@ export default {
             return _buildCollaboratorShare(
               element.shareInfo,
               context.getters.highlightedFile,
-              context.rootGetters.user.version.edition !== 'reva'
+              !context.rootGetters.isOcis
             )
           })
         )
@@ -808,7 +800,7 @@ export default {
           const share = _buildCollaboratorShare(
             updatedShare.shareInfo,
             getters.highlightedFile,
-            rootGetters.user.version.edition !== 'reva'
+            !rootGetters.isOcis
           )
           commit('CURRENT_FILE_OUTGOING_SHARES_UPDATE', share)
           resolve(share)
@@ -831,7 +823,7 @@ export default {
             _buildCollaboratorShare(
               share.shareInfo,
               context.getters.highlightedFile,
-              context.rootGetters.user.version.edition !== 'reva'
+              !context.rootGetters.isOcis
             )
           )
           context.commit('UPDATE_CURRENT_FILE_SHARE_TYPES')
@@ -866,7 +858,7 @@ export default {
           _buildCollaboratorShare(
             share.shareInfo,
             context.getters.highlightedFile,
-            context.rootGetters.user.version.edition !== 'reva'
+            !context.rootGetters.isOcis
           )
         )
         context.commit('UPDATE_CURRENT_FILE_SHARE_TYPES')
@@ -950,7 +942,7 @@ export default {
                     element.shareInfo,
                     { type: 'folder' },
                     $gettext,
-                    context.rootGetters.user.version.edition !== 'reva'
+                    !context.rootGetters.isOcis
                   ),
                   outgoing: true,
                   indirect: true
@@ -975,7 +967,7 @@ export default {
                   ..._buildCollaboratorShare(
                     element.shareInfo,
                     { type: 'folder' },
-                    context.rootGetters.user.version.edition !== 'reva'
+                    !context.rootGetters.isOcis
                   ),
                   incoming: true,
                   indirect: true
@@ -1011,12 +1003,7 @@ export default {
       client.shares
         .shareFileWithLink(path, params)
         .then(data => {
-          const link = _buildShare(
-            data.shareInfo,
-            null,
-            $gettext,
-            context.rootGetters.user.version.edition !== 'reva'
-          )
+          const link = _buildShare(data.shareInfo, null, $gettext, !context.rootGetters.isOcis)
           context.commit('CURRENT_FILE_OUTGOING_SHARES_ADD', link)
           context.commit('UPDATE_CURRENT_FILE_SHARE_TYPES')
           resolve(link)
@@ -1031,12 +1018,7 @@ export default {
       client.shares
         .updateShare(id, params)
         .then(data => {
-          const link = _buildShare(
-            data.shareInfo,
-            null,
-            $gettext,
-            context.rootGetters.user.version.edition !== 'reva'
-          )
+          const link = _buildShare(data.shareInfo, null, $gettext, !context.rootGetters.isOcis)
           context.commit('CURRENT_FILE_OUTGOING_SHARES_UPDATE', link)
           resolve(link)
         })

--- a/changelog/unreleased/share-permission
+++ b/changelog/unreleased/share-permission
@@ -1,0 +1,5 @@
+Change: Attach share permission to roles
+
+We've attached the share permission of collaborators to roles. There is no longer a share additional permission.
+
+https://github.com/owncloud/phoenix/pull/4216

--- a/src/pages/account.vue
+++ b/src/pages/account.vue
@@ -61,9 +61,9 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(['user', 'configuration', 'getNavItemsByExtension']),
+    ...mapGetters(['user', 'configuration', 'getNavItemsByExtension', 'isOcis']),
     editUrl() {
-      if (this.user.version.edition === 'reva') {
+      if (this.isOcis) {
         return null
       }
       return this.configuration.server.replace(/\/$/, '') + '/index.php/settings/personal'

--- a/src/store/app.js
+++ b/src/store/app.js
@@ -111,7 +111,8 @@ const getters = {
     return state.notifications.data.length && !state.notifications.failed
       ? state.notifications.data
       : false
-  }
+  },
+  isOcis: (state, getters, rootState) => rootState.user.version.edition === 'reva'
 }
 
 export default {

--- a/tests/acceptance/features/webUIResharing/reshareUsers.feature
+++ b/tests/acceptance/features/webUIResharing/reshareUsers.feature
@@ -19,7 +19,7 @@ Feature: Resharing shared files with different permissions
     And user "user3" has accepted the share "simple-folder" offered by user "user1"
     And user "user2" has logged in using the webUI
     When the user opens the share dialog for folder "simple-folder" using the webUI
-    Then user "User Three" should be listed as "Viewer" in the collaborators list for folder "simple-folder" on the webUI
+    Then user "User Three" should be listed as "Advanced permissions" in the collaborators list for folder "simple-folder" on the webUI
     And no custom permissions should be set for collaborator "User Three" for folder "simple-folder" on the webUI
 
   Scenario: Reshare a folder without share permissions using API and check if it is listed on the collaborators list for resharer
@@ -30,7 +30,7 @@ Feature: Resharing shared files with different permissions
     And user "user1" has logged in using the webUI
     And the user opens folder "Shares" using the webUI
     When the user opens the share dialog for folder "simple-folder" using the webUI
-    Then user "User Three" should be listed as "Viewer" in the collaborators list for folder "simple-folder" on the webUI
+    Then user "User Three" should be listed as "Advanced permissions" in the collaborators list for folder "simple-folder" on the webUI
     And no custom permissions should be set for collaborator "User Three" for folder "simple-folder" on the webUI
 
   @skipOnOCIS @issue-product-270
@@ -62,11 +62,11 @@ Feature: Resharing shared files with different permissions
       | permissions | <permissions>         |
     Examples:
     | role                 | displayed-role          | collaborators-permissions     | displayed-permissions | permissions                         |
-    | Viewer               | Viewer                  | share                         | share                 | read, share                         |
-    | Editor               | Editor                  | share                         | share                 | all                                 |
+    | Viewer               | Viewer                  | ,                             | ,                     | read, share                         |
+    | Editor               | Editor                  | ,                             | ,                     | all                                 |
     | Advanced permissions | Advanced permissions    | share, create                 | share, create         | read, share, create                 |
     | Advanced permissions | Advanced permissions    | update, share                 | share, update         | read, update, share                 |
-    | Advanced permissions | Editor                  | delete, share, create, update | share                 | read, share, delete, update, create |
+    | Advanced permissions | Editor                  | delete, share, create, update |                       | read, share, delete, update, create |
 
   @skipOnOC10 @issue-product-203
   #after fixing the issue delete this scenario and use the one above by deleting the @skipOnOCIS tag there
@@ -87,12 +87,12 @@ Feature: Resharing shared files with different permissions
       | item_type   | folder         |
       | permissions | <permissions>  |
     Examples:
-      | role                 | displayed-role       | collaborators-permissions     | displayed-permissions | permissions                         |
-      | Viewer               | Viewer               | share                         | share                 | read, share                         |
-      | Editor               | Editor               | share                         | share                 | all                                 |
-      | Advanced permissions | Advanced permissions | share, create                 | share, create, update | read, share, create, update         |
-      | Advanced permissions | Advanced permissions | update, share                 | share, update         | read, update, share                 |
-      | Advanced permissions | Editor               | delete, share, create, update | share                 | read, share, delete, update, create |
+      | role                 | displayed-role       | collaborators-permissions | displayed-permissions | permissions                  |
+      | Viewer               | Viewer               | ,                         | ,                     | read                         |
+      | Editor               | Editor               | ,                         | ,                     | all                          |
+      | Advanced permissions | Advanced permissions | create                    | create                | read, create                 |
+      | Advanced permissions | Advanced permissions | update                    | update                | read, update                 |
+      | Advanced permissions | Editor               | delete, create, update    |                       | read, delete, update, create |
 
   @skipOnOCIS @issue-product-203 @issue-4193
   Scenario Outline: share a received folder with another user with same permissions(including share permissions) and check if the user is displayed in collaborators list for original owner
@@ -123,11 +123,11 @@ Feature: Resharing shared files with different permissions
       | permissions | <permissions>         |
     Examples:
     | role                 | displayed-role          | collaborators-permissions     | displayed-permissions | permissions                         |
-    | Viewer               | Viewer                  | share                         | share                 | read, share                         |
-    | Editor               | Editor                  | share                         | share                 | all                                 |
+    | Viewer               | Viewer                  | ,                             | ,                     | read, share                         |
+    | Editor               | Editor                  | ,                             | ,                     | all                                 |
     | Advanced permissions | Advanced permissions    | share, create                 | share, create         | read, share, create                 |
     | Advanced permissions | Advanced permissions    | update, share                 | share, update         | read, update, share                 |
-    | Advanced permissions | Editor                  | delete, share, create, update | share                 | read, share, delete, update, create |
+    | Advanced permissions | Editor                  | delete, share, create, update | ,                     | read, share, delete, update, create |
 
   @skipOnOC10 @issue-product-203 @issue-ocis-717
   #after fixing the issue delete this scenario and use the one above by deleting the @skipOnOCIS tag there
@@ -158,12 +158,12 @@ Feature: Resharing shared files with different permissions
       | item_type   | folder         |
       | permissions | <permissions>  |
     Examples:
-      | role                 | displayed-role       | collaborators-permissions     | displayed-permissions | permissions                         |
-      | Viewer               | Viewer               | share                         | share                 | read, share                         |
-      | Editor               | Editor               | share                         | share                 | all                                 |
-      | Advanced permissions | Advanced permissions | share, create                 | share, update, create | read, share, create, update         |
-      | Advanced permissions | Advanced permissions | update, share                 | share, update         | read, update, share                 |
-      | Advanced permissions | Editor               | delete, share, create, update | share                 | read, share, delete, update, create |
+      | role                 | displayed-role       | collaborators-permissions | displayed-permissions | permissions                  |
+      | Viewer               | Viewer               | ,                         | ,                     | read                         |
+      | Editor               | Editor               | ,                         | ,                     | all                          |
+      | Advanced permissions | Advanced permissions | create                    | create                | read, create                 |
+      | Advanced permissions | Advanced permissions | update                    | update                | read, update                 |
+      | Advanced permissions | Editor               | delete, create, update    | ,                     | read, delete, update, create |
 
   @skipOnOCIS @issue-product-203 @issue-4193
   Scenario: share a folder with another user with share permissions and reshare without share permissions to different user, and check if user is displayed for original sharer
@@ -177,7 +177,6 @@ Feature: Resharing shared files with different permissions
     Then user "User Three" should be listed as "Viewer" in the collaborators list for folder "simple-folder" on the webUI
     And no custom permissions should be set for collaborator "User Three" for folder "simple-folder" on the webUI
     And user "User One" should be listed as "Viewer" in the collaborators list for folder "simple-folder" on the webUI
-    And custom permissions "share" should be set for user "User One" for folder "simple-folder" on the webUI
     And user "user1" should have received a share with these details:
       | field       | value                 |
       | uid_owner   | user2                 |
@@ -191,7 +190,7 @@ Feature: Resharing shared files with different permissions
       | share_with  | user3                 |
       | file_target | /Shares/simple-folder |
       | item_type   | folder                |
-      | permissions | read                  |
+      | permissions | read, share           |
 
   @skipOnOC10 @issue-product-203
   #after fixing the issue delete this scenario and use the one above by deleting the @skipOnOCIS tag there
@@ -236,7 +235,7 @@ Feature: Resharing shared files with different permissions
       | share_with  | user3                 |
       | file_target | /Shares/simple-folder |
       | item_type   | folder                |
-      | permissions | read                  |
+      | permissions | read, share           |
 
   @skipOnOC10 @issue-product-203
   #after fixing the issue delete this scenario and use the one above by deleting the @skipOnOCIS tag there

--- a/tests/acceptance/features/webUIResharing/reshareUsers.feature
+++ b/tests/acceptance/features/webUIResharing/reshareUsers.feature
@@ -1,3 +1,5 @@
+# Reshare permission is not available now in the oCIS webUI
+@skipOnOCIS
 Feature: Resharing shared files with different permissions
   As a user
   I want to reshare received files and folders with other users with different permissions

--- a/tests/acceptance/features/webUIResharingToRoot/reshareUsers.feature
+++ b/tests/acceptance/features/webUIResharingToRoot/reshareUsers.feature
@@ -16,7 +16,7 @@ Feature: Resharing shared files with different permissions
       And user "user1" has shared folder "simple-folder (2)" with user "user3" with "read" permissions
       And user "user2" has logged in using the webUI
       When the user opens the share dialog for folder "simple-folder" using the webUI
-      Then user "User Three" should be listed as "Viewer" in the collaborators list for folder "simple-folder" on the webUI
+      Then user "User Three" should be listed as "Advanced permissions" in the collaborators list for folder "simple-folder" on the webUI
       And no custom permissions should be set for collaborator "User Three" for folder "simple-folder" on the webUI
 
   Scenario: Reshare a folder without share permissions using API and check if it is listed on the collaborators list for resharer
@@ -24,7 +24,7 @@ Feature: Resharing shared files with different permissions
       And user "user1" has shared folder "simple-folder (2)" with user "user3" with "read" permissions
       And user "user1" has logged in using the webUI
       When the user opens the share dialog for folder "simple-folder (2)" using the webUI
-      Then user "User Three" should be listed as "Viewer" in the collaborators list for folder "simple-folder (2)" on the webUI
+      Then user "User Three" should be listed as "Advanced permissions" in the collaborators list for folder "simple-folder (2)" on the webUI
       And no custom permissions should be set for collaborator "User Three" for folder "simple-folder (2)" on the webUI
 
   Scenario: Reshare a folder without share permissions using API and check if the receiver can reshare
@@ -48,11 +48,11 @@ Feature: Resharing shared files with different permissions
     | permissions | <permissions>      |
     Examples:
     | role                 | displayed-role          | collaborators-permissions     | displayed-permissions | permissions                         |
-    | Viewer               | Viewer                  | share                         | share                 | read, share                         |
-    | Editor               | Editor                  | share                         | share                 | all                                 |
+    | Viewer               | Viewer                  | ,                             | ,                     | read, share                         |
+    | Editor               | Editor                  | ,                             | ,                     | all                                 |
     | Advanced permissions | Advanced permissions    | share, create                 | share, create         | read, share, create                 |
     | Advanced permissions | Advanced permissions    | update, share                 | share, update         | read, update, share                 |
-    | Advanced permissions | Editor                  | delete, share, create, update | share                 | read, share, delete, update, create |
+    | Advanced permissions | Editor                  | delete, share, create, update | ,                     | read, share, delete, update, create |
 
   Scenario Outline: share a received folder with another user with same permissions(including share permissions) and check if the user is displayed in collaborators list for original owner
     Given user "user2" has shared folder "simple-folder" with user "user1" with "<permissions>" permissions
@@ -79,11 +79,11 @@ Feature: Resharing shared files with different permissions
     | permissions | <permissions>      |
     Examples:
     | role                 | displayed-role          | collaborators-permissions     | displayed-permissions | permissions                         |
-    | Viewer               | Viewer                  | share                         | share                 | read, share                         |
-    | Editor               | Editor                  | share                         | share                 | all                                 |
+    | Viewer               | Viewer                  | ,                             | ,                     | read, share                         |
+    | Editor               | Editor                  | ,                             | ,                     | all                                 |
     | Advanced permissions | Advanced permissions    | share, create                 | share, create         | read, share, create                 |
     | Advanced permissions | Advanced permissions    | update, share                 | share, update         | read, update, share                 |
-    | Advanced permissions | Editor                  | delete, share, create, update | share                 | read, share, delete, update, create |
+    | Advanced permissions | Editor                  | delete, share, create, update | ,                     | read, share, delete, update, create |
 
   Scenario: share a folder with another user with share permissions and reshare without share permissions to different user, and check if user is displayed for original sharer
     Given user "user2" has shared folder "simple-folder" with user "user1" with "read, share" permissions
@@ -93,7 +93,6 @@ Feature: Resharing shared files with different permissions
     Then user "User Three" should be listed as "Viewer" in the collaborators list for folder "simple-folder" on the webUI
     And no custom permissions should be set for collaborator "User Three" for folder "simple-folder" on the webUI
     And user "User One" should be listed as "Viewer" in the collaborators list for folder "simple-folder" on the webUI
-    And custom permissions "share" should be set for user "User One" for folder "simple-folder" on the webUI
     And user "user1" should have received a share with these details:
     | field       | value              |
     | uid_owner   | user2              |
@@ -107,7 +106,7 @@ Feature: Resharing shared files with different permissions
     | share_with  | user3              |
     | file_target | /simple-folder (2) |
     | item_type   | folder             |
-    | permissions | read               |
+    | permissions | read, share        |
 
   Scenario: share a folder with another user with share permissions and reshare without share permissions to different user, and check if user is displayed for the receiver
     Given user "user2" has shared folder "simple-folder" with user "user1" with "read, share" permissions
@@ -119,7 +118,7 @@ Feature: Resharing shared files with different permissions
     | share_with  | user3              |
     | file_target | /simple-folder (2) |
     | item_type   | folder             |
-    | permissions | read               |
+    | permissions | read, share        |
 
   Scenario Outline: share a file/folder without share permissions and check if another user can reshare
     Given user "user2" has shared folder "<shared-entry-name>" with user "user1" with "read" permissions

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -73,7 +73,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
       | uid_owner   | user1                      |
       | share_with  | user1@%remote_backend_url% |
       | item_type   | folder                     |
-      | permissions | read                       |
+      | permissions | read, share                |
     And as "user1" folder "Shares/simple-empty-folder" should exist on remote server
 
   @issue-3309
@@ -156,7 +156,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
       | uid_owner   | user1                      |
       | share_with  | user2                      |
       | item_type   | folder                     |
-      | permissions | read                       |
+      | permissions | read, share                |
 
   Scenario: test resharing a federated server to remote again
     Given user "user2" has been created with default attributes on remote server
@@ -171,7 +171,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
       | uid_owner   | user1                      |
       | share_with  | user2@%remote_backend_url% |
       | item_type   | folder                     |
-      | permissions | read                       |
+      | permissions | read, share                |
     And as "user2" folder "Shares/simple-folder" should exist on remote server
 
   Scenario: try resharing a folder with read-only permissions

--- a/tests/acceptance/features/webUISharingExternalToRoot/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternalToRoot/federationSharing.feature
@@ -78,7 +78,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
       | uid_owner   | user1                      |
       | share_with  | user1@%remote_backend_url% |
       | item_type   | folder                     |
-      | permissions | read                       |
+      | permissions | read, share                |
     And as "user1" folder "simple-empty-folder" should exist on remote server
 
   @issue-3309
@@ -157,7 +157,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
       | uid_owner   | user1                      |
       | share_with  | user2                      |
       | item_type   | folder                     |
-      | permissions | read                       |
+      | permissions | read, share                |
 
   Scenario: test resharing a federated server to remote again
     Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
@@ -170,7 +170,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
       | uid_owner   | user1                      |
       | share_with  | user2@%remote_backend_url% |
       | item_type   | folder                     |
-      | permissions | read                       |
+      | permissions | read, share                |
     And as "user2" folder "simple-folder (2)" should exist on remote server
 
   Scenario: try resharing a folder with read-only permissions

--- a/tests/acceptance/features/webUISharingFilePermissionMultipleUsers/shareFileWithMultipleUsers.feature
+++ b/tests/acceptance/features/webUISharingFilePermissionMultipleUsers/shareFileWithMultipleUsers.feature
@@ -108,8 +108,8 @@ Feature: Sharing files with multiple internal users with different permissions
     And user "User Four" should not be listed in the collaborators list on the webUI
     And as "user4" file "/Shares/lorem.txt" should not exist
     Examples:
-      | role                 | displayed-role       | extra-permissions | displayed-permissions | actual-permissions  |
-      | Viewer               | Viewer               | ,                 | ,                     | read                |
-      | Editor               | Editor               | ,                 | ,                     | read, update        |
-      | Advanced permissions | Viewer               | ,                 | ,                     | read                |
-      | Advanced permissions | Advanced permissions | update            | update                | read, update        |
+      | role                 | displayed-role | extra-permissions | displayed-permissions | actual-permissions  |
+      | Viewer               | Viewer         | ,                 | ,                     | read                |
+      | Editor               | Editor         | ,                 | ,                     | read, update        |
+      | Advanced permissions | Viewer         | ,                 | ,                     | read                |
+      | Advanced permissions | Editor         | update            | ,                     | read, update        |

--- a/tests/acceptance/features/webUISharingFilePermissionMultipleUsers/shareFileWithMultipleUsers.feature
+++ b/tests/acceptance/features/webUISharingFilePermissionMultipleUsers/shareFileWithMultipleUsers.feature
@@ -55,15 +55,13 @@ Feature: Sharing files with multiple internal users with different permissions
     And user "User Four" should not be listed in the collaborators list on the webUI
     And as "user4" file "/Shares/lorem.txt" should not exist
     Examples:
-      | role                 | displayed-role | extra-permissions | displayed-permissions | actual-permissions  |
-      | Viewer               | Viewer         | share             | share                 | read, share         |
-      | Viewer               | Viewer         | ,                 | ,                     | read                |
-      | Editor               | Editor         | share             | share                 | share, read, update |
-      | Editor               | Editor         | ,                 | ,                     | read, update        |
-      | Advanced permissions | Viewer         | ,                 | ,                     | read                |
-      | Advanced permissions | Viewer         | share             | share                 | read, share         |
-      | Advanced permissions | Editor         | update            | ,                     | read, update        |
-      | Advanced permissions | Editor         | share, update     | share                 | read, update, share |
+      | role                 | displayed-role               | extra-permissions | displayed-permissions | actual-permissions         |
+      | Viewer               | Viewer                       | ,                 | ,                     | read, share                |
+      | Editor               | Editor                       | ,                 | ,                     | read, update, share        |
+      | Advanced permissions | Advanced permissions         | ,                 | ,                     | read                       |
+      | Advanced permissions | Viewer                       | share             | ,                     | read, share                |
+      | Advanced permissions | Advanced permissions         | update            | update                | read, update               |
+      | Advanced permissions | Editor                       | share, update     | ,                     | read, update, share        |
 
   @skipOnOC10 @issue-product-203
   #after fixing the issue delete this scenario and use the one above by deleting the @skipOnOCIS tag there
@@ -110,12 +108,8 @@ Feature: Sharing files with multiple internal users with different permissions
     And user "User Four" should not be listed in the collaborators list on the webUI
     And as "user4" file "/Shares/lorem.txt" should not exist
     Examples:
-      | role                 | displayed-role | extra-permissions | displayed-permissions | actual-permissions  |
-      | Viewer               | Viewer         | share             | share                 | read, share         |
-      | Viewer               | Viewer         | ,                 | ,                     | read                |
-      | Editor               | Editor         | share             | share                 | share, read, update |
-      | Editor               | Editor         | ,                 | ,                     | read, update        |
-      | Advanced permissions | Viewer         | ,                 | ,                     | read                |
-      | Advanced permissions | Viewer         | share             | share                 | read, share         |
-      | Advanced permissions | Editor         | update            | ,                     | read, update        |
-      | Advanced permissions | Editor         | share, update     | share                 | read, update, share |
+      | role                 | displayed-role       | extra-permissions | displayed-permissions | actual-permissions  |
+      | Viewer               | Viewer               | ,                 | ,                     | read                |
+      | Editor               | Editor               | ,                 | ,                     | read, update        |
+      | Advanced permissions | Viewer               | ,                 | ,                     | read                |
+      | Advanced permissions | Advanced permissions | update            | update                | read, update        |

--- a/tests/acceptance/features/webUISharingFilePermissionsGroups/sharePermissionsGroup.feature
+++ b/tests/acceptance/features/webUISharingFilePermissionsGroups/sharePermissionsGroup.feature
@@ -55,12 +55,9 @@ Feature: Sharing files with internal groups with permissions
     But group "grp1" should not be listed in the collaborators list on the webUI
     And as "user1" file "/Shares/lorem.txt" should not exist
     Examples:
-    | role                 | displayed-role | extra-permissions | displayed-permissions | actual-permissions  |
-    | Viewer               | Viewer         | share             | share                 | read, share         |
-    | Viewer               | Viewer         | ,                 | ,                     | read                |
-    | Editor               | Editor         | share             | share                 | share, read, update |
-    | Editor               | Editor         | ,                 | ,                     | read, update        |
-    | Advanced permissions | Viewer         | ,                 | ,                     | read                |
-    | Advanced permissions | Viewer         | share             | share                 | read, share         |
-    | Advanced permissions | Editor         | update            | ,                     | read, update        |
-    | Advanced permissions | Editor         | share, update     | share                 | read, update, share |
+    | role                 | displayed-role               | extra-permissions | displayed-permissions | actual-permissions  |
+    | Viewer               | Viewer                       | ,                 | ,                     | read, share         |
+    | Editor               | Editor                       | ,                 | ,                     | share, read, update |
+    | Advanced permissions | Advanced permissions         | ,                 | ,                     | read                |
+    | Advanced permissions | Viewer                       | share             | ,                     | read, share         |
+    | Advanced permissions | Editor                       | share, update     | ,                     | read, update, share |

--- a/tests/acceptance/features/webUISharingFolderAdvancedPermissionMultipleUsers/sharedFolderWithMultipleUsersAdvancedPermissions.feature
+++ b/tests/acceptance/features/webUISharingFolderAdvancedPermissionMultipleUsers/sharedFolderWithMultipleUsersAdvancedPermissions.feature
@@ -117,7 +117,7 @@ Feature: Sharing folders with multiple internal users using advanced permissions
       | role                 | displayed-role       | extra-permissions     | displayed-permissions | actual-permissions                  |
       | Advanced permissions | Advanced permissions | delete                | delete                | read, delete                        |
       | Advanced permissions | Advanced permissions | update                | update                | read, update                        |
-      | Advanced permissions | Advanced permissions | create                | create                | read, create                        |
+      | Advanced permissions | Advanced permissions | create                | create, update        | read, create, update                |
       | Advanced permissions | Advanced permissions | delete, update        | delete, update        | read, delete, update                |
-      | Advanced permissions | Advanced permissions | delete, create        |                       | read, delete, create                |
+      | Advanced permissions | Editor               | delete, create        | ,                     | read, delete, create                |
       | Advanced permissions | Advanced permissions | update, create        | update, create        | read, update, create                |

--- a/tests/acceptance/features/webUISharingFolderAdvancedPermissionMultipleUsers/sharedFolderWithMultipleUsersAdvancedPermissions.feature
+++ b/tests/acceptance/features/webUISharingFolderAdvancedPermissionMultipleUsers/sharedFolderWithMultipleUsersAdvancedPermissions.feature
@@ -117,13 +117,7 @@ Feature: Sharing folders with multiple internal users using advanced permissions
       | role                 | displayed-role       | extra-permissions     | displayed-permissions | actual-permissions                  |
       | Advanced permissions | Advanced permissions | delete                | delete                | read, delete                        |
       | Advanced permissions | Advanced permissions | update                | update                | read, update                        |
-      | Advanced permissions | Advanced permissions | create                | create, update        | read, create, update                |
-      | Advanced permissions | Advanced permissions | share, delete         | share, delete         | read, share, delete                 |
-      | Advanced permissions | Advanced permissions | share, update         | share, update         | read, update, share                 |
-      | Advanced permissions | Advanced permissions | share, create         | share, create, update | read, share, create, update         |
+      | Advanced permissions | Advanced permissions | create                | create                | read, create                        |
       | Advanced permissions | Advanced permissions | delete, update        | delete, update        | read, delete, update                |
-      | Advanced permissions | Editor               | delete, create        |                       | read, delete, create, update        |
+      | Advanced permissions | Advanced permissions | delete, create        |                       | read, delete, create                |
       | Advanced permissions | Advanced permissions | update, create        | update, create        | read, update, create                |
-      | Advanced permissions | Advanced permissions | share, delete, update | share, delete, update | read, share, delete, update         |
-      | Advanced permissions | Editor               | share, create, delete | share                 | read, share, delete, create, update |
-      | Advanced permissions | Advanced permissions | share, update, create | share, update, create | read, share, update, create         |

--- a/tests/acceptance/features/webUISharingFolderAdvancedPermissionMultipleUsers/sharedFolderWithMultipleUsersAdvancedPermissions.feature
+++ b/tests/acceptance/features/webUISharingFolderAdvancedPermissionMultipleUsers/sharedFolderWithMultipleUsersAdvancedPermissions.feature
@@ -119,5 +119,5 @@ Feature: Sharing folders with multiple internal users using advanced permissions
       | Advanced permissions | Advanced permissions | update                | update                | read, update                        |
       | Advanced permissions | Advanced permissions | create                | create, update        | read, create, update                |
       | Advanced permissions | Advanced permissions | delete, update        | delete, update        | read, delete, update                |
-      | Advanced permissions | Editor               | delete, create        | ,                     | read, delete, create                |
+      | Advanced permissions | Editor               | delete, create        | ,                     | read, delete, create, update        |
       | Advanced permissions | Advanced permissions | update, create        | update, create        | read, update, create                |

--- a/tests/acceptance/features/webUISharingFolderPermissionMultipleUsers/shareFolderWithMultipleUsers.feature
+++ b/tests/acceptance/features/webUISharingFolderPermissionMultipleUsers/shareFolderWithMultipleUsers.feature
@@ -55,15 +55,13 @@ Feature: Sharing folders with multiple internal users with different permissions
     And user "User Four" should not be listed in the collaborators list on the webUI
     And as "user4" folder "simple-folder (2)" should not exist
     Examples:
-      | role                 | displayed-role          | extra-permissions             | displayed-permissions | actual-permissions           |
-      | Viewer               | Viewer                  | share                         | share                 | read, share                  |
-      | Viewer               | Viewer                  | ,                             | ,                     | read                         |
-      | Editor               | Editor                  | share                         | share                 | all                          |
-      | Editor               | Editor                  | ,                             | ,                     | read, update, delete, create |
-      | Advanced permissions | Viewer                  | ,                             | ,                     | read                         |
-      | Advanced permissions | Viewer                  | share                         | share                 | read, share                  |
-      | Advanced permissions | Editor                  | delete, update, create        | ,                     | read, delete, update, create |
-      | Advanced permissions | Editor                  | share, delete, update, create | share                 | all                          |
+      | role                 | displayed-role          | extra-permissions             | displayed-permissions  | actual-permissions           |
+      | Viewer               | Viewer                  | ,                             | ,                      | read, share                  |
+      | Editor               | Editor                  | ,                             | ,                      | all                          |
+      | Advanced permissions | Advanced permissions    | ,                             | ,                      | read                         |
+      | Advanced permissions | Viewer                  | share                         | ,                      | read, share                  |
+      | Advanced permissions | Advanced permissions    | delete, update, create        | delete, update, create | read, delete, update, create |
+      | Advanced permissions | Editor                  | share, delete, update, create | ,                      | all                          |
 
   @skipOnOC10 @issue-product-203
   #after fixing the issue delete this scenario and use the one above by deleting the @skipOnOCIS tag there
@@ -111,11 +109,11 @@ Feature: Sharing folders with multiple internal users with different permissions
     And as "user4" folder "simple-folder (2)" should not exist
     Examples:
       | role                 | displayed-role          | extra-permissions             | displayed-permissions | actual-permissions           |
-      | Viewer               | Viewer                  | share                         | share                 | read, share                  |
+      # | Viewer               | Viewer                  | share                         | share                 | read, share                  |
       | Viewer               | Viewer                  | ,                             | ,                     | read                         |
-      | Editor               | Editor                  | share                         | share                 | all                          |
+      # | Editor               | Editor                  | share                         | share                 | all                          |
       | Editor               | Editor                  | ,                             | ,                     | read, update, delete, create |
       | Advanced permissions | Viewer                  | ,                             | ,                     | read                         |
-      | Advanced permissions | Viewer                  | share                         | share                 | read, share                  |
+      # | Advanced permissions | Viewer                  | share                         | share                 | read, share                  |
       | Advanced permissions | Editor                  | delete, update, create        | ,                     | read, delete, update, create |
-      | Advanced permissions | Editor                  | share, delete, update, create | share                 | all                          |
+      # | Advanced permissions | Editor                  | share, delete, update, create | share                 | all                          |

--- a/tests/acceptance/features/webUISharingFolderPermissionsGroups/sharePermissionsGroup.feature
+++ b/tests/acceptance/features/webUISharingFolderPermissionsGroups/sharePermissionsGroup.feature
@@ -56,12 +56,10 @@ Feature: Sharing folders with internal groups with different roles and permissio
     But group "grp1" should not be listed in the collaborators list on the webUI
     And as "user1" folder "/Shares/simple-folder" should not exist
     Examples:
-    | role                 | displayed-role          | extra-permissions             | displayed-permissions | actual-permissions           |
-    | Viewer               | Viewer                  | share                         | share                 | read, share                  |
-    | Viewer               | Viewer                  | ,                             | ,                     | read                         |
-    | Editor               | Editor                  | share                         | share                 | all                          |
-    | Editor               | Editor                  | ,                             | ,                     | read, update, delete, create |
-    | Advanced permissions | Viewer                  | ,                             | ,                     | read                         |
-    | Advanced permissions | Viewer                  | share                         | share                 | read, share                  |
-    | Advanced permissions | Editor                  | delete, update, create        | ,                     | read, delete, update, create |
-    | Advanced permissions | Editor                  | share, delete, update, create | share                 | all                          |
+    | role                 | displayed-role       | extra-permissions             | displayed-permissions  | actual-permissions           |
+    | Viewer               | Viewer               | ,                             | ,                      | read, share                  |
+    | Editor               | Editor               | ,                             | ,                      | all                          |
+    | Advanced permissions | Advanced permissions | ,                             | ,                      | read                         |
+    | Advanced permissions | Viewer               | share                         | ,                      | read, share                  |
+    | Advanced permissions | Advanced permissions | delete, update, create        | delete, update, create | read, delete, update, create |
+    | Advanced permissions | Editor               | share, delete, update, create | ,                      | all                          |

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -65,10 +65,10 @@ Feature: Sharing files and folders with internal groups
     Then folder "simple-folder" should be marked as shared by "User Three" on the webUI
     And file "testimage.jpg" should be marked as shared by "User Three" on the webUI
     Examples:
-      | set-role             | expected-role | permissions-folder         | permissions-file |
-      | Viewer               | Viewer        | read                       | read             |
-      | Editor               | Editor        | read,update,create, delete | read,update      |
-      | Advanced permissions | Viewer        | read                       | read             |
+      | set-role             | expected-role        | permissions-folder              | permissions-file  |
+      | Viewer               | Viewer               | read,share                      | read,share        |
+      | Editor               | Editor               | read,update,create,delete,share | read,update,share |
+      | Advanced permissions | Advanced permissions | read                            | read              |
 
   @skip @issue-4102
   Scenario: share a file with an internal group a member overwrites and unshares the file

--- a/tests/acceptance/features/webUISharingInternalGroupsToRoot/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroupsToRoot/shareWithGroups.feature
@@ -59,10 +59,10 @@ Feature: Sharing files and folders with internal groups
     Then folder "simple-folder (2)" should be marked as shared by "User Three" on the webUI
     And file "testimage (2).jpg" should be marked as shared by "User Three" on the webUI
     Examples:
-      | set-role             | expected-role | permissions-folder         | permissions-file |
-      | Viewer               | Viewer        | read                       | read             |
-      | Editor               | Editor        | read,update,create, delete | read,update      |
-      | Advanced permissions | Viewer        | read                       | read             |
+      | set-role             | expected-role        | permissions-folder              | permissions-file       |
+      | Viewer               | Viewer               | read,share                      | read,share             |
+      | Editor               | Editor               | read,update,create,delete,share | read,update,share      |
+      | Advanced permissions | Advanced permissions | read                            | read                   |
 
   Scenario: share a file with an internal group a member overwrites and unshares the file
     Given user "user3" has logged in using the webUI

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -103,7 +103,7 @@ Feature: Sharing files and folders with internal users
       | read,update,create  | Viewer               | Viewer        | read                      |
       | read                | Editor               | Editor        | read,update,create,delete |
       | read                | Advanced permissions | Viewer        | read                      |
-      | all                 | Advanced permissions | Editor        | read,update,create,delete |
+      | read,update,create  | Advanced permissions | Editor        | read,update,create,delete |
 
   @skip @issue-4102
   Scenario: share a file with another internal user who overwrites and unshares the file

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -51,10 +51,10 @@ Feature: Sharing files and folders with internal users
     #    And folder "simple-folder (2)" should be marked as shared by "User Two" on the webUI
     #    And file "testimage (2).jpg" should be marked as shared by "User Two" on the webUI
     Examples:
-      | set-role             | expected-role | permissions-folder        | permissions-file |
-      | Viewer               | Viewer        | read                      | read             |
-      | Editor               | Editor        | read,update,create,delete | read,update      |
-      | Advanced permissions | Viewer        | read                      | read             |
+      | set-role             | expected-role               | permissions-folder              | permissions-file  |
+      | Viewer               | Viewer                      | read,share                      | read, share       |
+      | Editor               | Editor                      | read,update,create,delete,share | read,update,share |
+      | Advanced permissions | Advanced permissions        | read                            | read              |
 
   @skipOnOCIS @issue-product-203
   Scenario Outline: change the collaborators of a file & folder
@@ -74,11 +74,11 @@ Feature: Sharing files and folders with internal users
       | item_type   | folder                 |
       | permissions | <expected-permissions> |
     Examples:
-      | initial-permissions | set-role             | expected-role | expected-permissions      |
-      | read,update,create  | Viewer               | Viewer        | read                      |
-      | read                | Editor               | Editor        | read,update,create,delete |
-      | read                | Advanced permissions | Viewer        | read                      |
-      | all                 | Advanced permissions | Editor        | all                       |
+      | initial-permissions | set-role             | expected-role        | expected-permissions            |
+      | read,update,create  | Viewer               | Viewer               | read,share                      |
+      | read                | Editor               | Editor               | read,update,create,delete,share |
+      | read                | Advanced permissions | Advanced permissions | read                            |
+      | all                 | Advanced permissions | Editor               | all                             |
 
   @skipOnOC10 @issue-product-203
   #after fixing the issue delete this scenario and use the one above by deleting the @skipOnOCIS tag there
@@ -713,7 +713,7 @@ Feature: Sharing files and folders with internal users
     And user "user2" has accepted the share "simple-folder" offered by user "user1"
     When user "user2" logs in using the webUI
     And the user opens folder "Shares" using the webUI
-    Then user "User Two" should be listed as "Editor" in the collaborators list for folder "simple-folder (2)" on the webUI
+    Then user "User Two" should be listed as "Advanced permissions" in the collaborators list for folder "simple-folder (2)" on the webUI
 
   @skipOnOCIS @issue-4169
   Scenario: share a file with another internal user which should expire after 2 days
@@ -949,7 +949,7 @@ Feature: Sharing files and folders with internal users
       | share_with  | user2                 |
       | file_target | /Shares/simple-folder |
       | item_type   | folder                |
-      | permissions | read                  |
+      | permissions | read,share            |
 
   @skipOnOCIS @issue-product-203
   Scenario Outline: Share files/folders with special characters in their name
@@ -983,10 +983,10 @@ Feature: Sharing files and folders with internal users
       | Sample,Folder,With,Comma |
       | sample,1.txt             |
     Examples:
-      | set-role             | expected-role | permissions-folder        | permissions-file |
-      | Viewer               | Viewer        | read                      | read             |
-      | Editor               | Editor        | read,update,create,delete | read,update      |
-      | Advanced permissions | Viewer        | read                      | read             |
+      | set-role             | expected-role        | permissions-folder              | permissions-file  |
+      | Viewer               | Viewer               | read,share                      | read,share        |
+      | Editor               | Editor               | read,update,create,delete,share | read,update,share |
+      | Advanced permissions | Advanced permissions | read                            | read              |
 
   @skipOnOC10 @issue-product-203
   #after fixing the issue delete this scenario and use the one above by deleting the @skipOnOCIS tag there

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -99,11 +99,11 @@ Feature: Sharing files and folders with internal users
       | item_type   | folder                 |
       | permissions | <expected-permissions> |
     Examples:
-      | initial-permissions | set-role             | expected-role | expected-permissions      |
-      | read,update,create  | Viewer               | Viewer        | read                      |
-      | read                | Editor               | Editor        | read,update,create,delete |
-      | read                | Advanced permissions | Viewer        | read                      |
-      | read,update,create  | Advanced permissions | Editor        | read,update,create,delete |
+      | initial-permissions       | set-role             | expected-role | expected-permissions      |
+      | read,update,create        | Viewer               | Viewer        | read                      |
+      | read                      | Editor               | Editor        | read,update,create,delete |
+      | read                      | Advanced permissions | Viewer        | read                      |
+      | read,update,create,delete | Advanced permissions | Editor        | read,update,create,delete |
 
   @skip @issue-4102
   Scenario: share a file with another internal user who overwrites and unshares the file

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -77,7 +77,7 @@ Feature: Sharing files and folders with internal users
       | initial-permissions | set-role             | expected-role        | expected-permissions            |
       | read,update,create  | Viewer               | Viewer               | read,share                      |
       | read                | Editor               | Editor               | read,update,create,delete,share |
-      | read                | Advanced permissions | Advanced permissions | read                            |
+      | read,share          | Advanced permissions | Viewer               | read,share                      |
       | all                 | Advanced permissions | Editor               | all                             |
 
   @skipOnOC10 @issue-product-203

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -103,7 +103,7 @@ Feature: Sharing files and folders with internal users
       | read,update,create  | Viewer               | Viewer        | read                      |
       | read                | Editor               | Editor        | read,update,create,delete |
       | read                | Advanced permissions | Viewer        | read                      |
-      | all                 | Advanced permissions | Editor        | all                       |
+      | all                 | Advanced permissions | Editor        | read,update,create,delete |
 
   @skip @issue-4102
   Scenario: share a file with another internal user who overwrites and unshares the file
@@ -580,7 +580,8 @@ Feature: Sharing files and folders with internal users
     When the user opens the share dialog for file "lorem.txt" using the webUI
     Then user "User Two" should be listed as "Editor" via "simple-folder" in the collaborators list on the webUI
 
-  @issue-2897
+  # Share permission is not available in oCIS webUI so when setting all permissions, it is displayed as "Advanced permissions" there
+  @skipOnOCIS @issue-2897
   Scenario: sharing details of items inside a re-shared folder
     Given user "user3" has been created with default attributes
     And user "user1" has uploaded file with content "test" to "/simple-folder/lorem.txt"
@@ -594,6 +595,21 @@ Feature: Sharing files and folders with internal users
     Then user "User Three" should be listed as "Editor" via "simple-folder" in the collaborators list on the webUI
     When the user opens the share dialog for file "lorem.txt" using the webUI
     Then user "User Three" should be listed as "Editor" via "simple-folder" in the collaborators list on the webUI
+
+  @skipOnOC10 @issue-2897
+  Scenario: sharing details of items inside a re-shared folder
+    Given user "user3" has been created with default attributes
+    And user "user1" has uploaded file with content "test" to "/simple-folder/lorem.txt"
+    And user "user1" has shared folder "simple-folder" with user "user2"
+    And user "user2" has accepted the share "simple-folder" offered by user "user1"
+    And user "user2" has shared folder "Shares/simple-folder" with user "user3"
+    And user "user2" has logged in using the webUI
+    And the user has opened folder "Shares"
+    And the user has opened folder "simple-folder"
+    When the user opens the share dialog for folder "simple-empty-folder" using the webUI
+    Then user "User Three" should be listed as "Advanced permissions" via "simple-folder" in the collaborators list on the webUI
+    When the user opens the share dialog for file "lorem.txt" using the webUI
+    Then user "User Three" should be listed as "Advanced permissions" via "simple-folder" in the collaborators list on the webUI
 
   @issue-2897 @skipOnOCIS @issue-4193
   Scenario: sharing details of items inside a shared folder shared with multiple users

--- a/tests/acceptance/features/webUISharingInternalUsersToRoot/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsersToRoot/shareWithUsers.feature
@@ -70,7 +70,7 @@ Feature: Sharing files and folders with internal users
       | initial-permissions | set-role             | expected-role        | expected-permissions            |
       | read,update,create  | Viewer               | Viewer               | read,share                      |
       | read                | Editor               | Editor               | read,update,create,delete,share |
-      | read                | Advanced permissions | Advanced permissions | read                            |
+      | read,share          | Advanced permissions | Viewer               | read,share                      |
       | all                 | Advanced permissions | Editor               | all                             |
 
   Scenario: share a file with another internal user who overwrites and unshares the file
@@ -589,7 +589,7 @@ Feature: Sharing files and folders with internal users
     And user "user1" has shared folder "simple-folder" with user "user2" with "read" permission
     And user "user1" has shared folder "simple-folder" with group "grp1" with "read,update,create,delete" permissions
     When user "user2" has logged in using the webUI
-    Then user "User Two" should be listed as "Editor" in the collaborators list for folder "simple-folder (2)" on the webUI
+    Then user "User Two" should be listed as "Advanced permissions" in the collaborators list for folder "simple-folder (2)" on the webUI
 
   Scenario: share a file with another internal user which should expire after 2 days
     Given user "user1" has logged in using the webUI

--- a/tests/acceptance/features/webUISharingInternalUsersToRoot/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsersToRoot/shareWithUsers.feature
@@ -46,10 +46,10 @@ Feature: Sharing files and folders with internal users
     #    And folder "simple-folder (2)" should be marked as shared by "User Two" on the webUI
     #    And file "testimage (2).jpg" should be marked as shared by "User Two" on the webUI
     Examples:
-      | set-role             | expected-role | permissions-folder        | permissions-file |
-      | Viewer               | Viewer        | read                      | read             |
-      | Editor               | Editor        | read,update,create,delete | read,update      |
-      | Advanced permissions | Viewer        | read                      | read             |
+      | set-role             | expected-role        | permissions-folder              | permissions-file       |
+      | Viewer               | Viewer               | read,share                      | read,share             |
+      | Editor               | Editor               | read,update,create,delete,share | read,update,share      |
+      | Advanced permissions | Advanced permissions | read                            | read                   |
 
   Scenario Outline: change the collaborators of a file & folder
     Given user "user2" has logged in using the webUI
@@ -67,11 +67,11 @@ Feature: Sharing files and folders with internal users
       | item_type   | folder                 |
       | permissions | <expected-permissions> |
     Examples:
-      | initial-permissions | set-role             | expected-role | expected-permissions      |
-      | read,update,create  | Viewer               | Viewer        | read                      |
-      | read                | Editor               | Editor        | read,update,create,delete |
-      | read                | Advanced permissions | Viewer        | read                      |
-      | all                 | Advanced permissions | Editor        | all                       |
+      | initial-permissions | set-role             | expected-role        | expected-permissions            |
+      | read,update,create  | Viewer               | Viewer               | read,share                      |
+      | read                | Editor               | Editor               | read,update,create,delete,share |
+      | read                | Advanced permissions | Advanced permissions | read                            |
+      | all                 | Advanced permissions | Editor               | all                             |
 
   Scenario: share a file with another internal user who overwrites and unshares the file
     Given user "user2" has logged in using the webUI
@@ -805,7 +805,7 @@ Feature: Sharing files and folders with internal users
       | share_with  | user2                |
       | file_target | /simple-folder (2)   |
       | item_type   | folder               |
-      | permissions | read                 |
+      | permissions | read,share           |
 
     Scenario Outline: Share files/folders with special characters in their name
       Given user "user2" has created folder "Sample,Folder,With,Comma"
@@ -835,7 +835,7 @@ Feature: Sharing files and folders with internal users
         | Sample,Folder,With,Comma |
         | sample,1.txt             |
       Examples:
-        | set-role             | expected-role | permissions-folder        | permissions-file |
-        | Viewer               | Viewer        | read                      | read             |
-        | Editor               | Editor        | read,update,create,delete | read,update      |
-        | Advanced permissions | Viewer        | read                      | read             |
+        | set-role             | expected-role        | permissions-folder              | permissions-file       |
+        | Viewer               | Viewer               | read,share                      | read,share             |
+        | Editor               | Editor               | read,update,create,delete,share | read,update,share      |
+        | Advanced permissions | Advanced permissions | read                            | read                   |

--- a/tests/acceptance/features/webUISharingPermissionToRoot/shareFileWithMultipleUsers.feature
+++ b/tests/acceptance/features/webUISharingPermissionToRoot/shareFileWithMultipleUsers.feature
@@ -59,4 +59,4 @@ Feature: Sharing files with multiple internal users with different permissions
       # | Advanced permissions | Viewer         | ,                 | ,                     | read                |
       # | Advanced permissions | Viewer         | share             | share                 | read, share         |
       # | Advanced permissions | Editor         | update            | ,                     | read, update        |
-      | Advanced permissions | Editor         | share, update     | share                 | read, update, share |
+      | Advanced permissions | Editor         | share, update     | ,                     | read, update, share |

--- a/tests/acceptance/features/webUISharingPermissionToRoot/shareFolderWithMultipleUsers.feature
+++ b/tests/acceptance/features/webUISharingPermissionToRoot/shareFolderWithMultipleUsers.feature
@@ -59,4 +59,4 @@ Feature: Sharing folders with multiple internal users with different permissions
       # | Advanced permissions | Viewer                  | ,                             | ,                     | read                         |
       # | Advanced permissions | Viewer                  | share                         | share                 | read, share                  |
       # | Advanced permissions | Editor                  | delete, update, create        | ,                     | read, delete, update, create |
-      | Advanced permissions | Editor                  | share, delete, update, create | share                 | all                          |
+      | Advanced permissions | Editor                  | share, delete, update, create | ,                     | all                          |

--- a/tests/acceptance/features/webUISharingPermissionToRoot/sharePermissionsFileGroup.feature
+++ b/tests/acceptance/features/webUISharingPermissionToRoot/sharePermissionsFileGroup.feature
@@ -59,4 +59,4 @@ Feature: Sharing files with internal groups with permissions
     # | Advanced permissions | Viewer         | ,                 | ,                     | read                |
     # | Advanced permissions | Viewer         | share             | share                 | read, share         |
     # | Advanced permissions | Editor         | update            | ,                     | read, update        |
-    | Advanced permissions | Editor         | share, update     | share                 | read, update, share |
+    | Advanced permissions | Editor         | share, update     | ,                     | read, update, share |

--- a/tests/acceptance/features/webUISharingPermissionToRoot/sharePermissionsFoldersGroup.feature
+++ b/tests/acceptance/features/webUISharingPermissionToRoot/sharePermissionsFoldersGroup.feature
@@ -60,4 +60,4 @@ Feature: Sharing folders with internal groups with different roles and permissio
     # | Advanced permissions | Viewer                  | ,                             | ,                     | read                         |
     # | Advanced permissions | Viewer                  | share                         | share                 | read, share                  |
     # | Advanced permissions | Editor                  | delete, update, create        | ,                     | read, delete, update, create |
-    | Advanced permissions | Editor                  | share, delete, update, create | share                 | all                          |
+    | Advanced permissions | Editor                  | share, delete, update, create | ,                     | all                          |

--- a/tests/acceptance/features/webUISharingPermissionToRoot/sharePermissionsUsers.feature
+++ b/tests/acceptance/features/webUISharingPermissionToRoot/sharePermissionsUsers.feature
@@ -11,18 +11,18 @@ Feature: Sharing files and folders with internal users with different permission
       | user2    |
 
   Scenario: Change permissions of the previously shared folder
-    Given user "user2" has shared folder "simple-folder" with user "user1" with "read" permissions
+    Given user "user2" has shared folder "simple-folder" with user "user1" with "read, update" permissions
     And user "user2" has logged in using the webUI
-    Then no custom permissions should be set for collaborator "User One" for folder "simple-folder" on the webUI
-    When the user sets custom permission for current role of collaborator "User One" for folder "simple-folder" to "share" using the webUI
-    Then custom permission "share" should be set for user "User One" for folder "simple-folder" on the webUI
+    Then custom permission "update" should be set for user "User One" for folder "simple-folder" on the webUI
+    When the user sets custom permission for current role of collaborator "User One" for folder "simple-folder" to "share, update" using the webUI
+    Then custom permissions "share, update" should be set for user "User One" for folder "simple-folder" on the webUI
     And user "user1" should have received a share with these details:
-      | field       | value              |
-      | uid_owner   | user2              |
-      | share_with  | user1              |
-      | file_target | /simple-folder (2) |
-      | item_type   | folder             |
-      | permissions | read, share        |
+      | field       | value               |
+      | uid_owner   | user2               |
+      | share_with  | user1               |
+      | file_target | /simple-folder (2)  |
+      | item_type   | folder              |
+      | permissions | read, share, update |
 
   @issue-1853
   Scenario: Change permissions of the previously shared folder
@@ -82,19 +82,18 @@ Feature: Sharing files and folders with internal users with different permission
       | permissions | <permissions>      |
     Examples:
       | role                 | displayed-role          | extra-permissions             | displayed-permissions | permissions                         |
-      | Viewer               | Viewer                  | share                         | share                 | read, share                         |
-      | Editor               | Editor                  | share                         | share                 | all                                 |
+      | Viewer               | Viewer                  | ,                             | ,                     | read, share                         |
+      | Editor               | Editor                  | ,                             | ,                     | all                                 |
       | Advanced permissions | Advanced permissions    | share, create                 | share, create         | read, share, create                 |
       | Advanced permissions | Advanced permissions    | update, share                 | share, update         | read, update, share                 |
-      | Advanced permissions | Editor                  | delete, share, create, update | share                 | read, share, delete, update, create |
+      | Advanced permissions | Editor                  | delete, share, create, update | ,                     | read, share, delete, update, create |
 
   Scenario Outline: Change permissions of the previously shared file
     Given user "user2" has shared file "lorem.txt" with user "user1" with "<initial-permissions>" permissions
     And user "user2" has logged in using the webUI
-    Then no custom permissions should be set for collaborator "User One" for file "lorem.txt" on the webUI
+    Then custom permissions "<set-permissions>" should be set for user "User One" for file "lorem.txt" on the webUI
     When the user sets custom permission for current role of collaborator "User One" for file "lorem.txt" to "share" using the webUI
-    Then custom permission "share" should be set for user "User One" for file "lorem.txt" on the webUI
-    And user "user1" should have received a share with these details:
+    Then user "user1" should have received a share with these details:
       | field       | value          |
       | uid_owner   | user2          |
       | share_with  | user1          |
@@ -102,23 +101,22 @@ Feature: Sharing files and folders with internal users with different permission
       | item_type   | file           |
       | permissions | <permissions>  |
     Examples:
-      | initial-permissions | permissions         |
-      | read, update        | read, share, update |
-      | read                | read, share         |
+      | initial-permissions | permissions         | set-permissions |
+      | read, update        | read, share         | update          |
+      | read                | read, share         | ,               |
 
-  Scenario: Delete all custom permissions of the previously shared file
-    Given user "user2" has shared file "lorem.txt" with user "user1" with "read, share" permissions
+  Scenario: Delete all custom permissions of the previously shared folder
+    Given user "user2" has shared file "simple-folder" with user "user1" with "read, share, update" permissions
     And user "user2" has logged in using the webUI
-    Then custom permissions "share" should be set for user "User One" for file "lorem.txt" on the webUI
-    When the user disables all the custom permissions of collaborator "User One" for file "lorem.txt" using the webUI
-    Then no custom permissions should be set for collaborator "User One" for file "lorem.txt" on the webUI
+    When the user disables all the custom permissions of collaborator "User One" for file "simple-folder" using the webUI
+    Then no custom permissions should be set for collaborator "User One" for file "simple-folder" on the webUI
     And user "user1" should have received a share with these details:
-      | field       | value          |
-      | uid_owner   | user2          |
-      | share_with  | user1          |
-      | file_target | /lorem (2).txt |
-      | item_type   | file           |
-      | permissions | read           |
+      | field       | value              |
+      | uid_owner   | user2              |
+      | share_with  | user1              |
+      | file_target | /simple-folder (2) |
+      | item_type   | folder             |
+      | permissions | read               |
 
   Scenario Outline: share a file with another internal user assigning a role and the permissions
     Given user "user2" has logged in using the webUI
@@ -134,15 +132,15 @@ Feature: Sharing files and folders with internal users with different permission
       | permissions | <permissions>  |
     Examples:
       | role                 | displayed-role | collaborators-permissions | displayed-permissions | permissions         |
-      | Viewer               | Viewer         | share                     | share                 | read, share         |
-      | Editor               | Editor         | share                     | share                 | read, share, update |
-      | Advanced permissions | Editor         | share, update             | share                 | read, share, update |
+      | Viewer               | Viewer         | ,                         | ,                     | read, share         |
+      | Editor               | Editor         | ,                         | ,                     | read, share, update |
+      | Advanced permissions | Editor         | share, update             | ,                     | read, share, update |
 
   Scenario: Share a folder without share permissions using API and check if it is listed on the collaborators list for original owner
     Given user "user2" has shared folder "simple-folder" with user "user1" with "read" permissions
     And user "user2" has logged in using the webUI
     When the user opens the share dialog for folder "simple-folder" using the webUI
-    Then user "User One" should be listed as "Viewer" in the collaborators list for folder "simple-folder" on the webUI
+    Then user "User One" should be listed as "Advanced permissions" in the collaborators list for folder "simple-folder" on the webUI
     And no custom permissions should be set for collaborator "User One" for folder "simple-folder" on the webUI
 
   Scenario: Resource owner upgrades share permissions of a re-share

--- a/tests/acceptance/features/webUISharingPermissionsUsers/sharePermissionsUsers.feature
+++ b/tests/acceptance/features/webUISharingPermissionsUsers/sharePermissionsUsers.feature
@@ -19,8 +19,7 @@ Feature: Sharing files and folders with internal users with different permission
     And user "user2" has logged in using the webUI
     Then no custom permissions should be set for collaborator "User One" for folder "simple-folder" on the webUI
     When the user sets custom permission for current role of collaborator "User One" for folder "simple-folder" to "share" using the webUI
-    Then custom permission "share" should be set for user "User One" for folder "simple-folder" on the webUI
-    And user "user1" should have received a share with these details:
+    Then user "user1" should have received a share with these details:
       | field       | value                 |
       | uid_owner   | user2                 |
       | share_with  | user1                 |
@@ -31,19 +30,19 @@ Feature: Sharing files and folders with internal users with different permission
   @skipOnOC10 @issue-product-203 @issue-ocis-717
   #after fixing the issue delete this scenario and use the one above by deleting the @skipOnOCIS tag there
   Scenario: Change permissions of the previously shared folder
-    Given user "user2" has shared folder "simple-folder" with user "user1" with "read" permissions
+    Given user "user2" has shared folder "simple-folder" with user "user1" with "read, update" permissions
     And user "user1" has accepted the share "simple-folder" offered by user "user2"
     And user "user2" has logged in using the webUI
-    Then no custom permissions should be set for collaborator "User One" for folder "simple-folder" on the webUI
-    When the user sets custom permission for current role of collaborator "User One" for folder "simple-folder" to "share" using the webUI
-    Then custom permission "share" should be set for user "User One" for folder "simple-folder" on the webUI
+    Then custom permission "update" should be set for user "User One" for folder "simple-folder" on the webUI
+    When the user sets custom permission for current role of collaborator "User One" for folder "simple-folder" to "create" using the webUI
+    Then custom permission "create" should be set for user "User One" for folder "simple-folder" on the webUI
     And user "user1" should have received a share with these details:
-      | field       | value          |
-      | uid_owner   | user2          |
-      | share_with  | user1          |
-      | file_target | /simple-folder |
-      | item_type   | folder         |
-      | permissions | read, share    |
+      | field       | value                |
+      | uid_owner   | user2                |
+      | share_with  | user1                |
+      | file_target | /simple-folder       |
+      | item_type   | folder               |
+      | permissions | read, update, create |
 
   @issue-1853
   @skipOnOCIS @issue-product-270
@@ -111,11 +110,11 @@ Feature: Sharing files and folders with internal users with different permission
       | permissions | <permissions>         |
     Examples:
       | role                 | displayed-role          | extra-permissions             | displayed-permissions | permissions                         |
-      | Viewer               | Viewer                  | share                         | share                 | read, share                         |
-      | Editor               | Editor                  | share                         | share                 | all                                 |
+      | Viewer               | Viewer                  | ,                             | ,                     | read, share                         |
+      | Editor               | Editor                  | ,                             | ,                     | all                                 |
       | Advanced permissions | Advanced permissions    | share, create                 | share, create         | read, share, create                 |
       | Advanced permissions | Advanced permissions    | update, share                 | share, update         | read, update, share                 |
-      | Advanced permissions | Editor                  | delete, share, create, update | share                 | read, share, delete, update, create |
+      | Advanced permissions | Editor                  | delete, share, create, update | ,                     | read, share, delete, update, create |
 
   @skipOnOC10 @issue-product-203
   #after fixing the issue delete this scenario and use the one above by deleting the @skipOnOCIS tag there
@@ -133,22 +132,21 @@ Feature: Sharing files and folders with internal users with different permission
       | item_type   | folder         |
       | permissions | <permissions>  |
     Examples:
-      | role                 | displayed-role       | extra-permissions             | displayed-permissions | permissions                         |
-      | Viewer               | Viewer               | share                         | share                 | read, share                         |
-      | Editor               | Editor               | share                         | share                 | all                                 |
-      | Advanced permissions | Advanced permissions | share, create                 | share, create, update | read, share, create, update         |
-      | Advanced permissions | Advanced permissions | update, share                 | share, update         | read, update, share                 |
-      | Advanced permissions | Editor               | delete, share, create, update | share                 | read, share, delete, update, create |
+      | role                 | displayed-role       | extra-permissions             | displayed-permissions | permissions                  |
+      | Viewer               | Viewer               | ,                             | ,                     | read                         |
+      | Editor               | Editor               | ,                             | ,                     | all                          |
+      | Advanced permissions | Advanced permissions | create                        | create                | read                         |
+      | Advanced permissions | Advanced permissions | update                        | update                | read, update                 |
+      | Advanced permissions | Editor               | delete, create, update        | ,                     | read, delete, update, create |
 
   @skipOnOCIS @issue-product-203
   Scenario Outline: Change permissions of the previously shared file
     Given user "user2" has shared file "lorem.txt" with user "user1" with "<initial-permissions>" permissions
     And user "user1" has accepted the share "lorem.txt" offered by user "user2"
     And user "user2" has logged in using the webUI
-    Then no custom permissions should be set for collaborator "User One" for file "lorem.txt" on the webUI
+    Then custom permission "<displayed-permissions>" should be set for user "User One" for file "lorem.txt" on the webUI
     When the user sets custom permission for current role of collaborator "User One" for file "lorem.txt" to "share" using the webUI
-    Then custom permission "share" should be set for user "User One" for file "lorem.txt" on the webUI
-    And user "user1" should have received a share with these details:
+    Then user "user1" should have received a share with these details:
       | field       | value             |
       | uid_owner   | user2             |
       | share_with  | user1             |
@@ -156,63 +154,64 @@ Feature: Sharing files and folders with internal users with different permission
       | item_type   | file              |
       | permissions | <permissions>     |
     Examples:
-      | initial-permissions | permissions         |
-      | read, update        | read, share, update |
-      | read                | read, share         |
+      | initial-permissions | permissions         | displayed-permissions |
+      | read, update        | read, share         | update                |
+      | read                | read, share         | ,                     |
 
-  @skipOnOC10 @issue-product-203
-  #after fixing the issue delete this scenario and use the one above by deleting the @skipOnOCIS tag there
-  Scenario Outline: Change permissions of the previously shared file
-    Given user "user2" has shared file "lorem.txt" with user "user1" with "<initial-permissions>" permissions
-    And user "user1" has accepted the share "lorem.txt" offered by user "user2"
-    And user "user2" has logged in using the webUI
-    Then no custom permissions should be set for collaborator "User One" for file "lorem.txt" on the webUI
-    When the user sets custom permission for current role of collaborator "User One" for file "lorem.txt" to "share" using the webUI
-    Then custom permission "share" should be set for user "User One" for file "lorem.txt" on the webUI
-    And user "user1" should have received a share with these details:
-      | field       | value         |
-      | uid_owner   | user2         |
-      | share_with  | user1         |
-      | file_target | /lorem.txt    |
-      | item_type   | file          |
-      | permissions | <permissions> |
-    Examples:
-      | initial-permissions | permissions         |
-      | read, update        | read, share, update |
-      | read                | read, share         |
+  #  As the reshare permission has been hidden in oCIS there's no use for this scenario at the moment
+  # @skipOnOC10 @issue-product-203
+  # #after fixing the issue delete this scenario and use the one above by deleting the @skipOnOCIS tag there
+  # Scenario Outline: Change permissions of the previously shared file
+  #   Given user "user2" has shared file "lorem.txt" with user "user1" with "<initial-permissions>" permissions
+  #   And user "user1" has accepted the share "lorem.txt" offered by user "user2"
+  #   And user "user2" has logged in using the webUI
+  #   Then no custom permissions should be set for collaborator "User One" for file "lorem.txt" on the webUI
+  #   When the user sets custom permission for current role of collaborator "User One" for file "lorem.txt" to "share" using the webUI
+  #   Then custom permission "share" should be set for user "User One" for file "lorem.txt" on the webUI
+  #   And user "user1" should have received a share with these details:
+  #     | field       | value         |
+  #     | uid_owner   | user2         |
+  #     | share_with  | user1         |
+  #     | file_target | /lorem.txt    |
+  #     | item_type   | file          |
+  #     | permissions | <permissions> |
+  #   Examples:
+  #     | initial-permissions | permissions         |
+  #     | read, update        | read, share, update |
+  #     | read                | read, share         |
 
   @skipOnOCIS @issue-product-203
-  Scenario: Delete all custom permissions of the previously shared file
-    Given user "user2" has shared file "lorem.txt" with user "user1" with "read, share" permissions
-    And user "user1" has accepted the share "lorem.txt" offered by user "user2"
+  Scenario: Delete all custom permissions of the previously shared folder
+    Given user "user2" has shared folder "simple-folder" with user "user1" with "read, update" permissions
+    And user "user1" has accepted the share "simple-folder" offered by user "user2"
     And user "user2" has logged in using the webUI
-    Then custom permissions "share" should be set for user "User One" for file "lorem.txt" on the webUI
-    When the user disables all the custom permissions of collaborator "User One" for file "lorem.txt" using the webUI
-    Then no custom permissions should be set for collaborator "User One" for file "lorem.txt" on the webUI
+    When the user disables all the custom permissions of collaborator "User One" for folder "simple-folder" using the webUI
+    Then no custom permissions should be set for collaborator "User One" for folder "simple-folder" on the webUI
     And user "user1" should have received a share with these details:
-      | field       | value             |
-      | uid_owner   | user2             |
-      | share_with  | user1             |
-      | file_target | /Shares/lorem.txt |
-      | item_type   | file              |
-      | permissions | read              |
+      | field       | value                 |
+      | uid_owner   | user2                 |
+      | share_with  | user1                 |
+      | file_target | /Shares/simple-folder |
+      | item_type   | folder                |
+      | permissions | read                  |
 
-  @skipOnOC10 @issue-product-203
-  #after fixing the issue delete this scenario and use the one above by deleting the @skipOnOCIS tag there
-  Scenario: Delete all custom permissions of the previously shared file
-    Given user "user2" has shared file "lorem.txt" with user "user1" with "read, share" permissions
-    And user "user1" has accepted the share "lorem.txt" offered by user "user2"
-    And user "user2" has logged in using the webUI
-    Then custom permissions "share" should be set for user "User One" for file "lorem.txt" on the webUI
-    When the user disables all the custom permissions of collaborator "User One" for file "lorem.txt" using the webUI
-    Then no custom permissions should be set for collaborator "User One" for file "lorem.txt" on the webUI
-    And user "user1" should have received a share with these details:
-      | field       | value      |
-      | uid_owner   | user2      |
-      | share_with  | user1      |
-      | file_target | /lorem.txt |
-      | item_type   | file       |
-      | permissions | read       |
+  #  As the reshare permission has been hidden in oCIS there's no use for this scenario at the moment
+  # @skipOnOC10 @issue-product-203
+  # #after fixing the issue delete this scenario and use the one above by deleting the @skipOnOCIS tag there
+  # Scenario: Delete all custom permissions of the previously shared file
+  #   Given user "user2" has shared file "lorem.txt" with user "user1" with "read, share" permissions
+  #   And user "user1" has accepted the share "lorem.txt" offered by user "user2"
+  #   And user "user2" has logged in using the webUI
+  #   Then custom permissions "share" should be set for user "User One" for file "lorem.txt" on the webUI
+  #   When the user disables all the custom permissions of collaborator "User One" for file "lorem.txt" using the webUI
+  #   Then no custom permissions should be set for collaborator "User One" for file "lorem.txt" on the webUI
+  #   And user "user1" should have received a share with these details:
+  #     | field       | value      |
+  #     | uid_owner   | user2      |
+  #     | share_with  | user1      |
+  #     | file_target | /lorem.txt |
+  #     | item_type   | file       |
+  #     | permissions | read       |
 
   @skipOnOCIS @issue-product-203
   Scenario Outline: share a file with another internal user assigning a role and the permissions
@@ -230,9 +229,9 @@ Feature: Sharing files and folders with internal users with different permission
       | permissions | <permissions>     |
     Examples:
       | role                 | displayed-role | collaborators-permissions | displayed-permissions | permissions         |
-      | Viewer               | Viewer         | share                     | share                 | read, share         |
-      | Editor               | Editor         | share                     | share                 | read, share, update |
-      | Advanced permissions | Editor         | share, update             | share                 | read, share, update |
+      | Viewer               | Viewer         | ,                         | ,                     | read, share         |
+      | Editor               | Editor         | ,                         | ,                     | read, share, update |
+      | Advanced permissions | Editor         | share, update             | ,                     | read, share, update |
 
   @skipOnOC10 @issue-product-203
   #after fixing the issue delete this scenario and use the one above by deleting the @skipOnOCIS tag there
@@ -250,11 +249,21 @@ Feature: Sharing files and folders with internal users with different permission
       | item_type   | file          |
       | permissions | <permissions> |
     Examples:
-      | role                 | displayed-role | collaborators-permissions | displayed-permissions | permissions         |
-      | Viewer               | Viewer         | share                     | share                 | read, share         |
-      | Editor               | Editor         | share                     | share                 | read, share, update |
-      | Advanced permissions | Editor         | share, update             | share                 | read, share, update |
+      | role                 | displayed-role | collaborators-permissions | displayed-permissions | permissions  |
+      | Viewer               | Viewer         | ,                         | ,                     | read         |
+      | Editor               | Editor         | ,                         | ,                     | read, update |
+      | Advanced permissions | Editor         | update                    | ,                     | read, update |
 
+  @skipOnOCIS
+  Scenario: Share a folder without share permissions using API and check if it is listed on the collaborators list for original owner
+    Given user "user2" has shared folder "simple-folder" with user "user1" with "read" permissions
+    And user "user1" has accepted the share "simple-folder" offered by user "user2"
+    And user "user2" has logged in using the webUI
+    When the user opens the share dialog for folder "simple-folder" using the webUI
+    Then user "User One" should be listed as "Advanced permissions" in the collaborators list for folder "simple-folder" on the webUI
+    And no custom permissions should be set for collaborator "User One" for folder "simple-folder" on the webUI
+
+  @skipOnOC10
   Scenario: Share a folder without share permissions using API and check if it is listed on the collaborators list for original owner
     Given user "user2" has shared folder "simple-folder" with user "user1" with "read" permissions
     And user "user1" has accepted the share "simple-folder" offered by user "user2"

--- a/tests/acceptance/features/webUISharingPermissionsUsers/sharePermissionsUsers.feature
+++ b/tests/acceptance/features/webUISharingPermissionsUsers/sharePermissionsUsers.feature
@@ -135,7 +135,7 @@ Feature: Sharing files and folders with internal users with different permission
       | role                 | displayed-role       | extra-permissions             | displayed-permissions | permissions                  |
       | Viewer               | Viewer               | ,                             | ,                     | read                         |
       | Editor               | Editor               | ,                             | ,                     | read, create, update, delete |
-      | Advanced permissions | Advanced permissions | create                        | create                | read, create                 |
+      | Advanced permissions | Advanced permissions | create                        | create, update        | read, create, update         |
       | Advanced permissions | Advanced permissions | update                        | update                | read, update                 |
       | Advanced permissions | Editor               | delete, create, update        | ,                     | read, delete, update, create |
 

--- a/tests/acceptance/features/webUISharingPermissionsUsers/sharePermissionsUsers.feature
+++ b/tests/acceptance/features/webUISharingPermissionsUsers/sharePermissionsUsers.feature
@@ -35,7 +35,7 @@ Feature: Sharing files and folders with internal users with different permission
     And user "user2" has logged in using the webUI
     Then custom permission "update" should be set for user "User One" for folder "simple-folder" on the webUI
     When the user sets custom permission for current role of collaborator "User One" for folder "simple-folder" to "create" using the webUI
-    Then custom permission "create" should be set for user "User One" for folder "simple-folder" on the webUI
+    Then custom permissions "create, update" should be set for user "User One" for folder "simple-folder" on the webUI
     And user "user1" should have received a share with these details:
       | field       | value                |
       | uid_owner   | user2                |
@@ -134,8 +134,8 @@ Feature: Sharing files and folders with internal users with different permission
     Examples:
       | role                 | displayed-role       | extra-permissions             | displayed-permissions | permissions                  |
       | Viewer               | Viewer               | ,                             | ,                     | read                         |
-      | Editor               | Editor               | ,                             | ,                     | all                          |
-      | Advanced permissions | Advanced permissions | create                        | create                | read                         |
+      | Editor               | Editor               | ,                             | ,                     | read, create, update, delete |
+      | Advanced permissions | Advanced permissions | create                        | create                | read, create                 |
       | Advanced permissions | Advanced permissions | update                        | update                | read, update                 |
       | Advanced permissions | Editor               | delete, create, update        | ,                     | read, delete, update, create |
 
@@ -346,12 +346,12 @@ Feature: Sharing files and folders with internal users with different permission
     And user "user1" has logged in using the webUI
     When the user opens folder "Shares" using the webUI
     And the user browses to the folder "simple-folder" on the files page
-    And the user shares folder "simple-empty-folder" with user "User Three" as "Advanced permissions" with permissions "share, delete, create, update" using the webUI
+    And the user shares folder "simple-empty-folder" with user "User Three" as "Advanced permissions" with permissions "delete, create, update" using the webUI
     And user "user3" accepts the share "simple-empty-folder" offered by user "user1" using the sharing API
     Then user "user3" should have received a share with these details:
-      | field       | value                |
-      | uid_owner   | user1                |
-      | share_with  | user3                |
-      | file_target | /simple-empty-folder |
-      | item_type   | folder               |
-      | permissions | all                  |
+      | field       | value                        |
+      | uid_owner   | user1                        |
+      | share_with  | user3                        |
+      | file_target | /simple-empty-folder         |
+      | item_type   | folder                       |
+      | permissions | read, delete, create, update |


### PR DESCRIPTION
## Description
We've attached the share permission of collaborators to roles. There is no longer a share additional permission. In oCIS, the share permission is hidden as it is not yet possible to enable re-sharing.