### PR TITLE
[Tests-Only] Rephrase "following file should be listed on the webUI" step

### DIFF
--- a/tests/acceptance/features/webUIFiles/copy.feature
+++ b/tests/acceptance/features/webUIFiles/copy.feature
@@ -29,13 +29,13 @@ Feature: copy files and folders
     Given user "user1" has logged in using the webUI
     And the user has browsed to the files page
     When the user batch copies these files into folder "simple-empty-folder" using the webUI
-      | name        |
+      | file_name   |
       | data.zip    |
       | lorem.txt   |
       | testapp.zip |
     Then breadcrumb for folder "simple-empty-folder" should be displayed on the webUI
-    And the following file should be listed on the webUI
-      | name-parts  |
+    And the following files should be listed on the webUI
+      | file_name   |
       | data.zip    |
       | lorem.txt   |
       | testapp.zip |

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -44,13 +44,13 @@ Feature: move files
     Given user "user1" has logged in using the webUI
     And the user has browsed to the files page
     When the user batch moves these files into folder "simple-empty-folder" using the webUI
-      | name        |
+      | file_name   |
       | data.zip    |
       | lorem.txt   |
       | testapp.zip |
     Then breadcrumb for folder "simple-empty-folder" should be displayed on the webUI
-    And the following file should be listed on the webUI
-      | name-parts  |
+    And the following files should be listed on the webUI
+      | file_name   |
       | data.zip    |
       | lorem.txt   |
       | testapp.zip |

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature
@@ -41,8 +41,8 @@ Feature: move folders
       | strängé नेपाली folder |
     Then breadcrumb for folder "simple-empty-folder" should be displayed on the webUI
     And the following folders should be listed on the webUI
-      | name-parts           |
-      | simple-folder        |
+      | folders               |
+      | simple-folder         |
       | strängé नेपाली folder |
 
   Scenario Outline: move a folder into another folder (problematic characters)

--- a/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
+++ b/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
@@ -76,7 +76,7 @@ Feature: rename folders
       | simple-empty-folder   | Test" 'me o'ut"            |
     And the user reloads the current page of the webUI
     Then these folders should be listed on the webUI
-      | files                      |
+      | folders                    |
       | '"First 'single" quotes" ' |
       | Test" 'me o'ut"            |
     When the user renames the following folder using the webUI
@@ -85,9 +85,9 @@ Feature: rename folders
       | Test" 'me o'ut"            | another normal folder |
     And the user reloads the current page of the webUI
     Then these folders should be listed on the webUI
-      | files                   |
-      | a normal folder         |
-      | another normal folder   |
+      | folders               |
+      | a normal folder       |
+      | another normal folder |
 
   # These are valid file names for ocis
   @skipOnOCIS

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -981,18 +981,6 @@ When('user {string} has renamed the following file', function(user, table) {
   return webdav.move(user, fromName, toName)
 })
 
-Then('the following file should be listed on the webUI', async function(table) {
-  const resources = table.hashes().map(data => data['name-parts'])
-
-  for (const resource of resources) {
-    const found = await client.page.FilesPageElement.filesList().isElementListed(resource)
-
-    assert.strictEqual(found, true, `Element ${resource} is not present on the filesList!`)
-  }
-
-  return true
-})
-
 Then('the following file should not be listed on the webUI', async function(table) {
   const name = table
     .hashes()


### PR DESCRIPTION

## Description
Rephrase `the following file/folder should be listed on the webUI` step

## Related Issue
- Fixes https://github.com/owncloud/phoenix/issues/4215

## How Has This Been Tested?
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 