### PR TITLE
Revert "[CI] Fix CI trigger on push and heads/master"

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -359,10 +359,9 @@ def yarnlint():
 		'depends_on': [],
 		'trigger': {
 			'ref': [
+				'refs/heads/master',
 				'refs/tags/**',
 				'refs/pull/**',
-				'refs/pull-requests/**',
-				'refs/merge-requests/**',
 			]
 		}
 	}
@@ -399,7 +398,6 @@ def build(ctx):
 		'depends_on': [],
 		'trigger': {
 			'ref': [
-				'refs/merge-requests/**',
 				'refs/heads/master',
 				'refs/tags/**',
 			]
@@ -646,8 +644,6 @@ def acceptance():
 								'ref': [
 									'refs/tags/**',
 									'refs/pull/**',
-									'refs/pull-requests/**',
-									'refs/merge-requests/**',
 								]
 							},
 							'volumes': [{

--- a/.drone.star
+++ b/.drone.star
@@ -7,6 +7,8 @@ config = {
 
 	'branches': [
 		'master',
+		'release*',
+		'develop*'
 	],
 
 	'yarnlint': True,
@@ -299,14 +301,7 @@ config = {
 		'acceptance': {
 			'ocisBranch': 'master',
 			'ocisCommit': 'd1543f76a29c06ab2640c613a5429e401f23ce2a',
-		},
-	},
-
-	'trigger': {
-		'ref': [
-			'refs/tags/**',
-			'refs/pull/**',
-		]
+		}
 	},
 
 	'build': True
@@ -363,7 +358,12 @@ def yarnlint():
 			lintTest(),
 		'depends_on': [],
 		'trigger': {
-			'ref': list(config['trigger']['ref'])
+			'ref': [
+				'refs/tags/**',
+				'refs/pull/**',
+				'refs/pull-requests/**',
+				'refs/merge-requests/**',
+			]
 		}
 	}
 
@@ -397,7 +397,13 @@ def build(ctx):
 			buildRelease(ctx) +
 			buildDockerImage(),
 		'depends_on': [],
-		'trigger': config['trigger']
+		'trigger': {
+			'ref': [
+				'refs/merge-requests/**',
+				'refs/heads/master',
+				'refs/tags/**',
+			]
+		}
 	}
 
 	pipelines.append(result)
@@ -492,7 +498,12 @@ def changelog(ctx):
 			},
 			],
 		'depends_on': [],
-		'trigger': config['trigger']
+		'trigger': {
+			'ref': [
+				'refs/heads/master',
+				'refs/pull/**',
+			],
+		},
 	}
 
 	pipelines.append(result)
@@ -632,7 +643,12 @@ def acceptance():
 								),
 							'depends_on': [],
 							'trigger': {
-								'ref': list(config['trigger']['ref'])
+								'ref': [
+									'refs/tags/**',
+									'refs/pull/**',
+									'refs/pull-requests/**',
+									'refs/merge-requests/**',
+								]
 							},
 							'volumes': [{
 								'name': 'uploads',
@@ -1138,7 +1154,12 @@ def website(ctx):
 			},
 		],
 		'depends_on': [],
-		'trigger': config['trigger'],
+		'trigger': {
+			'ref': [
+				'refs/heads/master',
+				'refs/pull/**',
+			],
+		},
 	}
   ]
 


### PR DESCRIPTION
This PR reverts a commit that breaks changelogs on CI. Needs some changes on top.

- [ ] remove `release` and `develop` branches from list of branches
- [ ] make trigger config more explicit. we only want to have triggers on master, so we don't need to iterate on the list of branches. can state `master` explicitly.