### PR TITLE
Add auto-close capability to alerts

### DIFF
--- a/apps/draw-io/src/DrawIoEditor.vue
+++ b/apps/draw-io/src/DrawIoEditor.vue
@@ -52,7 +52,10 @@ export default {
       this.showMessage({
         title: this.$gettext('PDF could not be loaded…'),
         desc: error,
-        status: 'danger'
+        status: 'danger',
+        autoClose: {
+          enabled: true
+        }
       })
     },
 

--- a/apps/files/src/components/AllFilesList.vue
+++ b/apps/files/src/components/AllFilesList.vue
@@ -264,7 +264,10 @@ export default {
           this.showMessage({
             title: this.$gettext('Loading folder failed…'),
             desc: error.message,
-            status: 'danger'
+            status: 'danger',
+            autoClose: {
+              enabled: true
+            }
           })
         })
     },

--- a/apps/files/src/components/FilesAppBar.vue
+++ b/apps/files/src/components/FilesAppBar.vue
@@ -397,7 +397,10 @@ export default {
         this.showMessage({
           title: this.$gettext('Loading folder failed…'),
           desc: error.message,
-          status: 'danger'
+          status: 'danger',
+          autoClose: {
+            enabled: true
+          }
         })
       })
     },
@@ -465,7 +468,10 @@ export default {
             this.showMessage({
               title: this.$gettext('Creating folder failed…'),
               desc: error,
-              status: 'danger'
+              status: 'danger',
+              autoClose: {
+                enabled: true
+              }
             })
           })
           .finally(() => {
@@ -537,7 +543,10 @@ export default {
           this.showMessage({
             title: this.$gettext('Creating file failed…'),
             desc: error,
-            status: 'danger'
+            status: 'danger',
+            autoClose: {
+              enabled: true
+            }
           })
         })
       }
@@ -627,7 +636,10 @@ export default {
         .clearTrashBin()
         .then(() => {
           this.showMessage({
-            title: this.$gettext('All deleted files were removed')
+            title: this.$gettext('All deleted files were removed'),
+            autoClose: {
+              enabled: true
+            }
           })
           this.removeFilesFromTrashbin(this.activeFiles)
         })
@@ -635,7 +647,10 @@ export default {
           this.showMessage({
             title: this.$gettext('Could not delete files'),
             desc: error.message,
-            status: 'danger'
+            status: 'danger',
+            autoClose: {
+              enabled: true
+            }
           })
         })
     },
@@ -647,7 +662,10 @@ export default {
           .then(() => {
             const translated = this.$gettext('%{file} was restored successfully')
             this.showMessage({
-              title: this.$gettextInterpolate(translated, { file: file.name }, true)
+              title: this.$gettextInterpolate(translated, { file: file.name }, true),
+              autoClose: {
+                enabled: true
+              }
             })
             this.removeFilesFromTrashbin([file])
           })
@@ -656,7 +674,10 @@ export default {
             this.showMessage({
               title: this.$gettextInterpolate(translated, { file: file.name }, true),
               desc: error.message,
-              status: 'danger'
+              status: 'danger',
+              autoClose: {
+                enabled: true
+              }
             })
           })
       }

--- a/apps/files/src/components/LocationPicker/LocationPicker.vue
+++ b/apps/files/src/components/LocationPicker/LocationPicker.vue
@@ -391,7 +391,10 @@ export default {
         this.showMessage({
           title: this.$gettextInterpolate(title, { resource: errors[0].resource }, true),
           desc: errors[0].message,
-          status: 'danger'
+          status: 'danger',
+          autoClose: {
+            enabled: true
+          }
         })
 
         return
@@ -420,7 +423,10 @@ export default {
         this.showMessage({
           title,
           desc: this.$gettextInterpolate(desc, { count: errors.length }, false),
-          status: 'danger'
+          status: 'danger',
+          autoClose: {
+            enabled: true
+          }
         })
         console.error('Move / copy failed:', errors)
 

--- a/apps/files/src/components/Trashbin.vue
+++ b/apps/files/src/components/Trashbin.vue
@@ -142,7 +142,10 @@ export default {
           this.removeFilesFromTrashbin([file])
           const translated = this.$gettext('%{file} was restored successfully')
           this.showMessage({
-            title: this.$gettextInterpolate(translated, { file: file.name }, true)
+            title: this.$gettextInterpolate(translated, { file: file.name }, true),
+            autoClose: {
+              enabled: true
+            }
           })
         })
         .catch(error => {
@@ -150,7 +153,10 @@ export default {
           this.showMessage({
             title: this.$gettextInterpolate(translated, { file: file.name }, true),
             desc: error.message,
-            status: 'danger'
+            status: 'danger',
+            autoClose: {
+              enabled: true
+            }
           })
         })
       this.resetFileSelection()

--- a/apps/files/src/fileactions.js
+++ b/apps/files/src/fileactions.js
@@ -184,7 +184,10 @@ export default {
         const title = this.$gettextInterpolate(translated, { file: file.name }, true)
         this.showMessage({
           title: title,
-          status: 'danger'
+          status: 'danger',
+          autoClose: {
+            enabled: true
+          }
         })
       })
     },
@@ -236,7 +239,10 @@ export default {
           )
           this.showMessage({
             title: title,
-            status: 'danger'
+            status: 'danger',
+            autoClose: {
+              enabled: true
+            }
           })
         })
     },

--- a/apps/files/src/mixins.js
+++ b/apps/files/src/mixins.js
@@ -230,7 +230,10 @@ export default {
                 { folder: item.name },
                 true
               ),
-              status: 'danger'
+              status: 'danger',
+              autoClose: {
+                enabled: true
+              }
             })
 
             continue
@@ -301,7 +304,10 @@ export default {
         this.showMessage({
           title: this.$gettext('Upload failed'),
           desc: this.$gettext('Upload of a folder is not supported in Internet Explorer.'),
-          status: 'danger'
+          status: 'danger',
+          autoClose: {
+            enabled: true
+          }
         })
         return
       }
@@ -321,7 +327,10 @@ export default {
             { folder: directoryName },
             true
           ),
-          status: 'danger'
+          status: 'danger',
+          autoClose: {
+            enabled: true
+          }
         })
       } else {
         // Get folder structure

--- a/apps/files/src/mixins/deleteResources.js
+++ b/apps/files/src/mixins/deleteResources.js
@@ -109,7 +109,10 @@ export default {
           this.removeFilesFromTrashbin([resource])
           const translated = this.$gettext('%{file} was successfully deleted')
           this.showMessage({
-            title: this.$gettextInterpolate(translated, { file: resource.name }, true)
+            title: this.$gettextInterpolate(translated, { file: resource.name }, true),
+            autoClose: {
+              enabled: true
+            }
           })
         })
         .catch(error => {
@@ -126,7 +129,10 @@ export default {
           this.showMessage({
             title: this.$gettextInterpolate(translated, { file: resource.name }, true),
             desc: error.message,
-            status: 'danger'
+            status: 'danger',
+            autoClose: {
+              enabled: true
+            }
           })
         })
     },

--- a/apps/files/src/quickActions.js
+++ b/apps/files/src/quickActions.js
@@ -29,7 +29,10 @@ function createPublicLink(ctx) {
           desc: $gettext(
             'Public link has been successfully created and copied into your clipboard.'
           ),
-          status: 'success'
+          status: 'success',
+          autoClose: {
+            enabled: true
+          }
         })
         resolve()
       })

--- a/apps/files/src/store/actions.js
+++ b/apps/files/src/store/actions.js
@@ -362,7 +362,10 @@ export default {
               'showMessage',
               {
                 title: $gettext('Loading folder failed…'),
-                status: 'danger'
+                status: 'danger',
+                autoClose: {
+                  enabled: true
+                }
               },
               { root: true }
             )
@@ -441,7 +444,10 @@ export default {
             'showMessage',
             {
               title: $gettext('Loading list of deleted files has failed…'),
-              status: 'danger'
+              status: 'danger',
+              autoClose: {
+                enabled: true
+              }
             },
             { root: true }
           )
@@ -461,7 +467,10 @@ export default {
           {
             title: $gettext('Loading list of deleted files has failed…'),
             desc: e.message,
-            status: 'danger'
+            status: 'danger',
+            autoClose: {
+              enabled: true
+            }
           },
           { root: true }
         )
@@ -498,7 +507,10 @@ export default {
           {
             title: $gettext('Loading shared files failed…'),
             desc: e.message,
-            status: 'danger'
+            status: 'danger',
+            autoClose: {
+              enabled: true
+            }
           },
           { root: true }
         )
@@ -535,7 +547,10 @@ export default {
           {
             title: $gettext('Loading shared files failed…'),
             desc: e.message,
-            status: 'danger'
+            status: 'danger',
+            autoClose: {
+              enabled: true
+            }
           },
           { root: true }
         )
@@ -632,7 +647,10 @@ export default {
             'showMessage',
             {
               title: title,
-              status: 'danger'
+              status: 'danger',
+              autoClose: {
+                enabled: true
+              }
             },
             { root: true }
           )
@@ -685,7 +703,10 @@ export default {
             {
               title: this.$gettext('Error while searching.'),
               desc: error.message,
-              status: 'danger'
+              status: 'danger',
+              autoClose: {
+                enabled: true
+              }
             },
             { root: true }
           )
@@ -793,7 +814,10 @@ export default {
             {
               title: $gettext('Error while sharing.'),
               desc: e,
-              status: 'danger'
+              status: 'danger',
+              autoClose: {
+                enabled: true
+              }
             },
             { root: true }
           )
@@ -821,7 +845,10 @@ export default {
           {
             title: $gettext('Error while sharing.'),
             desc: e,
-            status: 'danger'
+            status: 'danger',
+            autoClose: {
+              enabled: true
+            }
           },
           { root: true }
         )
@@ -998,7 +1025,10 @@ export default {
           {
             title: $gettext('Error while changing share state'),
             desc: e.message,
-            status: 'danger'
+            status: 'danger',
+            autoClose: {
+              enabled: true
+            }
           },
           { root: true }
         )

--- a/apps/media-viewer/src/mixins/loader.js
+++ b/apps/media-viewer/src/mixins/loader.js
@@ -77,7 +77,10 @@ export default {
             this.showMessage({
               title: this.$gettext('Loading folder failed…'),
               desc: error.message,
-              status: 'danger'
+              status: 'danger',
+              autoClose: {
+                enabled: true
+              }
             })
           })
       }

--- a/changelog/unreleased/autoclose-alerts
+++ b/changelog/unreleased/autoclose-alerts
@@ -1,0 +1,7 @@
+Enhancement: Auto-close alerts
+
+We've added a property which enables alerts to be automatically closed.
+When enabling the auto-close, it will get assigned timeout of 5 seconds.
+Default timeout can be overwritten inside of the `autoClose` object.
+
+https://github.com/owncloud/phoenix/pull/4236

--- a/src/components/Notifications.vue
+++ b/src/components/Notifications.vue
@@ -93,7 +93,10 @@ export default {
         this.showMessage({
           title: this.$gettext('Loading folder failed…'),
           desc: error.message,
-          status: 'danger'
+          status: 'danger',
+          autoClose: {
+            enabled: true
+          }
         })
       })
     }

--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -84,7 +84,10 @@ export default {
           this.showMessage({
             title: this.$gettext('Search failed'),
             desc: e.message,
-            status: 'danger'
+            status: 'danger',
+            autoClose: {
+              enabled: true
+            }
           })
         })
         .finally(() => {

--- a/src/plugins/phoenix.js
+++ b/src/plugins/phoenix.js
@@ -76,7 +76,10 @@ export default {
             this.showMessage({
               title: this.$gettext('Download failed'),
               desc: this.$gettext('File could not be located'),
-              status: 'danger'
+              status: 'danger',
+              autoClose: {
+                enabled: true
+              }
             })
             return
           }
@@ -96,7 +99,10 @@ export default {
               this.showMessage({
                 title: this.$gettext('Download failed'),
                 desc: request.statusText,
-                status: 'danger'
+                status: 'danger',
+                autoClose: {
+                  enabled: true
+                }
               })
 
               // Remove item from progress queue in case the request failed

--- a/src/store/app.js
+++ b/src/store/app.js
@@ -12,8 +12,15 @@ const actions = {
   toggleSidebar(context, visible) {
     context.commit('TOGGLE_SIDEBAR', visible)
   },
-  showMessage(context, message) {
-    context.commit('ENQUEUE_MESSAGE', message)
+  showMessage({ commit }, message) {
+    commit('ENQUEUE_MESSAGE', message)
+
+    // auto close message if desired
+    if (message.autoClose && message.autoClose.enabled === true) {
+      setTimeout(() => {
+        commit('REMOVE_MESSAGE', message)
+      }, message.autoClose.timeout || 5000)
+    }
   },
   deleteMessage(context, mId) {
     context.commit('REMOVE_MESSAGE', mId)
@@ -64,10 +71,12 @@ const actions = {
 const mutations = {
   ENQUEUE_MESSAGE(state, message) {
     // set random id to improve iteration in v-for & lodash
-    if (!message.id)
+    if (!message.id) {
       message.id = Math.random()
         .toString(36)
         .slice(2, -1)
+    }
+
     state.messages.push(message)
   },
   REMOVE_MESSAGE(state, item) {

--- a/src/store/settings.js
+++ b/src/store/settings.js
@@ -20,7 +20,10 @@ const actions = {
       dispatch('showMessage', {
         title: 'Failed to load settings values.',
         desc: error.response.statusText,
-        status: 'danger'
+        status: 'danger',
+        autoClose: {
+          enabled: true
+        }
       })
     }
   }


### PR DESCRIPTION
## Description
We've added a property which enables alerts to be automatically closed.
When enabling the auto-close, it will get assigned timeout of 5 seconds.
Default timeout can be overwritten inside of the `autoClose` object.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/owncloud-design-system/issues/766