### PR TITLE
Fix dynamic client registration

### DIFF
--- a/changelog/unreleased/openid-connect-dynamic-client-registration
+++ b/changelog/unreleased/openid-connect-dynamic-client-registration
@@ -3,3 +3,4 @@ Enhancement: Added support for OpenID Connect Dynamic Client Registration 1.0
 ownCloud Phoenix can use the dynamic client registration protocol to exchange client id and client secret woth the IdP
 
 https://github.com/owncloud/phoenix/pull/4286
+https://github.com/owncloud/phoenix/pull/4306

--- a/src/phoenix.js
+++ b/src/phoenix.js
@@ -307,7 +307,7 @@ async function registerClient(openIdConfig) {
     })
     config = await config.json()
     // if dynamic client registration is necessary - do this here now
-    if (config.openIdConnect.dynamic) {
+    if (config.openIdConnect && config.openIdConnect.dynamic) {
       const clientData = await registerClient(config.openIdConnect)
       config.openIdConnect.client_id = clientData.client_id
       config.openIdConnect.client_secret = clientData.client_secret


### PR DESCRIPTION
## Description
There was a bug where page load was failing when not using oidc, but plain oauth2 instead. This PR fixes it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
