### PR TITLE
Use handler of the file editor

### DIFF
--- a/apps/files/src/components/FilesAppBar.vue
+++ b/apps/files/src/components/FilesAppBar.vue
@@ -533,13 +533,16 @@ export default {
         if (this.publicPage()) {
           p = this.$client.publicFiles.putFileContents(filePath, null, this.publicLinkPassword, '')
         }
-        p.then(() => {
+        p.then(async () => {
+          const file = await this.$client.files.fileInfo(filePath, this.davProperties)
+          const fileId = file.fileInfo['{http://owncloud.org/ns}fileid']
+
           this.$_ocFilesFolder_getFolder()
           this.fileFolderCreationLoading = false
           this.hideModal()
 
           if (this.newFileAction) {
-            this.$_fileActions_openEditor(this.newFileAction, filePath)
+            this.$_fileActions_openEditor(this.newFileAction, filePath, fileId)
           }
         }).catch(error => {
           this.fileFolderCreationLoading = false

--- a/apps/files/src/mixins/fileActions.js
+++ b/apps/files/src/mixins/fileActions.js
@@ -28,6 +28,7 @@ export default {
   computed: {
     ...mapState(['apps']),
     ...mapGetters('Files', ['highlightedFile', 'currentFolder']),
+    ...mapGetters(['configuration']),
 
     $_fileActions_systemActions() {
       const systemActions = []
@@ -46,7 +47,7 @@ export default {
             return `Open in ${this.apps.meta[editor.app].name}`
           },
           icon: this.apps.meta[editor.app].icon,
-          handler: item => this.$_fileActions_openEditor(editor, item.path),
+          handler: item => this.$_fileActions_openEditor(editor, item.path, item.id),
           isEnabled: ({ resource }) => {
             if (editor.routes && checkRoute(editor.routes, this.$route.name)) {
               return false
@@ -65,7 +66,11 @@ export default {
   methods: {
     ...mapActions(['openFile']),
 
-    $_fileActions_openEditor(editor, filePath) {
+    $_fileActions_openEditor(editor, filePath, fileId) {
+      if (editor.handler) {
+        return editor.handler(this.configuration, filePath, fileId)
+      }
+
       // TODO: Refactor in the store
       this.openFile({
         filePath: filePath

--- a/changelog/unreleased/editor-handler
+++ b/changelog/unreleased/editor-handler
@@ -1,0 +1,5 @@
+Enhancement: Use handler of file editors
+
+In case the extension is a file editor which defines a custom handler, we are triggering that handler instead of trying to open any assigned route.
+
+https://github.com/owncloud/phoenix/pull/4324

--- a/src/store/apps.js
+++ b/src/store/apps.js
@@ -82,7 +82,8 @@ const mutations = {
           icon: e.icon,
           newTab: e.newTab || false,
           routeName: e.routeName,
-          extension: e.extension
+          extension: e.extension,
+          handler: e.handler
         }
 
         state.fileEditors.push(editor)


### PR DESCRIPTION
In case the editor defines a custom handler instead of a route when opening a file, trigger the handler.