### PR TITLE
[draw.io] Deployment config + .vsdx support

### DIFF
--- a/apps/draw-io/src/DrawIoEditor.vue
+++ b/apps/draw-io/src/DrawIoEditor.vue
@@ -26,7 +26,7 @@ export default {
         ui: 'minimal'
       })
 
-      return 'https://www.draw.io?' + query
+      return `https://embed.diagrams.net?${query}`
     }
   },
   created() {

--- a/apps/draw-io/src/DrawIoEditor.vue
+++ b/apps/draw-io/src/DrawIoEditor.vue
@@ -9,6 +9,7 @@ export default {
   name: 'DrawIoEditor',
   data: () => ({
     filePath: '',
+    fileExtension: '',
     currentETag: null
   }),
   computed: {
@@ -31,14 +32,14 @@ export default {
   },
   created() {
     this.filePath = this.$route.params.filePath
-    this.extension = this.filePath.split('.').pop()
+    this.fileExtension = this.filePath.split('.').pop()
 
     window.addEventListener('message', event => {
       if (event.data.length > 0) {
         var payload = JSON.parse(event.data)
         switch (payload.event) {
           case 'init':
-            this.extension === 'vsdx' ? this.importVisio() : this.load()
+            this.fileExtension === 'vsdx' ? this.importVisio() : this.load()
             break
           case 'autosave':
           case 'save':
@@ -63,7 +64,6 @@ export default {
         }
       })
     },
-
     load() {
       this.$client.files
         .getFileContents(this.filePath, { resolveWithResponseObject: true })
@@ -89,7 +89,7 @@ export default {
         'X-Requested-With': 'XMLHttpRequest'
       })
       // Change the working file after the import
-      this.filePath += '.drawio'
+      this.filePath += `_${this.getTimestamp()}.drawio`
       fetch(url, { headers })
         .then(resp => {
           // Not setting `currentETag` on imports allows to create new files
@@ -137,6 +137,11 @@ export default {
     },
     exit() {
       window.close()
+    },
+    getTimestamp() {
+      const date = new Date()
+      return `${date.getFullYear()}${date.getMonth() +
+        1}${date.getDate()}T${date.getHours()}${date.getMinutes()}${date.getSeconds()}`
     }
   }
 }
@@ -154,6 +159,5 @@ export default {
   margin: 0;
   padding: 0;
   overflow: hidden;
-  z-index: 999999;
 }
 </style>

--- a/apps/draw-io/src/DrawIoEditor.vue
+++ b/apps/draw-io/src/DrawIoEditor.vue
@@ -12,6 +12,7 @@ export default {
   data: () => ({
     filePath: '',
     fileExtension: '',
+    isReadOnly: null,
     currentETag: null
   }),
   computed: {
@@ -27,7 +28,7 @@ export default {
     iframeSource() {
       const query = queryString.stringify({
         embed: 1,
-        chrome: 1,
+        chrome: this.isReadOnly ? 0 : 1,
         picker: 0,
         stealth: 1,
         spin: 1,
@@ -41,6 +42,9 @@ export default {
   created() {
     this.filePath = this.$route.params.filePath
     this.fileExtension = this.filePath.split('.').pop()
+    this.$client.files.fileInfo(this.filePath, ['{http://owncloud.org/ns}permissions']).then(v => {
+      this.isReadOnly = v.fileInfo['{http://owncloud.org/ns}permissions'].indexOf('W') === -1
+    })
     window.addEventListener('message', event => {
       if (event.data.length > 0) {
         var payload = JSON.parse(event.data)

--- a/apps/draw-io/src/DrawIoEditor.vue
+++ b/apps/draw-io/src/DrawIoEditor.vue
@@ -123,6 +123,13 @@ export default {
         })
         .then(resp => {
           this.currentETag = resp.ETag
+          this.$refs.drawIoEditor.contentWindow.postMessage(
+            JSON.stringify({
+              action: 'status',
+              modified: false
+            }),
+            '*'
+          )
         })
         .catch(error => {
           this.error(error)

--- a/apps/draw-io/src/DrawIoEditor.vue
+++ b/apps/draw-io/src/DrawIoEditor.vue
@@ -4,6 +4,8 @@
 <script>
 import { mapGetters, mapActions } from 'vuex'
 import queryString from 'query-string'
+import moment from 'moment'
+import { basename } from 'path'
 
 export default {
   name: 'DrawIoEditor',
@@ -88,8 +90,21 @@ export default {
         Authorization: 'Bearer ' + this.getToken,
         'X-Requested-With': 'XMLHttpRequest'
       })
-      // Change the working file after the import
+      const getDescription = () =>
+        this.$gettextInterpolate(
+          'The diagram will open as a new .drawio file: %{file}',
+          { file: basename(this.filePath) },
+          true
+        )
+      // Change the working file after the import so the original file is not overwritten
       this.filePath += `_${this.getTimestamp()}.drawio`
+      this.showMessage({
+        title: this.$gettext('Diagram imported'),
+        desc: getDescription(),
+        autoClose: {
+          enabled: true
+        }
+      })
       fetch(url, { headers })
         .then(resp => {
           // Not setting `currentETag` on imports allows to create new files
@@ -139,9 +154,7 @@ export default {
       window.close()
     },
     getTimestamp() {
-      const date = new Date()
-      return `${date.getFullYear()}${date.getMonth() +
-        1}${date.getDate()}T${date.getHours()}${date.getMinutes()}${date.getSeconds()}`
+      return moment().format('YYYYMMDD[T]HHmmss')
     }
   }
 }

--- a/apps/draw-io/src/DrawIoEditor.vue
+++ b/apps/draw-io/src/DrawIoEditor.vue
@@ -16,13 +16,13 @@ export default {
     currentETag: null
   }),
   computed: {
-    ...mapGetters(['getToken', 'configuration']),
+    ...mapGetters(['getToken']),
     loading() {
       return this.content === ''
     },
     config() {
       const { url = 'https://embed.diagrams.net', theme = 'minimal', autosave = false } =
-        this.configuration.applications.find(app => app.title.en === 'draw-io') || {}
+        this.$store.state.apps.fileEditors.find(editor => editor.app === 'draw-io').config || {}
       return { url, theme, autosave: autosave ? 1 : 0 }
     },
     iframeSource() {

--- a/apps/draw-io/src/DrawIoEditor.vue
+++ b/apps/draw-io/src/DrawIoEditor.vue
@@ -40,6 +40,7 @@ export default {
           case 'init':
             this.extension === 'vsdx' ? this.importVisio() : this.load()
             break
+          case 'autosave':
           case 'save':
             this.save(payload)
             break
@@ -71,7 +72,8 @@ export default {
           this.$refs.drawIoEditor.contentWindow.postMessage(
             JSON.stringify({
               action: 'load',
-              xml: resp.body
+              xml: resp.body,
+              autosave: 1
             }),
             '*'
           )
@@ -102,7 +104,8 @@ export default {
             this.$refs.drawIoEditor.contentWindow.postMessage(
               JSON.stringify({
                 action: 'load',
-                xml: reader.result
+                xml: reader.result,
+                autosave: 1
               }),
               '*'
             )

--- a/apps/draw-io/src/DrawIoEditor.vue
+++ b/apps/draw-io/src/DrawIoEditor.vue
@@ -55,7 +55,7 @@ export default {
     ...mapActions(['showMessage']),
     error(error) {
       this.showMessage({
-        title: this.$gettext('PDF could not be loaded…'),
+        title: this.$gettext('The diagram could not be loaded…'),
         desc: error,
         status: 'danger',
         autoClose: {

--- a/apps/draw-io/src/app.js
+++ b/apps/draw-io/src/app.js
@@ -36,6 +36,11 @@ const appInfo = {
         'files-shared-with-me',
         'public-files'
       ]
+    },
+    {
+      extension: 'vsdx',
+      newTab: true,
+      routeName: 'draw-io-edit'
     }
   ]
 }

--- a/apps/draw-io/webpack.common.js
+++ b/apps/draw-io/webpack.common.js
@@ -1,15 +1,10 @@
 const VueLoaderPlugin = require('vue-loader/lib/plugin')
+const webpack = require('webpack')
 
 module.exports = {
-  plugins: [
-    new VueLoaderPlugin()
-  ],
+  plugins: [new VueLoaderPlugin(), new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/)],
   entry: {
-    'draw-io': [
-      'core-js/modules/es6.promise',
-      'core-js/modules/es6.array.iterator',
-      './src/app.js'
-    ]
+    'draw-io': ['core-js/modules/es6.promise', 'core-js/modules/es6.array.iterator', './src/app.js']
   },
   output: {
     publicPath: 'apps/draw-io/',
@@ -17,42 +12,42 @@ module.exports = {
     filename: 'draw-io.bundle.js'
   },
   module: {
-    rules: [{
-      test: /\.js?$/,
-      exclude: /node_modules/,
-      loader: 'babel-loader',
-      options: {
-        rootMode: 'upward'
-      }
-    }, {
-      test: /\.vue$/,
-      loader: 'vue-loader'
-    },
-    {
-      test: /\.jsx?$/,
-      include: /node_modules\/(?=(query-string|split-on-first|strict-uri-encode)\/).*/,
-      use: {
+    rules: [
+      {
+        test: /\.js?$/,
+        exclude: /node_modules/,
         loader: 'babel-loader',
         options: {
-          presets: [
-            [
-              '@babel/preset-env',
-              {
-                targets: {
-                  ie: '11'
-                }
-              }
-            ]
-          ]
+          rootMode: 'upward'
         }
+      },
+      {
+        test: /\.vue$/,
+        loader: 'vue-loader'
+      },
+      {
+        test: /\.jsx?$/,
+        include: /node_modules\/(?=(query-string|split-on-first|strict-uri-encode)\/).*/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: [
+              [
+                '@babel/preset-env',
+                {
+                  targets: {
+                    ie: '11'
+                  }
+                }
+              ]
+            ]
+          }
+        }
+      },
+      {
+        test: /\.css$/,
+        use: ['vue-style-loader', 'css-loader']
       }
-    },
-    {
-      test: /\.css$/,
-      use: [
-        'vue-style-loader',
-        'css-loader'
-      ]
-    }]
+    ]
   }
 }

--- a/changelog/unreleased/drawio-custom-configuration
+++ b/changelog/unreleased/drawio-custom-configuration
@@ -1,0 +1,8 @@
+Enhancement: Add custom configuration to the draw.io app
+
+Added mechanism to specify custom configuration instead of using a hardcoded
+one. The new settings include support for a custom draw.io server, enabling
+autosave and using a specific theme.
+
+https://github.com/owncloud/phoenix/pull/4337
+https://github.com/owncloud/phoenix/issues/4328

--- a/changelog/unreleased/drawio-vsdx-support
+++ b/changelog/unreleased/drawio-vsdx-support
@@ -1,0 +1,8 @@
+Enhancement: Add support for .vsdx files in the draw.io app
+
+Added the support to open .vsdx files (Microsoft Visio Files) directly
+from OwnCloud, instead of creating a new diagram to import the file from
+local storage.
+
+https://github.com/owncloud/phoenix/pull/4337
+https://github.com/owncloud/phoenix/issues/4327

--- a/config.json.sample-oc10
+++ b/config.json.sample-oc10
@@ -29,5 +29,16 @@
       "icon": "info",
       "path": "/internal-app"
     }
+  ],
+  "external_apps": [
+    {
+      "id": "draw-io",
+      "path": "apps/draw-io/dist/draw-io.bundle.js",
+      "config": {
+        "url": "https://embed.diagrams.net",
+        "autosave": false,
+        "theme": "minimal"
+      }
+    }
   ]
 }

--- a/config.json.sample-ocis
+++ b/config.json.sample-ocis
@@ -24,6 +24,15 @@
     {
       "id": "accounts",
       "path": "https://localhost:9200/accounts.js"
+    },
+    {
+      "id": "draw-io",
+      "path": "apps/draw-io/dist/draw-io.bundle.js",
+      "config": {
+        "url": "https://embed.diagrams.net",
+        "autosave": false,
+        "theme": "minimal"
+      }
     }
   ]
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Phoenix. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
1. This PR allows to import .vsdx (Microsoft Visio files) directly from OC.
2. Once the file is open, if saved, a new `<filename>_<timestamp>.drawio` file is created with the modifications. (This avoids overwriting the original file with XML content). A message informing this should be shown ( #4335 )
3. By default, the draw-io app now points to `https://embed.diagrams.net` (The official embed-specific draw.io server)
4. If specified, the configuration in `config.json` will be used for the connections to draw.io (server url, autosave and theme)
    ```json
    {
      ...
      "applications": [
        {
          "title": {
            "en": "draw-io"
          },
          "url": "https://custom.draw.io.url",
          "autosave": true,
          "theme": "atlas"
        }
      ]
    }
    ```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Closes #4327 
- Closes #4328 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Privacy reasons
- Flexibility
- Support for more formats

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
Docker OC 10 + local Phoenix: following [this docs](https://owncloud.github.io/clients/web/getting-started)
- test case 1:
Use custom draw.io server, enable autosave, use the 'atlas' theme
- test case 2:
Open a .vsdx file by clicking on it

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Import .vsdx files directly from OwnCloud
- [x] Custom draw.io server support
- [x] Autosave support 
- [x] Different themes support 
- [x] Specify draw.io settings in the global configuration
- [x] Use by default the embed-specific diagrams.net server
- [x] View mode for read-only diagrams
