### PR TITLE
[tests-only] Bump OCIS commit id

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -298,7 +298,7 @@ config = {
 	'defaults': {
 		'acceptance': {
 			'ocisBranch': 'master',
-			'ocisCommit': '7f1eef36d887b5955a178d9a1c82b8a9b0113675',
+			'ocisCommit': 'd1543f76a29c06ab2640c613a5429e401f23ce2a',
 		},
 	},
 


### PR DESCRIPTION
To the current https://github.com/owncloud/ocis/commits/master

This will show that the current Phoenix and OCIS master branches work together.

Then we can look at why https://github.com/owncloud/ocis/pull/868 is having trouble.