### PR TITLE
Updating uk-margin-remove to use oc-m-rm

### DIFF
--- a/apps/files/src/components/UploadProgress.vue
+++ b/apps/files/src/components/UploadProgress.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="files-upload-progress" class="uk-clearfix oc-py-rm">
-    <div class="uk-margin-remove uk-position-relative uk-width-expand">
+    <div class="oc-m-rm uk-position-relative uk-width-expand">
       <oc-progress
         ref="progressbar"
         :aria-hidden="true"


### PR DESCRIPTION
## Description
With the recent migration to replace **uk-** styles with **oc-** styling, I found this one was missed.

## Motivation and Context
See Above.

## Screenshots (if appropriate):
Does not affect the UI visually (in typical cases that I can see).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
