### PR TITLE
[tests-only]remove skipOnOCIS tag from moveFiles test

### DIFF
--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -70,7 +70,6 @@ Feature: move files
       | "question?"         | "folder-with-question?"          |
       | "&and#hash"         | "folder-with-&and#hash"          |
 
-  @skipOnOCIS
   Scenario: move files on a public share
     Given user "user1" has shared folder "simple-folder" with link with "read, update, create, delete" permissions
     And the public uses the webUI to access the last public link created by user "user1"

--- a/tests/acceptance/pageObjects/filesPage.js
+++ b/tests/acceptance/pageObjects/filesPage.js
@@ -67,6 +67,21 @@ module.exports = {
       return null
     },
     /**
+     * Check if the breadcrumb element is visible or not
+     *
+     * @returns Promise
+     */
+    checkBreadcrumbVisibility: async function(resourceBreadcrumbXpath) {
+      await this.useXpath()
+        .waitForElementVisible({
+          selector: resourceBreadcrumbXpath,
+          abortOnFailure: false
+        })
+        .waitForAnimationToFinish()
+        .useCss()
+      return this
+    },
+    /**
      * Create a folder with the given name
      *
      * @param {string} name to set or null to use default value from dialog

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -652,6 +652,8 @@ const assertBreadcrumbIsDisplayedFor = async function(resource, clickable, nonCl
     abortOnFailure: false
   })
 
+  await client.page.filesPage().checkBreadcrumbVisibility(resourceBreadcrumbXpath)
+
   await client.element('xpath', resourceBreadcrumbXpath, result => {
     if (result.status > -1) {
       isBreadcrumbVisible = true


### PR DESCRIPTION
##  Description
This PR removes `@skipOnOCIS` tag from a scenario of `moveFiles.feature` test so that it passes on ocis.

## Related Issue
- part of https://github.com/owncloud/phoenix/issues/4269

## How Has This Been Tested?
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...