### PR TITLE
[tests-only] improve waiting when checking the not-existance on an item

### DIFF
--- a/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
+++ b/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
@@ -73,19 +73,12 @@ Feature: accept/decline shares coming from internal users
     Then User-based auto accepting checkbox should not be displayed on the personal sharing settings page in the webUI
 
   Scenario: User receives files when auto accept share is disabled
-    Given user "user1" has shared file "lorem.txt" with user "user2"
+    Given user "user1" has uploaded file with content "test" to "toshare.txt"
+    And user "user1" has shared file "toshare.txt" with user "user2"
     When the user browses to the shared-with-me page using the webUI
-    Then file "lorem.txt" shared by "User One" should be in "Pending" state on the webUI
+    Then file "toshare.txt" shared by "User One" should be in "Pending" state on the webUI
     When the user browses to the files page
-    Then file "lorem.txt" should not be listed on the webUI
-    And folder "Shares" should not be listed on the webUI
-
-  Scenario: shared file is in pending state when the Automatically accept incoming shares is disabled
-    Given user "user1" has shared file "lorem.txt" with user "user2"
-    When the user browses to the shared-with-me page using the webUI
-    Then file "lorem.txt" shared by "User One" should be in "Pending" state on the webUI
-    When the user browses to the files page
-    Then file "lorem.txt" should not be listed on the webUI
+    Then file "toshare.txt" should not be listed on the webUI
     And folder "Shares" should not be listed on the webUI
 
   Scenario: receive shares with same name from different users
@@ -97,29 +90,33 @@ Feature: accept/decline shares coming from internal users
     And file "lorem.txt" shared by "User Three" should be in "Pending" state on the webUI
 
   Scenario: decline an offered (pending) share
-    Given user "user1" has shared file "lorem.txt" with user "user2"
-    And user "user1" has shared file "testimage.jpg" with user "user2"
+    Given user "user1" has uploaded file with content "test" to "toshare.txt"
+    And user "user1" has uploaded file with content "test" to "anotherfile.txt"
+    And user "user1" has shared file "toshare.txt" with user "user2"
+    And user "user1" has shared file "anotherfile.txt" with user "user2"
     And the user has browsed to the shared-with-me page
-    When the user declines share "lorem.txt" offered by user "User One" using the webUI
-    Then file "lorem.txt" shared by "User One" should be in "Declined" state on the webUI
-    And file "testimage.jpg" shared by "User One" should be in "Pending" state on the webUI
+    When the user declines share "toshare.txt" offered by user "User One" using the webUI
+    Then file "toshare.txt" shared by "User One" should be in "Declined" state on the webUI
+    And file "anotherfile.txt" shared by "User One" should be in "Pending" state on the webUI
     When the user browses to the files page
-    Then file "lorem.txt" should not be listed on the webUI
-    And file "testimage.jpg" should not be listed on the webUI
+    Then file "toshare.txt" should not be listed on the webUI
+    And file "anotherfile.txt" should not be listed on the webUI
 
   Scenario: accept an offered (pending) share
-    Given user "user1" has shared file "lorem.txt" with user "user2"
-    And user "user1" has shared file "testimage.jpg" with user "user2"
+    Given user "user1" has uploaded file with content "test" to "toshare.txt"
+    And user "user1" has uploaded file with content "test" to "anotherfile.txt"
+    And user "user1" has shared file "toshare.txt" with user "user2"
+    And user "user1" has shared file "anotherfile.txt" with user "user2"
     And the user has browsed to the shared-with-me page
-    When the user accepts share "lorem.txt" offered by user "User One" using the webUI
-    Then file "lorem.txt" shared by "User One" should be in "Accepted" state on the webUI
-    And file "testimage.jpg" shared by "User One" should be in "Pending" state on the webUI
-    And the file "lorem.txt" shared by "User One" should be in "Accepted" state on the webUI after a page reload
-    And the file "testimage.jpg" shared by "User One" should be in "Pending" state on the webUI after a page reload
+    When the user accepts share "toshare.txt" offered by user "User One" using the webUI
+    Then file "toshare.txt" shared by "User One" should be in "Accepted" state on the webUI
+    And file "anotherfile.txt" shared by "User One" should be in "Pending" state on the webUI
+    And the file "toshare.txt" shared by "User One" should be in "Accepted" state on the webUI after a page reload
+    And the file "anotherfile.txt" shared by "User One" should be in "Pending" state on the webUI after a page reload
     When the user browses to the files page
     And the user opens folder "Shares" using the webUI
-    Then file "lorem.txt" should be listed on the webUI
-    And file "testimage.jpg" should not be listed on the webUI
+    Then file "toshare.txt" should be listed on the webUI
+    And file "anotherfile.txt" should not be listed on the webUI
 
   @skipOnOCIS @ocis-product-276
   Scenario: accept a previously declined share

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -381,6 +381,7 @@ Feature: Sharing files and folders with internal users
     And the user opens folder "simple-folder" using the webUI
     Then file "collaborate-on-this.txt" should be listed on the webUI
 
+  @skipOnOCIS @issue-ocis-730
   Scenario: deleting an entry on the shared-with-me page unshares from self
     Given user "user1" has shared folder "simple-folder" with user "user2"
     And user "user2" has accepted the share "simple-folder" offered by user "user1"

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -265,8 +265,7 @@ module.exports = {
         })
         .useCss()
       // Wait for preview to be loaded
-      this.waitForThumbnailLoaded(fileName, elementType)
-      return this
+      return this.waitForThumbnailLoaded(fileName, elementType)
     },
     /**
      * Wait for all visible thumbnails to finish loading
@@ -385,14 +384,14 @@ module.exports = {
      * @returns {boolean}
      */
     isElementListed: async function(element, elementType = 'file') {
-      let isListed = true
-      await this.waitForElementVisible('@filesTable')
-        .useXpath()
-        .waitForElementNotPresent('@loadingIndicator')
-        .api.elements('xpath', this.getFileRowSelectorByFileName(element, elementType), result => {
-          isListed = result.value.length > 0
+      let isListed = false
+      await this.waitForFileVisible(element, elementType)
+        .then(function() {
+          isListed = true
         })
-        .useCss()
+        .catch(function() {
+          isListed = false
+        })
       return isListed
     },
     /**

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -409,14 +409,20 @@ Then('the last uploaded folder should be listed on the webUI', async function() 
   return client
 })
 
-Then('file {string} should not be listed on the webUI', async function(file) {
-  const state = await client.page.FilesPageElement.filesList().isElementListed(file, 'file')
-  return client.assert.ok(!state, `Error: Resource ${file} is listed on the filesList`)
+Then('file {string} should not be listed on the webUI', function(file) {
+  return client.page.FilesPageElement.filesList()
+    .isElementListed(file, 'file')
+    .then(state => {
+      return client.assert.ok(!state, `Error: File ${file} is listed on the filesList`)
+    })
 })
 
 Then('folder {string} should not be listed on the webUI', async folder => {
-  const state = await client.page.FilesPageElement.filesList().isElementListed(folder, 'folder')
-  return client.assert.ok(!state, `Error: Resource ${folder} is listed on the filesList`)
+  return client.page.FilesPageElement.filesList()
+    .isElementListed(folder, 'folder')
+    .then(state => {
+      return client.assert.ok(!state, `Error: Folder ${folder} is listed on the filesList`)
+    })
 })
 
 Then('the deleted elements should not be listed on the webUI', function() {


### PR DESCRIPTION
## Description
when checking that an item does not exist, the code returned too early (before the list got rendered) and also did not scroll down trying to find the item. To reduce false-positives use the existing `waitForFileVisible` method

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...