### PR TITLE
fix loginAsUser

### DIFF
--- a/changelog/unreleased/fix-login-as-user
+++ b/changelog/unreleased/fix-login-as-user
@@ -1,0 +1,5 @@
+Bugfix: Fix loginAsUser
+
+loginAsUser wasn't waiting until the loading finished. Added an additional check
+
+https://github.com/owncloud/phoenix/pull/4297

--- a/tests/acceptance/helpers/loginHelper.js
+++ b/tests/acceptance/helpers/loginHelper.js
@@ -29,6 +29,8 @@ module.exports = {
       .then(() => {
         client.globals.currentUser = userId
       })
+
+    await client.page.filesPage().waitForElementPresent('@newFileButtonLoaded')
     await client.page.FilesPageElement.filesList().waitForAllThumbnailsLoaded()
   },
 


### PR DESCRIPTION
~~waitForAllThumbnailsLoaded wasn't correctly waiting. It would return immediately if the files list was not loaded yet.~~
loginAsUser wasn't correctly waiting for the files list. waitForAllThumbnailsLoaded returns immediately if the list or loader takes longer to appear.
Found here https://drone.owncloud.com/owncloud/ocis/1342/32/7
https://github.com/owncloud/phoenix/blob/572da6eeef637ce304cec5a366b9e423affb4772/tests/acceptance/helpers/loginHelper.js#L32