### PR TITLE
[tests-only] fix order of arguments in assert

### DIFF
--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -457,7 +457,7 @@ Then('the deleted elements should not be listed on the webUI after a page reload
 
 Then('the versions list should contain {int} entries', async function(expectedNumber) {
   const count = await client.page.FilesPageElement.versionsDialog().getVersionsCount()
-  return assert.strictEqual(expectedNumber, count)
+  return assert.strictEqual(count, expectedNumber)
 })
 
 Then('the versions list for resource {string} should contain {int} entry/entries', async function(
@@ -471,7 +471,7 @@ Then('the versions list for resource {string} should contain {int} entry/entries
   await client.waitForOutstandingAjaxCalls()
   const count = await api.versionsDialog().getVersionsCount()
 
-  assert.strictEqual(expectedNumber, count)
+  assert.strictEqual(count, expectedNumber)
 
   client.page.FilesPageElement.appSideBar().closeSidebar(100)
 


### PR DESCRIPTION
##  Description
the order of arguments for `assert.strictEqual` is actual, expected
![image](https://user-images.githubusercontent.com/2425577/99520282-0423a480-29bb-11eb-8c06-b59b6f911fc3.png)

## Motivation and Context
reduce confusion when seeing test log output


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...