### PR TITLE
[tests-only] split and name ocis suites the same as oc10 suites

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -197,62 +197,61 @@ config = {
 		},
 		'webUI-ocis': {
 			'suites': {
-				'webUIOCIS1': [
-					'webUICreateFilesFolders',
-					'webUIDeleteFilesFolders',
-					'webUIFavorites',
-					'webUIFiles',
+				'webUIOCISBasic': [
 					'webUILogin',
 					'webUINotifications',
-				],
-				'webUIOCIS2': [
 					'webUIPrivateLinks',
+					'webUIPreview',
+					'webUIAccount',
+				],
+				'webUIOCISCreate': [
+					'webUICreateFilesFolders',
+				],
+				'webUIOCISDelete': [
+					'webUIDeleteFilesFolders',
+				],
+				'webUIOCISRename': [
 					'webUIRenameFiles',
 					'webUIRenameFolders',
-					'webUIUpload',
-					'webUIAccount'
 				],
-				'webUIOCIS3': [
-					'webUISharingPermissionsUsers',
-					'webUIRestrictSharing',
+				'webUIOCISSharingBasic': [
 					'webUISharingAcceptShares',
-					'webUISharingAutocompletion',
+					'webUISharingAcceptSharesToRoot',
 				],
-				'webUIOCIS4': [
-					'webUISharingFilePermissionMultipleUsers',
-					'webUISharingFilePermissionsGroups',
-					'webUISharingFolderAdvancedPermissionMultipleUsers',
-					'webUISharingFolderAdvancedPermissionsGroups',
+				'webUIOCISRestrictSharing': [
+					'webUIRestrictSharing',
 				],
-				'webUIOCIS5': [
-					'webUISharingFolderPermissionMultipleUsers',
-					'webUISharingFolderPermissionsGroups',
-					'webUISharingPermissionsUsers',
-					'webUISharingExternal',
-					'webUISharingInternalGroups',
-					'webUISharingNotifications'
+				'webUIOCISSharingNotifications': [
+					'webUISharingNotifications',
+					'webUISharingNotificationsToRoot',
 				],
-				'webUIOCISSharingPublic': [
-					'webUISharingPublic',
-					'webUISharingPublicDifferentRoles',
-				],
-				'webUIOCISSharingPublicExpire': [
-					'webUISharingPublicExpire',
-				],
-				'webUIOCISTrashbin': [
-					'webUITrashbin',
-					'webUITrashbinRestore',
-					'webUITrashbinFilesFolders',
-				],
-				'webUIOCISSharingInternalUsers': [
-					'webUISharingInternalUsers',
-					'webUISharingInternalUsersExpire',
-				],
-				'webUIOCISResharing': [
-					# for now run this suite by itself see https://github.com/owncloud/ocis/issues/736
-					'webUIResharing',
-				],
-
+				'webUIFavorites': 'OCISFavorites',
+				'webUIFiles': 'OCISFiles',
+				'webUISharingAutocompletion': 'OCISSharingAutocompletion',
+				'webUISharingInternalGroups': 'OCISSharingInternalGroups',
+				'webUISharingInternalGroupsToRoot': 'OCISSharingInternalGroupsRoot',
+				'webUISharingInternalUsers': 'OCISSharingInternalUsers',
+				'webUISharingInternalUsersExpire': 'OCISSharingInternalUsersExpire',
+				'webUISharingInternalUsersToRoot': 'OCISSharingInternalUsersRoot',
+				'webUISharingInternalUsersExpireToRoot': 'OCISSharingInternalUsersExpireToRoot',
+				'webUISharingPermissionsUsers': 'OCISSharingPermissionsUsers',
+				'webUISharingFilePermissionsGroups': 'OCISSharingFilePermissionsGroups',
+				'webUISharingFolderPermissionsGroups': 'OCISSharingFolderPermissionsGroups',
+				'webUISharingFolderAdvancedPermissionsGroups': 'OCISSharingFolderAdvPermissionsGrp',
+				'webUISharingPermissionToRoot': 'OCISSharingPermissionToRoot',
+				'webUIResharing': 'OCISResharing', # for now run this suite by itself see https://github.com/owncloud/ocis/issues/736
+				'webUIResharingToRoot': 'OCISResharingToRoot',
+				'webUISharingPublic': 'OCISSharingPublic',
+				'webUISharingPublicExpire': 'OCISSharingPublicExpire',
+				'webUISharingPublicDifferentRoles': 'OCISSharingPublicDifferentRoles',
+				'webUITrashbin': 'OCISTrashbin',
+				'webUITrashbinFilesFolders': 'OCISTrashbinFilesFolders',
+				'webUITrashbinRestore': 'OCISTrashbinRestore',
+				'webUIUpload': 'OCISUpload',
+				'webUISharingFilePermissionMultipleUsers': 'OCISSharingFilePermissionMultipleUsers',
+				'webUISharingFolderPermissionMultipleUsers': 'OCISSharingFolderPermissionMultipleUsers',
+				'webUISharingFolderAdvancedPermissionMultipleUsers': 'OCISSharingFolderAdvancedPermissionMU',
+				'webUIMoveFilesFolders': 'OCISMove',
 			},
 			'extraEnvironment': {
 				'NODE_TLS_REJECT_UNAUTHORIZED': '0',

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -70,6 +70,7 @@ Feature: move files
       | "question?"         | "folder-with-question?"          |
       | "&and#hash"         | "folder-with-&and#hash"          |
 
+  @skipOnOCIS
   Scenario: move files on a public share
     Given user "user1" has shared folder "simple-folder" with link with "read, update, create, delete" permissions
     And the public uses the webUI to access the last public link created by user "user1"

--- a/tests/acceptance/features/webUIPreview/imageMediaViewer.feature
+++ b/tests/acceptance/features/webUIPreview/imageMediaViewer.feature
@@ -23,6 +23,7 @@ Feature: display image in media viewer on the webUI
     And the public views the file "test_video.mp4" in the media viewer using the webUI
     Then the file "test_video.mp4" should be displayed in the media viewer webUI
 
+  @skipOnOCIS
   Scenario: image preview in public share
     Given user "user1" has uploaded file "testavatar.jpg" to "simple-empty-folder/testavatar.jpg"
     And user "user1" has created a public link with following settings
@@ -31,6 +32,7 @@ Feature: display image in media viewer on the webUI
     And the public views the file "testavatar.jpg" in the media viewer using the webUI
     Then the file "testavatar.jpg" should be displayed in the media viewer webUI
 
+  @skipOnOCIS
   Scenario Outline: navigate to next and previous videos with media viewer is possible
     Given user "user1" has uploaded file "<resource-one>" to "<resource-one>"
     And user "user1" has uploaded file "<resource-two>" to "<resource-two>"


### PR DESCRIPTION
## Description
use the same naming and splitting of ocis tests as for oc10 tests

## Related Issue
- Fixes  #4223

## Motivation and Context
reduce confusion

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...