### PR TITLE
[Tests-Only]Adjust the assertion message for the UI tests

### DIFF
--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -1,5 +1,6 @@
 const util = require('util')
 const path = require('path')
+const assert = require('assert')
 const xpathHelper = require('../../helpers/xpath')
 const { join } = require('../../helpers/path')
 const { client } = require('nightwatch-api')
@@ -267,11 +268,11 @@ module.exports = {
         .getAttribute(linkSelector, 'filename', function(result) {
           client.globals.waitForConditionTimeout = oldWaitForConditionTimeout
           if (result.value.error) {
-            this.assert.fail(result.value.error)
+            assert.fail(result.value.error)
           }
           // using basename because some file lists display the full path while the
           // file name attribute only contains the basename
-          this.assert.strictEqual(
+          assert.strictEqual(
             result.value,
             path.basename(fileName),
             'displayed file name not as expected'
@@ -347,7 +348,7 @@ module.exports = {
       return this.useXpath()
         .waitForElementVisible(rowSelector)
         .getAttribute(linkSelector, 'innerText', function(result) {
-          this.assert.strictEqual(result.value.trim(), path, 'displayed file name not as expected')
+          assert.strictEqual(result.value.trim(), path, 'displayed file name not as expected')
         })
         .useCss()
     },

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -313,14 +313,14 @@ When(
 )
 
 Then('it should not be possible to create files using the webUI', function() {
-  return client.page.filesPage().canCreateFiles(isDisabled => {
-    client.assert.strictEqual(isDisabled, true, 'Create action must not be enabled')
+  return client.page.filesPage().canCreateFiles(async isDisabled => {
+    await assert.strictEqual(isDisabled, true, 'Create action must not be enabled')
   })
 })
 
 Then('it should be possible to create files using the webUI', function() {
-  return client.page.filesPage().canCreateFiles(isDisabled => {
-    client.assert.strictEqual(isDisabled, false, 'Create action must be enabled')
+  return client.page.filesPage().canCreateFiles(async isDisabled => {
+    await assert.strictEqual(isDisabled, false, 'Create action must be enabled')
   })
 })
 
@@ -429,7 +429,10 @@ Then('file {string} should not be listed on the webUI', function(file) {
   return client.page.FilesPageElement.filesList()
     .isElementListed(file, 'file', client.globals.waitForNegativeConditionTimeout)
     .then(state => {
-      return client.assert.ok(!state, `Error: File ${file} is listed on the filesList`)
+      const message = state
+        ? `Error: File '${file}' is listed on the filesList`
+        : `File '${file}' is not listed on the filesList`
+      return client.assert.ok(!state, message)
     })
 })
 
@@ -437,7 +440,10 @@ Then('folder {string} should not be listed on the webUI', async folder => {
   return client.page.FilesPageElement.filesList()
     .isElementListed(folder, 'folder', client.globals.waitForNegativeConditionTimeout)
     .then(state => {
-      return client.assert.ok(!state, `Error: Folder ${folder} is listed on the filesList`)
+      const message = state
+        ? `Error: Folder '${folder}' is listed on the filesList`
+        : `Folder '${folder}' is not listed on the filesList`
+      return client.assert.ok(!state, message)
     })
 })
 


### PR DESCRIPTION
## Description
This PR readjusts the message used for assertions in the webui tests.

## Related Issue
- Fixes https://github.com/owncloud/phoenix/issues/4115

## How Has This Been Tested?
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...