### PR TITLE
[Tests-Only] fix browse to files page

### DIFF
--- a/changelog/unreleased/fix-browse-to-files-page
+++ b/changelog/unreleased/fix-browse-to-files-page
@@ -1,0 +1,6 @@
+Bugfix: Fix browse to files page in the ui tests 
+
+When the ui tests where executing the "the user has browsed to the files page" step then it wouldn't wait until the files were loaded.
+
+https://github.com/owncloud/phoenix/issues/4281
+

--- a/tests/acceptance/helpers/navigationHelper.js
+++ b/tests/acceptance/helpers/navigationHelper.js
@@ -41,7 +41,7 @@ module.exports = {
     return client.waitForElementPresent({
       ...locator,
       abortOnFailure: false, // don't fail if we are too late
-      timeout: client.globals.waitForNegativeConditionTimeout
+      timeout: client.globals.waitForConditionTimeout
     })
   }
 }

--- a/tests/acceptance/pageObjects/filesPage.js
+++ b/tests/acceptance/pageObjects/filesPage.js
@@ -413,7 +413,8 @@ module.exports = {
       selector: '#files-breadcrumb li:nth-of-type(2)'
     },
     newFileButtonLoaded: {
-      selector: '//button[@id="new-file-menu-btn" and contains(@class, "oc-button-primary")]',
+      selector:
+        '//button[@id="new-file-menu-btn" and contains(@class, "oc-button-primary") and not(@disabled)]',
       locateStrategy: 'xpath'
     },
     breadcrumbMobile: {

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -81,7 +81,6 @@ Then('the files table should be displayed', () => {
 
 Given('the user has browsed to the files page', async function() {
   await client.page.filesPage().navigateAndWaitTillLoaded()
-  await client.page.FilesPageElement.filesList().waitForAllThumbnailsLoaded()
 })
 
 When('the user opens folder {string} directly on the webUI', async function(folder) {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
In the selenium tests when browsing to the files list page the tests were not waiting for the files to load.
I found this issue in this PR https://github.com/owncloud/ocis/pull/638 I don't know why it worked before.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/phoenix/issues/4281