### PR TITLE
[tests-only] use shorter timeout for 'should not be listed' steps

### DIFF
--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -42,6 +42,7 @@ module.exports = {
       launch_url: LOCAL_LAUNCH_URL,
       globals: {
         waitForConditionTimeout: 20000,
+        waitForNegativeConditionTimeout: 1000,
         waitForConditionPollInterval: 10,
         filesForUpload: REMOTE_UPLOAD_DIR,
         mountedUploadDir: LOCAL_UPLOAD_DIR,

--- a/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
@@ -70,8 +70,8 @@ Feature: deleting files and folders
     Then as "user1" file "data.zip" should not exist
     And as "user1" file "lorem.txt" should not exist
     And as "user1" folder "simple-folder" should not exist
-    And the folder should be empty on the webUI
-    And the folder should be empty on the webUI after a page reload
+    And there should be no resources listed on the webUI
+    And there should be no resources listed on the webUI after a page reload
     And no message should be displayed on the webUI
 
   @ocis-reva-issue-106 @skipOnOCIS @ocis-reve-issue-442

--- a/tests/acceptance/features/webUITrashbinDelete/trashbinDelete.feature
+++ b/tests/acceptance/features/webUITrashbinDelete/trashbinDelete.feature
@@ -98,7 +98,7 @@ Feature: files and folders can be deleted from the trashbin
   Scenario: Select all files and delete from trashbin in a batch
     When the user marks all files for batch action using the webUI
     And the user batch deletes the marked files using the webUI
-    Then the folder should be empty on the webUI
+    Then there should be no resources listed on the webUI
 
   @skipOnOC10
   @issue-product-188
@@ -120,7 +120,7 @@ Feature: files and folders can be deleted from the trashbin
   Scenario: Clear trashbin
     When the user clears the trashbin
     Then the success message with header "All deleted files were removed" should be displayed on the webUI
-    And the trashbin should be empty on the webUI
+    And there should be no resources listed on the webUI
 
   @skipOnOC10
   @issue-product-139

--- a/tests/acceptance/features/webUITrashbinRestore/trashbinRestore.feature
+++ b/tests/acceptance/features/webUITrashbinRestore/trashbinRestore.feature
@@ -107,9 +107,10 @@ Feature: Restore deleted files/folders
       | lorem-big.txt |
       | simple-folder |
     And the user has browsed to the trashbin page
-    And the user marks all files for batch action using the webUI
+    When the user marks all files for batch action using the webUI
     And the user batch restores the marked files using the webUI
-    Then the folder should be empty on the webUI after a page reload
+    Then there should be no resources listed on the webUI
+    And there should be no resources listed on the webUI after a page reload
     When the user browses to the files page
     Then file "lorem.txt" should be listed on the webUI
     And file "lorem-big.txt" should be listed on the webUI

--- a/tests/acceptance/features/webUITrashbinRestore/trashbinRestore.feature
+++ b/tests/acceptance/features/webUITrashbinRestore/trashbinRestore.feature
@@ -20,8 +20,7 @@ Feature: Restore deleted files/folders
     Then file "sample,1.txt" should be listed on the webUI
     When the user restores file "data.zip" from the trashbin using the webUI
     When the user restores file "sample,1.txt" from the trashbin using the webUI
-    Then file "data.zip" should not be listed on the webUI
-    Then file "sample,1.txt" should not be listed on the webUI
+    Then there should be no resources listed on the webUI
     When the user browses to the files page
     Then file "data.zip" should be listed on the webUI
     Then file "sample,1.txt" should be listed on the webUI
@@ -34,8 +33,7 @@ Feature: Restore deleted files/folders
     And folder "Folder,With,Comma" should be listed on the webUI
     When the user restores folder "folder with space" from the trashbin using the webUI
     And the user restores folder "Folder,With,Comma" from the trashbin using the webUI
-    Then file "folder with space" should not be listed on the webUI
-    And file "Folder,With,Comma" should not be listed on the webUI
+    Then there should be no resources listed on the webUI
     When the user browses to the files page
     Then folder "folder with space" should be listed on the webUI
     And folder "Folder,With,Comma" should be listed on the webUI

--- a/tests/acceptance/features/webUITrashbinRestore/trashbinRestore.feature
+++ b/tests/acceptance/features/webUITrashbinRestore/trashbinRestore.feature
@@ -99,6 +99,7 @@ Feature: Restore deleted files/folders
     But file "lorem.txt" should not be listed on the webUI
     And file "lorem-big.txt" should not be listed on the webUI
 
+  @skipOnOC10 @issue-core-38039
   Scenario: Select all trashbin files and restore them in a batch
     Given the following files have been deleted by user "user1"
       | name          |

--- a/tests/acceptance/helpers/navigationHelper.js
+++ b/tests/acceptance/helpers/navigationHelper.js
@@ -7,7 +7,6 @@ module.exports = {
    */
   navigateAndWaitTillLoaded: function(url, loadingIndicatorSelector) {
     client.url(url)
-    client.refresh() // IE11 needs an extra refresh because of the hash in the url
     const locator = {}
     if (typeof loadingIndicatorSelector === 'object') {
       locator.selector = loadingIndicatorSelector.selector
@@ -30,7 +29,6 @@ module.exports = {
    */
   navigateAndWaitTillElementPresent: function(url, ElementSelector) {
     client.url(url)
-    client.refresh() // IE11 needs an extra refresh because of the hash in the url
     const locator = {}
     if (typeof ElementSelector === 'object') {
       locator.selector = ElementSelector.selector

--- a/tests/acceptance/helpers/navigationHelper.js
+++ b/tests/acceptance/helpers/navigationHelper.js
@@ -7,6 +7,7 @@ module.exports = {
    */
   navigateAndWaitTillLoaded: function(url, loadingIndicatorSelector) {
     client.url(url)
+    client.refresh() // IE11 needs an extra refresh because of the hash in the url
     const locator = {}
     if (typeof loadingIndicatorSelector === 'object') {
       locator.selector = loadingIndicatorSelector.selector
@@ -29,6 +30,7 @@ module.exports = {
    */
   navigateAndWaitTillElementPresent: function(url, ElementSelector) {
     client.url(url)
+    client.refresh() // IE11 needs an extra refresh because of the hash in the url
     const locator = {}
     if (typeof ElementSelector === 'object') {
       locator.selector = ElementSelector.selector

--- a/tests/acceptance/helpers/navigationHelper.js
+++ b/tests/acceptance/helpers/navigationHelper.js
@@ -16,7 +16,11 @@ module.exports = {
       throw new Error('Invalid type for loading indicator selector')
     }
     return client
-      .waitForElementPresent({ ...locator, abortOnFailure: false }) // don't fail if we are too late
+      .waitForElementPresent({
+        ...locator,
+        abortOnFailure: false, // don't fail if we are too late
+        timeout: client.globals.waitForNegativeConditionTimeout
+      })
       .waitForElementNotPresent(locator)
   },
 
@@ -34,6 +38,10 @@ module.exports = {
     } else {
       throw new Error('Invalid type for element selector')
     }
-    return client.waitForElementPresent({ ...locator, abortOnFailure: false }) // don't fail if we are too late
+    return client.waitForElementPresent({
+      ...locator,
+      abortOnFailure: false, // don't fail if we are too late
+      timeout: client.globals.waitForNegativeConditionTimeout
+    })
   }
 }

--- a/tests/acceptance/pageObjects/FilesPageElement/SharingDialog/collaboratorsDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/SharingDialog/collaboratorsDialog.js
@@ -51,13 +51,24 @@ module.exports = {
      *
      * @param {Object.<String,Object>} subSelectors Map of arbitrary attribute name to selector to query
      * inside the collaborator element, defaults to all when null
+     * @param filterDisplayName
+     * @param timeout
      * @returns {Promise.<string[]>} Array of users/groups in share list
      */
-    getCollaboratorsList: async function(subSelectors = null, filterDisplayName = null) {
+    getCollaboratorsList: async function(
+      subSelectors = null,
+      filterDisplayName = null,
+      timeout = null
+    ) {
       let results = []
       let informationSelector = {
         selector: '@collaboratorsInformation',
         abortOnFailure: false
+      }
+      if (timeout === null) {
+        timeout = this.api.globals.waitForConditionTimeout
+      } else {
+        timeout = parseInt(timeout, 10)
       }
       if (filterDisplayName !== null) {
         informationSelector = {
@@ -66,7 +77,8 @@ module.exports = {
             filterDisplayName
           ),
           locateStrategy: this.elements.collaboratorInformationByCollaboratorName.locateStrategy,
-          abortOnFailure: false
+          abortOnFailure: false,
+          timeout: timeout
         }
       }
 
@@ -84,8 +96,9 @@ module.exports = {
 
       let collaboratorsElementIds = null
       await this.initAjaxCounters()
-        .waitForElementPresent(informationSelector)
         .waitForOutstandingAjaxCalls()
+        .waitForAnimationToFinish()
+        .waitForElementPresent(informationSelector)
         .api.elements('css selector', this.elements.collaboratorsInformation, result => {
           collaboratorsElementIds = result.value.map(item => item[Object.keys(item)[0]])
         })

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -423,6 +423,7 @@ module.exports = {
       let visible = false
       let elementId = null
       await this.waitForElementNotPresent('@filesListProgressBar')
+      await this.waitForElementVisible('@filesListNoContentMessage')
       await this.api.element('@filesListNoContentMessage', result => {
         if (result.status !== -1) {
           elementId = result.value.ELEMENT

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -242,16 +242,24 @@ module.exports = {
      *
      * @param {string} fileName
      * @param {string} elementType
+     * @param timeout
      */
-    waitForFileVisible: async function(fileName, elementType = 'file') {
+    waitForFileVisible: async function(fileName, elementType = 'file', timeout = null) {
       const linkSelector = this.getFileLinkSelectorByFileName(fileName, elementType)
 
       await this.waitForElementPresent('@filesTableContainer')
       await this.filesListScrollToTop()
       // Find the item in files list if it's not in the view
       await this.findItemInFilesList(fileName)
+
+      // getAttribute does not have a timeout parameter, so we need to set the global timeout
+      const oldWaitForConditionTimeout = client.globals.waitForConditionTimeout
+      if (timeout !== null) {
+        client.globals.waitForConditionTimeout = parseInt(timeout, 10)
+      }
       await this.useXpath()
         .getAttribute(linkSelector, 'filename', function(result) {
+          client.globals.waitForConditionTimeout = oldWaitForConditionTimeout
           if (result.value.error) {
             this.assert.fail(result.value.error)
           }
@@ -381,11 +389,12 @@ module.exports = {
      *
      * @param {string} element Name of the file/folder/resource
      * @param {string} elementType
+     * @param timeout
      * @returns {boolean}
      */
-    isElementListed: async function(element, elementType = 'file') {
+    isElementListed: async function(element, elementType = 'file', timeout = null) {
       let isListed = false
-      await this.waitForFileVisible(element, elementType)
+      await this.waitForFileVisible(element, elementType, timeout)
         .then(function() {
           isListed = true
         })

--- a/tests/acceptance/pageObjects/phoenixPage.js
+++ b/tests/acceptance/pageObjects/phoenixPage.js
@@ -50,7 +50,11 @@ module.exports = {
         .waitForElementVisible(menuItemSelector)
         .click(menuItemSelector)
         .api.page.FilesPageElement.filesList()
-        .waitForElementPresent({ selector: '@filesListProgressBar', abortOnFailure: false }) // don't fail if we are too late
+        .waitForElementPresent({
+          selector: '@filesListProgressBar',
+          abortOnFailure: false, // don't fail if we are too late
+          timeout: this.api.globals.waitForNegativeConditionTimeout
+        })
         .waitForElementNotPresent('@filesListProgressBar')
         .useCss()
 

--- a/tests/acceptance/pageObjects/publicLinkPasswordPage.js
+++ b/tests/acceptance/pageObjects/publicLinkPasswordPage.js
@@ -45,7 +45,11 @@ module.exports = {
           .click('@passwordSubmitButton')
 
         return this.page.FilesPageElement.filesList()
-          .waitForElementPresent({ selector: '@filesListProgressBar', abortOnFailure: false }) // don't fail if we are too late
+          .waitForElementPresent({
+            selector: '@filesListProgressBar',
+            abortOnFailure: false, // don't fail if we are too late
+            timeout: this.api.globals.waitForNegativeConditionTimeout
+          })
           .waitForElementNotPresent('@filesListProgressBar')
       },
       /**

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -411,7 +411,7 @@ Then('the last uploaded folder should be listed on the webUI', async function() 
 
 Then('file {string} should not be listed on the webUI', function(file) {
   return client.page.FilesPageElement.filesList()
-    .isElementListed(file, 'file')
+    .isElementListed(file, 'file', client.globals.waitForNegativeConditionTimeout)
     .then(state => {
       return client.assert.ok(!state, `Error: File ${file} is listed on the filesList`)
     })
@@ -419,7 +419,7 @@ Then('file {string} should not be listed on the webUI', function(file) {
 
 Then('folder {string} should not be listed on the webUI', async folder => {
   return client.page.FilesPageElement.filesList()
-    .isElementListed(folder, 'folder')
+    .isElementListed(folder, 'folder', client.globals.waitForNegativeConditionTimeout)
     .then(state => {
       return client.assert.ok(!state, `Error: Folder ${folder} is listed on the filesList`)
     })
@@ -539,7 +539,11 @@ Then('the trashbin should be empty on the webUI', async function() {
 
 const theseResourcesShouldNotBeListed = async function(table) {
   for (const entry of table.rows()) {
-    const state = await client.page.FilesPageElement.filesList().isElementListed(entry[0])
+    const state = await client.page.FilesPageElement.filesList().isElementListed(
+      entry[0],
+      'file',
+      client.globals.waitForNegativeConditionTimeout
+    )
     assert.ok(!state, `Expected resource '${entry[0]}' to be 'not present' but found 'present'`)
   }
 }
@@ -802,7 +806,11 @@ const assertElementsAreListed = async function(elements) {
 
 const assertElementsAreNotListed = async function(elements) {
   for (const element of elements) {
-    const state = await client.page.FilesPageElement.filesList().isElementListed(element)
+    const state = await client.page.FilesPageElement.filesList().isElementListed(
+      element,
+      'file',
+      client.globals.waitForNegativeConditionTimeout
+    )
     assert.ok(!state, `Expected resource '${element}' to be 'not present' but found 'present'`)
   }
   return client

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -632,12 +632,12 @@ const assertBreadcrumbIsDisplayedFor = async function(resource, clickable, nonCl
   )
   let isBreadcrumbVisible = false
 
-  // Check if the breadcrumb is visible
+  // lets hope that the breadcrumbs would not take longer than the "NEW" button
   await client.waitForElementVisible({
-    selector: resourceBreadcrumbXpath,
-    locateStrategy: 'xpath',
+    selector: client.page.filesPage().elements.newFileMenuButtonAnyState.selector,
     abortOnFailure: false
   })
+
   await client.element('xpath', resourceBreadcrumbXpath, result => {
     if (result.status > -1) {
       isBreadcrumbVisible = true

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -368,7 +368,16 @@ When('the user unmarks the favorited file/folder {string} using the webUI sideba
   return client
 })
 
-Then('there should be no files/folders/resources listed on the webUI', async function() {
+Then('there should be no files/folders/resources listed on the webUI', assertNoResourcesListed)
+Then(
+  'there should be no files/folders/resources listed on the webUI after a page reload',
+  async function() {
+    await client.refresh()
+    return assertNoResourcesListed()
+  }
+)
+
+async function assertNoResourcesListed() {
   let currentUrl = null
   await client.url(result => {
     currentUrl = result.value
@@ -382,11 +391,11 @@ Then('there should be no files/folders/resources listed on the webUI', async fun
 
   const allRowsResult = await client.page.FilesPageElement.filesList().allFileRows()
 
-  assert.ok(
+  return assert.ok(
     allRowsResult.value.length === 0,
     `No resources are listed, ${allRowsResult.length} found`
   )
-})
+}
 
 Then('file {string} should be listed on the webUI', function(folder) {
   return client.page.FilesPageElement.filesList().waitForFileVisible(folder, 'file')
@@ -525,16 +534,6 @@ When('the user picks the row of file/folder {string} in the webUI', function(ite
 
 When('the user switches to {string} tab in details panel using the webUI', function(tab) {
   return client.page.filesPage().selectTabInSidePanel(tab)
-})
-
-Then('the folder should be empty on the webUI', async function() {
-  const allFileRows = await client.page.FilesPageElement.filesList().allFileRows()
-  return client.assert.equal(allFileRows.value.length, 0)
-})
-
-Then('the trashbin should be empty on the webUI', async function() {
-  const allFileRows = await client.page.FilesPageElement.filesList().allFileRows()
-  return client.assert.strictEqual(allFileRows.value.length, 0)
 })
 
 const theseResourcesShouldNotBeListed = async function(table) {
@@ -759,12 +758,6 @@ Then(/the count of files and folders shown on the webUI should be (\d+)/, async 
 ) {
   const itemsCount = await client.page.FilesPageElement.filesList().countFilesAndFolders()
   return client.assert.equal(itemsCount, noOfItems)
-})
-
-Then('the folder should be empty on the webUI after a page reload', async function() {
-  await client.refresh()
-  const allFileRows = await client.page.FilesPageElement.filesList().allFileRows()
-  return client.assert.equal(allFileRows.value.length, 0)
 })
 
 Then('the app-sidebar should be visible', function() {

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -315,7 +315,8 @@ const assertCollaboratorslistDoesNotContain = function(type, name) {
       {
         displayName: collaboratorsDialog.elements.collaboratorInformationSubName
       },
-      name
+      name,
+      client.globals.waitForNegativeConditionTimeout
     )
     .then(shares => {
       const share = shares.find(share => {


### PR DESCRIPTION
## Description
1. when waiting for something that should not be there use shorter timeouts
2. don't wait so long for the progress-bar to appear (it might have been there but gone again)
3. in mobile view the breadcrumbs are completely different, so don't wait for them but just for the "NEW" button to appear
4. get rid of multiple ways to check for an empty file list
5. skip a tests that fails because of owncloud/core/issues/38039 (I think it used to fail before, but the other steps would not notice)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes 4231

## Motivation and Context
quicker CI runs

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...