### PR TITLE
[tests-only] reduce timeout when checking if sidebar tabs are open

### DIFF
--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -18,11 +18,7 @@ module.exports = {
       await appSidebar.closeSidebar(500)
       await this.waitForFileVisible(fileName)
       await this.openSideBar(fileName)
-      const visible = await client.page.filesPage().isPanelVisible('people')
-      if (!visible) {
-        await appSidebar.openCollaboratorsTab()
-      }
-      return this
+      return client.page.filesPage().selectTabInSidePanel('people')
     },
     /**
      * @param {string} fileName
@@ -31,11 +27,7 @@ module.exports = {
     openPublicLinkDialog: async function(fileName) {
       await this.waitForFileVisible(fileName)
       await this.openSideBar(fileName)
-      const visible = await client.page.filesPage().isPanelVisible('links')
-      if (!visible) {
-        await this.api.page.FilesPageElement.appSideBar().openLinksTab()
-      }
-      return this
+      return client.page.filesPage().selectTabInSidePanel('links')
     },
     /**
      * @param {string} resource

--- a/tests/acceptance/pageObjects/filesPage.js
+++ b/tests/acceptance/pageObjects/filesPage.js
@@ -242,7 +242,10 @@ module.exports = {
       await this.useXpath()
         .waitForElementVisible('@sideBar')
         .useCss()
-      const panelVisible = await this.isPanelVisible(tab)
+      const panelVisible = await this.isPanelVisible(
+        tab,
+        this.api.globals.waitForNegativeConditionTimeout
+      )
       if (panelVisible) {
         return this
       } else {
@@ -251,21 +254,40 @@ module.exports = {
           .useCss()
       }
     },
-    isSidebarVisible: async function() {
+    isSidebarVisible: async function(timeout = null) {
       let isVisible = false
-      await this.isVisible('xpath', this.elements.sideBar.selector, result => {
-        isVisible = result.status === 0
-      })
+      if (timeout === null) {
+        timeout = this.api.globals.waitForConditionTimeout
+      } else {
+        timeout = parseInt(timeout, 10)
+      }
+      await this.isVisible(
+        {
+          locateStrategy: this.elements.sideBar.locateStrategy,
+          selector: this.elements.sideBar.selector,
+          timeout: timeout
+        },
+        result => {
+          isVisible = result.status === 0
+        }
+      )
       return isVisible
     },
-    isPanelVisible: async function(panelName) {
+    isPanelVisible: async function(panelName, timeout = null) {
       panelName = panelName === 'people' ? 'collaborators' : panelName
       const selector = this.elements[panelName + 'Panel']
       let isVisible = false
-
-      await this.isVisible(selector, result => {
-        isVisible = result.status === 0
-      })
+      if (timeout === null) {
+        timeout = this.api.globals.waitForConditionTimeout
+      } else {
+        timeout = parseInt(timeout, 10)
+      }
+      await this.isVisible(
+        { locateStrategy: 'css selector', selector: selector.selector, timeout: timeout },
+        result => {
+          isVisible = result.status === 0
+        }
+      )
       return isVisible
     },
     getVisibleTabs: async function() {

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -753,7 +753,9 @@ Then('the app-sidebar should be visible', async function() {
 })
 
 Then('the app-sidebar should be invisible', async function() {
-  const visible = await client.page.filesPage().isSidebarVisible()
+  const visible = await client.page
+    .filesPage()
+    .isSidebarVisible(client.globals.waitForNegativeConditionTimeout)
   assert.strictEqual(visible, false, 'app-sidebar should be invisible, but is not')
 })
 


### PR DESCRIPTION
## Description
reduce the timeout when checking if a particular tab/accordion item is open in the side panel and we expect its not.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/phoenix/issues/4312

## Motivation and Context
reduce CI time

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...