### PR TITLE
[tests-only] Fix waiting between upload & deletes

### DIFF
--- a/tests/acceptance/helpers/webdavHelper.js
+++ b/tests/acceptance/helpers/webdavHelper.js
@@ -207,15 +207,6 @@ exports.getSkeletonFile = function(filename) {
     })
 }
 
-exports.uploadFileWithContent = function(user, content, filename) {
-  const apiURL = `files/${user}/${filename}`
-  return httpHelper
-    .put(apiURL, user, content, { 'Content-Type': 'text/plain' })
-    .then(res =>
-      httpHelper.checkStatus(res, 'Could not upload file' + filename + 'with content' + content)
-    )
-}
-
 exports.getFavouritedResources = function(user) {
   const body = `<oc:filter-files  xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
                  <d:prop><d:resourcetype /></d:prop>

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -11,7 +11,6 @@ const path = require('../helpers/path')
 const util = require('util')
 let deletedElements
 let timeOfLastDeleteOperation = Date.now()
-let timeOfLastUploadOperation = Date.now()
 const { download } = require('../helpers/webdavHelper')
 const fs = require('fs')
 
@@ -94,7 +93,6 @@ Given('user {string} has uploaded file with content {string} to {string}', async
   content,
   filename
 ) {
-  await waitBetweenFileUploadOperations()
   await webdav.createFile(user, filename, content)
 })
 
@@ -103,7 +101,6 @@ Given('user {string} has uploaded file {string} to {string}', async function(
   source,
   filename
 ) {
-  await waitBetweenFileUploadOperations()
   const filePath = path.join(client.globals.filesForUpload, source)
   const content = fs.readFileSync(filePath)
   await webdav.createFile(user, filename, content)
@@ -215,18 +212,6 @@ const waitBetweenDeleteOperations = async function() {
     await client.pause(1000 - timeSinceLastDelete + 1)
   }
   timeOfLastDeleteOperation = Date.now()
-}
-
-/**
- * makes sure upload operations are carried out maximum once a second to avoid version issues
- * see https://github.com/owncloud/core/issues/23151
- */
-const waitBetweenFileUploadOperations = async function() {
-  const timeSinceLastFileUpload = Date.now() - timeOfLastUploadOperation
-  if (timeSinceLastFileUpload <= 1001) {
-    await client.pause(1001 - timeSinceLastFileUpload)
-  }
-  timeOfLastUploadOperation = Date.now()
 }
 
 Given('the following files/folders/resources have been deleted by user {string}', async function(

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -95,7 +95,7 @@ Given('user {string} has uploaded file with content {string} to {string}', async
   filename
 ) {
   await waitBetweenFileUploadOperations()
-  await webdav.uploadFileWithContent(user, content, filename)
+  await webdav.createFile(user, filename, content)
 })
 
 Given('user {string} has uploaded file {string} to {string}', async function(

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -10,7 +10,6 @@ const { move } = require('../helpers/webdavHelper')
 const path = require('../helpers/path')
 const util = require('util')
 let deletedElements
-let timeOfLastDeleteOperation = Date.now()
 const { download } = require('../helpers/webdavHelper')
 const fs = require('fs')
 
@@ -202,25 +201,12 @@ Then('breadcrumb for folder {string} should be displayed on the webUI', function
   return assertBreadcrumbIsDisplayedFor(resource, true, true)
 })
 
-/**
- * makes sure delete operations are carried out maximum once a second to avoid trashbin issues
- * see https://github.com/owncloud/core/issues/23151
- */
-const waitBetweenDeleteOperations = async function() {
-  const timeSinceLastDelete = Date.now() - timeOfLastDeleteOperation
-  if (timeSinceLastDelete <= 1000) {
-    await client.pause(1000 - timeSinceLastDelete + 1)
-  }
-  timeOfLastDeleteOperation = Date.now()
-}
-
 Given('the following files/folders/resources have been deleted by user {string}', async function(
   user,
   table
 ) {
   const filesToDelete = table.hashes()
   for (const entry of filesToDelete) {
-    await waitBetweenDeleteOperations()
     await webdav.delete(user, entry.name)
   }
   return client


### PR DESCRIPTION
## Description
the waiting before an upload or delete had an issue
the code waited before the upload in https://github.com/owncloud/phoenix/blob/034efba13d429b26b2cad7562d928866dfc84fe8/tests/acceptance/stepDefinitions/filesContext.js#L97
and after the waiting `timeOfLastUploadOperation` is set but the upload hasn't even started, so if the upload is slow the waiting will be too short in the next upload

this PR f makes sure the time variable is only set after the upload or delete

besides that there have been two functions uploading files with content, I've deleted one of them

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #4301

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...