### PR TITLE
[tests-only] cleanup various issues with the sidebar tests

### DIFF
--- a/tests/acceptance/features/webUIFiles/fileDetails.feature
+++ b/tests/acceptance/features/webUIFiles/fileDetails.feature
@@ -17,7 +17,7 @@ Feature: User can open the details panel for any file or folder
     Then the app-sidebar should be visible
     And the thumbnail should be visible in the app-sidebar
     And the "actions" details panel should be visible
-    When the user switches to "people" tab in details panel using the webUI
+    When the user switches to "people" accordion item in details panel using the webUI
     Then the "people" details panel should be visible
 
   @files_versions-app-required
@@ -26,9 +26,9 @@ Feature: User can open the details panel for any file or folder
     Then the app-sidebar should be visible
     And the thumbnail should be visible in the app-sidebar
     And the "actions" details panel should be visible
-    When the user switches to "people" tab in details panel using the webUI
+    When the user switches to "people" accordion item in details panel using the webUI
     Then the "people" details panel should be visible
-    When the user switches to "links" tab in details panel using the webUI
+    When the user switches to "links" accordion item in details panel using the webUI
     Then the "links" details panel should be visible
 
   @files_versions-app-required @skipOnOCIS @ocis-reva-issue-39
@@ -39,7 +39,7 @@ Feature: User can open the details panel for any file or folder
     Then the app-sidebar should be visible
     And the thumbnail should be visible in the app-sidebar
     And the "actions" details panel should be visible
-    When the user switches to "people" tab in details panel using the webUI
+    When the user switches to "people" accordion item in details panel using the webUI
     Then the "people" details panel should be visible
 
   @files_versions-app-required @skipOnOCIS @ocis-reva-issue-39
@@ -50,9 +50,9 @@ Feature: User can open the details panel for any file or folder
     Then the app-sidebar should be visible
     And the thumbnail should be visible in the app-sidebar
     And the "actions" details panel should be visible
-    When the user switches to "people" tab in details panel using the webUI
+    When the user switches to "people" accordion item in details panel using the webUI
     Then the "people" details panel should be visible
-    When the user switches to "links" tab in details panel using the webUI
+    When the user switches to "links" accordion item in details panel using the webUI
     Then the "links" details panel should be visible
 
   @skip @yetToImplement
@@ -65,9 +65,9 @@ Feature: User can open the details panel for any file or folder
     And the user clicks the details file action in the webUI
     Then the details dialog should be visible in the webUI
     And the thumbnail should be visible in the details panel
-    When the user switches to "sharing" tab in details panel using the webUI
+    When the user switches to "sharing" accordion item in details panel using the webUI
     Then the "sharing" details panel should be visible
-    When the user switches to "comments" tab in details panel using the webUI
+    When the user switches to "comments" accordion item in details panel using the webUI
     Then the "comments" details panel should be visible
 
   @comments-app-required @skipOnOCIS @ocis-reva-issue-64
@@ -78,11 +78,11 @@ Feature: User can open the details panel for any file or folder
     When the user picks the row of folder "simple-folder" in the webUI
     Then the app-sidebar should be visible
     And the thumbnail should be visible in the app-sidebar
-    When the user switches to "people" tab in details panel using the webUI
+    When the user switches to "people" accordion item in details panel using the webUI
     Then the "people" details panel should be visible
-#    When the user switches to "comments" tab in details panel using the webUI
+#    When the user switches to "comments" accordion item in details panel using the webUI
 #    Then the "comments" details panel should be visible
-    When the user switches to "links" tab in details panel using the webUI
+    When the user switches to "links" accordion item in details panel using the webUI
     Then the "links" details panel should be visible
 
   @comments-app-required @skipOnOCIS @ocis-reva-issue-64
@@ -93,11 +93,11 @@ Feature: User can open the details panel for any file or folder
     When the user picks the row of folder "simple-folder" in the webUI
     Then the app-sidebar should be visible
     And the thumbnail should be visible in the app-sidebar
-    When the user switches to "people" tab in details panel using the webUI
+    When the user switches to "people" accordion item in details panel using the webUI
     Then the "people" details panel should be visible
-#    When the user switches to "comments" tab in details panel using the webUI
+#    When the user switches to "comments" accordion item in details panel using the webUI
 #    Then the "comments" details panel should be visible
-    When the user switches to "links" tab in details panel using the webUI
+    When the user switches to "links" accordion item in details panel using the webUI
     Then the "links" details panel should be visible
 
   @comments-app-required @skipOnOCIS @ocis-reva-issue-64
@@ -109,11 +109,11 @@ Feature: User can open the details panel for any file or folder
     When the user picks the row of folder "simple-folder (2)" in the webUI
     Then the app-sidebar should be visible
     And the thumbnail should be visible in the app-sidebar
-    When the user switches to "people" tab in details panel using the webUI
+    When the user switches to "people" accordion item in details panel using the webUI
     Then the "people" details panel should be visible
-#    When the user switches to "comments" tab in details panel using the webUI
+#    When the user switches to "comments" accordion item in details panel using the webUI
 #    Then the "comments" details panel should be visible
-    When the user switches to "links" tab in details panel using the webUI
+    When the user switches to "links" accordion item in details panel using the webUI
     Then the "links" details panel should be visible
 
   @ocis-reva-issue-106
@@ -137,9 +137,9 @@ Feature: User can open the details panel for any file or folder
     And the user clicks the details file action in the webUI
     Then the details dialog should be visible in the webUI
     And the thumbnail should be visible in the details panel
-    When the user switches to "sharing" tab in details panel using the webUI
+    When the user switches to "sharing" accordion item in details panel using the webUI
     Then the "sharing" details panel should be visible
-    When the user switches to "comments" tab in details panel using the webUI
+    When the user switches to "comments" accordion item in details panel using the webUI
     Then the "comments" details panel should be visible
 
   Scenario: the sidebar is invisible after closing

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -548,7 +548,7 @@ Feature: Share by public link
       | role | Editor |
     And the public uses the webUI to access the last public link created by user "user1"
     And the user picks the row of file "lorem.txt" in the webUI
-    Then the following tabs should be visible in the details dialog
+    Then the following accordion items should be visible in the details dialog on the webUI
       | name          |
       | versions      |
       | links         |

--- a/tests/acceptance/helpers/timeoutHelper.js
+++ b/tests/acceptance/helpers/timeoutHelper.js
@@ -1,0 +1,11 @@
+const { client } = require('nightwatch-api')
+
+module.exports = {
+  parseTimeout: function(timeout) {
+    if (timeout === null) {
+      return client.globals.waitForConditionTimeout
+    } else {
+      return parseInt(timeout, 10)
+    }
+  }
+}

--- a/tests/acceptance/pageObjects/FilesPageElement/SharingDialog/collaboratorsDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/SharingDialog/collaboratorsDialog.js
@@ -1,4 +1,5 @@
 const util = require('util')
+const timeoutHelper = require('../../../helpers/timeoutHelper')
 
 module.exports = {
   commands: {
@@ -65,11 +66,7 @@ module.exports = {
         selector: '@collaboratorsInformation',
         abortOnFailure: false
       }
-      if (timeout === null) {
-        timeout = this.api.globals.waitForConditionTimeout
-      } else {
-        timeout = parseInt(timeout, 10)
-      }
+      timeout = timeoutHelper.parseTimeout(timeout)
       if (filterDisplayName !== null) {
         informationSelector = {
           selector: util.format(

--- a/tests/acceptance/pageObjects/FilesPageElement/appSideBar.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/appSideBar.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-unused-expressions */
+const timeoutHelper = require('../../helpers/timeoutHelper')
 
 module.exports = {
   commands: {
@@ -8,11 +9,7 @@ module.exports = {
       )
     },
     closeSidebar: function(timeout = null) {
-      if (timeout === null) {
-        timeout = this.api.globals.waitForConditionTimeout
-      } else {
-        timeout = parseInt(timeout, 10)
-      }
+      timeout = timeoutHelper.parseTimeout(timeout)
       try {
         this.click({
           selector: '@sidebarCloseBtn',

--- a/tests/acceptance/pageObjects/FilesPageElement/appSideBar.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/appSideBar.js
@@ -1,12 +1,13 @@
 /* eslint-disable no-unused-expressions */
+const util = require('util')
 const timeoutHelper = require('../../helpers/timeoutHelper')
 
 module.exports = {
   commands: {
     isThumbnailVisible: function() {
-      return this.waitForElementVisible(this.elements.sideBar).waitForElementVisible(
-        this.elements.sidebarThumbnail
-      )
+      return this.waitForElementVisible(
+        this.api.page.filesPage().elements.sideBar
+      ).waitForElementVisible(this.elements.sidebarThumbnail)
     },
     closeSidebar: function(timeout = null) {
       timeout = timeoutHelper.parseTimeout(timeout)
@@ -20,17 +21,68 @@ module.exports = {
       }
       return this.api.page.FilesPageElement.filesList()
     },
+    selectTab: async function(tab) {
+      await this.waitForElementVisible(this.api.page.filesPage().elements.sideBar)
+      const panelVisible = await this.isPanelVisible(
+        tab,
+        this.api.globals.waitForNegativeConditionTimeout
+      )
+      if (panelVisible) {
+        return this
+      } else {
+        return this.useXpath()
+          .click(this.getXpathOfLinkToTabInSidePanel(tab))
+          .useCss()
+      }
+    },
+    /**
+     * return the complete xpath of the link to the specified tab in the side-bar
+     * @param tab
+     * @returns {string}
+     */
+    getXpathOfLinkToTabInSidePanel: function(tab) {
+      return (
+        this.api.page.filesPage().elements.sideBar.selector +
+        util.format(this.elements.tabOfSideBar.selector, tab)
+      )
+    },
+    getVisibleTabs: async function() {
+      const tabs = []
+      let elements
+      await this.api.elements('@tabsInSideBar', function(result) {
+        elements = result.value
+      })
+      for (const { ELEMENT } of elements) {
+        await this.api.elementIdText(ELEMENT, function(result) {
+          tabs.push(result.value.toLowerCase())
+        })
+      }
+      return tabs
+    },
+    isPanelVisible: async function(panelName, timeout = null) {
+      panelName = panelName === 'people' ? 'collaborators' : panelName
+      const selector = this.elements[panelName + 'Panel']
+      let isVisible = false
+      timeout = timeoutHelper.parseTimeout(timeout)
+      await this.isVisible(
+        { locateStrategy: 'css selector', selector: selector.selector, timeout: timeout },
+        result => {
+          isVisible = result.status === 0
+        }
+      )
+      return isVisible
+    },
     /**
      * checks if the given tabs are present on the files-page-sidebar
      *
-     * @param {string} tabSelectorXpath
+     * @param {object} tabSelector
      * @returns {Promise<boolean>}
      */
-    isTabPresentOnCurrentSidebar: async function(tabSelectorXpath) {
+    isTabPresentOnCurrentSidebar: async function(tabSelector) {
       let isPresent = true
       await this.useXpath()
-        .waitForElementVisible('@sideBar') // sidebar is expected to be opened and visible
-        .api.elements('xpath', tabSelectorXpath, result => {
+        .waitForElementVisible(this.api.page.filesPage().elements.sideBar) // sidebar is expected to be opened and visible
+        .api.elements(tabSelector, result => {
           isPresent = result.value.length > 0
         })
         .useCss()
@@ -40,23 +92,23 @@ module.exports = {
      * @returns {Promise<boolean>}
      */
     isLinksTabPresentOnCurrentSidebar: function() {
-      return this.isTabPresentOnCurrentSidebar(this.elements.sidebarLinksTab.selector)
+      return this.isTabPresentOnCurrentSidebar(this.elements.sidebarLinksTab)
     },
     /**
      * @returns {Promise<boolean>}
      */
     isCollaboratorsTabPresentOnCurrentSidebar: function() {
-      return this.isTabPresentOnCurrentSidebar(this.elements.sidebarCollaboratorsTab.selector)
+      return this.isTabPresentOnCurrentSidebar(this.elements.sidebarCollaboratorsTab)
     },
     markFavoriteSidebar: function() {
       return this.useXpath()
-        .waitForElementVisible('@sideBar')
+        .waitForElementVisible(this.api.page.filesPage().elements.sideBar)
         .waitForElementVisible('@favoriteStarDimm')
         .click('@sidebarToggleFavoriteButton')
         .waitForElementVisible('@favoriteStarShining')
     },
     unmarkFavoriteSidebar: function() {
-      return this.waitForElementVisible('@sideBar')
+      return this.waitForElementVisible(this.api.page.filesPage().elements.sideBar)
         .waitForElementVisible('@favoriteStarShining')
         .click('@sidebarToggleFavoriteButton')
         .waitForElementVisible('@favoriteStarDimm')
@@ -72,8 +124,18 @@ module.exports = {
     }
   },
   elements: {
-    sideBar: {
-      selector: '.sidebar-container'
+    /**
+     * path from inside the side-bar
+     */
+    tabOfSideBar: {
+      // the translate bit is to make it case-insensitive
+      selector:
+        "//button[contains(translate(.,'ABCDEFGHJIKLMNOPQRSTUVWXYZ','abcdefghjiklmnopqrstuvwxyz'),'%s')]",
+      locateStrategy: 'xpath'
+    },
+    tabsInSideBar: {
+      selector: '//div[@class="sidebar-container"]//li/h3/button',
+      locateStrategy: 'xpath'
     },
     sidebarThumbnail: {
       selector: '.sidebar-title .oc-icon'
@@ -99,6 +161,18 @@ module.exports = {
     },
     favoriteStarShining: {
       selector: '.oc-star-shining'
+    },
+    versionsPanel: {
+      selector: '#oc-file-versions-sidebar'
+    },
+    collaboratorsPanel: {
+      selector: '#oc-files-sharing-sidebar'
+    },
+    linksPanel: {
+      selector: '#oc-files-file-link'
+    },
+    actionsPanel: {
+      selector: '#oc-files-actions-sidebar'
     }
   }
 }

--- a/tests/acceptance/pageObjects/FilesPageElement/appSideBar.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/appSideBar.js
@@ -21,43 +21,43 @@ module.exports = {
       }
       return this.api.page.FilesPageElement.filesList()
     },
-    selectTab: async function(tab) {
+    selectAccordionItem: async function(item) {
       await this.waitForElementVisible(this.api.page.filesPage().elements.sideBar)
       const panelVisible = await this.isPanelVisible(
-        tab,
+        item,
         this.api.globals.waitForNegativeConditionTimeout
       )
       if (panelVisible) {
         return this
       } else {
         return this.useXpath()
-          .click(this.getXpathOfLinkToTabInSidePanel(tab))
+          .click(this.getXpathOfLinkToAccordionItemInSidePanel(item))
           .useCss()
       }
     },
     /**
-     * return the complete xpath of the link to the specified tab in the side-bar
-     * @param tab
+     * return the complete xpath of the link to the specified accordion item in the side-bar
+     * @param item
      * @returns {string}
      */
-    getXpathOfLinkToTabInSidePanel: function(tab) {
+    getXpathOfLinkToAccordionItemInSidePanel: function(item) {
       return (
         this.api.page.filesPage().elements.sideBar.selector +
-        util.format(this.elements.tabOfSideBar.selector, tab)
+        util.format(this.elements.linkToOpenAccordionItem.selector, item)
       )
     },
-    getVisibleTabs: async function() {
-      const tabs = []
+    getVisibleAccordionItems: async function() {
+      const items = []
       let elements
-      await this.api.elements('@tabsInSideBar', function(result) {
+      await this.api.elements('@accordionItems', function(result) {
         elements = result.value
       })
       for (const { ELEMENT } of elements) {
         await this.api.elementIdText(ELEMENT, function(result) {
-          tabs.push(result.value.toLowerCase())
+          items.push(result.value.toLowerCase())
         })
       }
-      return tabs
+      return items
     },
     isPanelVisible: async function(panelName, timeout = null) {
       panelName = panelName === 'people' ? 'collaborators' : panelName
@@ -73,16 +73,16 @@ module.exports = {
       return isVisible
     },
     /**
-     * checks if the given tabs are present on the files-page-sidebar
+     * checks if the item with the given selector is present on the files-page-sidebar
      *
-     * @param {object} tabSelector
+     * @param {object} selector
      * @returns {Promise<boolean>}
      */
-    isTabPresentOnCurrentSidebar: async function(tabSelector) {
+    isAccordionItemPresent: async function(selector) {
       let isPresent = true
       await this.useXpath()
         .waitForElementVisible(this.api.page.filesPage().elements.sideBar) // sidebar is expected to be opened and visible
-        .api.elements(tabSelector, result => {
+        .api.elements(selector, result => {
           isPresent = result.value.length > 0
         })
         .useCss()
@@ -91,14 +91,14 @@ module.exports = {
     /**
      * @returns {Promise<boolean>}
      */
-    isLinksTabPresentOnCurrentSidebar: function() {
-      return this.isTabPresentOnCurrentSidebar(this.elements.sidebarLinksTab)
+    isLinksAccordionItemPresent: function() {
+      return this.isAccordionItemPresent(this.elements.linksAccordionItem)
     },
     /**
      * @returns {Promise<boolean>}
      */
-    isCollaboratorsTabPresentOnCurrentSidebar: function() {
-      return this.isTabPresentOnCurrentSidebar(this.elements.sidebarCollaboratorsTab)
+    isCollaboratorsAccordionItemPresent: function() {
+      return this.isAccordionItemPresent(this.elements.collaboratorsAccordionItem)
     },
     markFavoriteSidebar: function() {
       return this.useXpath()
@@ -118,13 +118,13 @@ module.exports = {
     /**
      * path from inside the side-bar
      */
-    tabOfSideBar: {
+    linkToOpenAccordionItem: {
       // the translate bit is to make it case-insensitive
       selector:
         "//button[contains(translate(.,'ABCDEFGHJIKLMNOPQRSTUVWXYZ','abcdefghjiklmnopqrstuvwxyz'),'%s')]",
       locateStrategy: 'xpath'
     },
-    tabsInSideBar: {
+    accordionItems: {
       selector: '//div[@class="sidebar-container"]//li/h3/button',
       locateStrategy: 'xpath'
     },
@@ -135,10 +135,10 @@ module.exports = {
       selector: '//div[@class="sidebar-container"]//div[@class="action"]//button',
       locateStrategy: 'xpath'
     },
-    sidebarCollaboratorsTab: {
+    collaboratorsAccordionItem: {
       selector: '#app-sidebar-files-sharing'
     },
-    sidebarLinksTab: {
+    linksAccordionItem: {
       selector: '#app-sidebar-file-link'
     },
     sidebarToggleFavoriteButton: {

--- a/tests/acceptance/pageObjects/FilesPageElement/appSideBar.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/appSideBar.js
@@ -112,15 +112,6 @@ module.exports = {
         .waitForElementVisible('@favoriteStarShining')
         .click('@sidebarToggleFavoriteButton')
         .waitForElementVisible('@favoriteStarDimm')
-    },
-    openCollaboratorsTab: function() {
-      return this.click('@sidebarCollaboratorsTab')
-    },
-    openVersionsTab: function() {
-      return this.click('@sidebarVersionsTab')
-    },
-    openLinksTab: function() {
-      return this.click('@sidebarLinksTab')
     }
   },
   elements: {
@@ -149,9 +140,6 @@ module.exports = {
     },
     sidebarLinksTab: {
       selector: '#app-sidebar-file-link'
-    },
-    sidebarVersionsTab: {
-      selector: '#app-sidebar-files-version'
     },
     sidebarToggleFavoriteButton: {
       selector: '#files-sidebar-star-icon'

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -18,7 +18,7 @@ module.exports = {
       await appSidebar.closeSidebar(500)
       await this.waitForFileVisible(fileName)
       await this.openSideBar(fileName)
-      return client.page.filesPage().selectTabInSidePanel('people')
+      return client.page.FilesPageElement.appSideBar().selectTab('people')
     },
     /**
      * @param {string} fileName
@@ -27,7 +27,7 @@ module.exports = {
     openPublicLinkDialog: async function(fileName) {
       await this.waitForFileVisible(fileName)
       await this.openSideBar(fileName)
-      return client.page.filesPage().selectTabInSidePanel('links')
+      return client.page.FilesPageElement.appSideBar().selectTab('links')
     },
     /**
      * @param {string} resource

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -18,7 +18,7 @@ module.exports = {
       await appSidebar.closeSidebar(500)
       await this.waitForFileVisible(fileName)
       await this.openSideBar(fileName)
-      return client.page.FilesPageElement.appSideBar().selectTab('people')
+      return client.page.FilesPageElement.appSideBar().selectAccordionItem('people')
     },
     /**
      * @param {string} fileName
@@ -27,7 +27,7 @@ module.exports = {
     openPublicLinkDialog: async function(fileName) {
       await this.waitForFileVisible(fileName)
       await this.openSideBar(fileName)
-      return client.page.FilesPageElement.appSideBar().selectTab('links')
+      return client.page.FilesPageElement.appSideBar().selectAccordionItem('links')
     },
     /**
      * @param {string} resource

--- a/tests/acceptance/pageObjects/FilesPageElement/publicLinksDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/publicLinksDialog.js
@@ -333,11 +333,8 @@ module.exports = {
       return this.waitForElementVisible(copyBtnSelector).click(copyBtnSelector)
     },
     copyPrivateLink: function() {
-      const appSideBarElements = this.api.page.FilesPageElement.appSideBar().elements
-      const sidebarLinksTab = appSideBarElements.sidebarLinksTab.selector
-      const sidebarCss = appSideBarElements.sideBar.selector
-
-      return this.waitForElementVisible(sidebarCss)
+      const sidebarLinksTab = this.api.page.FilesPageElement.appSideBar().elements.sidebarLinksTab
+      return this.waitForElementVisible(this.api.page.filesPage().elements.sideBar)
         .waitForElementVisible(sidebarLinksTab)
         .click(sidebarLinksTab)
         .waitForElementVisible('@sidebarPrivateLinkLabel')

--- a/tests/acceptance/pageObjects/FilesPageElement/publicLinksDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/publicLinksDialog.js
@@ -210,7 +210,7 @@ module.exports = {
         .waitForOutstandingAjaxCalls()
     },
     /**
-     * Gets the data of all public links of the currently open public link tab
+     * Gets the data of all public links of the currently open public link accordion item
      *
      * @param {Object.<String,Object>} subSelectors Map of arbitrary attribute name to selector to query
      * inside the collaborator element, defaults to all when null
@@ -273,7 +273,7 @@ module.exports = {
       return results
     },
     /**
-     * gets the urls of all public links of the currently open public link tab
+     * gets the urls of all public links of the currently open public link accordion item
      *
      * @returns {Promise<string>}
      */
@@ -333,10 +333,11 @@ module.exports = {
       return this.waitForElementVisible(copyBtnSelector).click(copyBtnSelector)
     },
     copyPrivateLink: function() {
-      const sidebarLinksTab = this.api.page.FilesPageElement.appSideBar().elements.sidebarLinksTab
+      const linksAccordionItem = this.api.page.FilesPageElement.appSideBar().elements
+        .linksAccordionItem
       return this.waitForElementVisible(this.api.page.filesPage().elements.sideBar)
-        .waitForElementVisible(sidebarLinksTab)
-        .click(sidebarLinksTab)
+        .waitForElementVisible(linksAccordionItem)
+        .click(linksAccordionItem)
         .waitForElementVisible('@sidebarPrivateLinkLabel')
         .click('@sidebarPrivateLinkLabel')
         .waitForElementNotPresent('@sidebarPrivateLinkLabel')

--- a/tests/acceptance/pageObjects/filesPage.js
+++ b/tests/acceptance/pageObjects/filesPage.js
@@ -1,6 +1,7 @@
 const util = require('util')
 const navigationHelper = require('../helpers/navigationHelper')
 const xpathHelper = require('../helpers/xpath')
+const timeoutHelper = require('../helpers/timeoutHelper')
 const { join, normalize } = require('../helpers/path')
 const { client } = require('nightwatch-api')
 
@@ -256,11 +257,7 @@ module.exports = {
     },
     isSidebarVisible: async function(timeout = null) {
       let isVisible = false
-      if (timeout === null) {
-        timeout = this.api.globals.waitForConditionTimeout
-      } else {
-        timeout = parseInt(timeout, 10)
-      }
+      timeout = timeoutHelper.parseTimeout(timeout)
       await this.isVisible(
         {
           locateStrategy: this.elements.sideBar.locateStrategy,
@@ -277,11 +274,7 @@ module.exports = {
       panelName = panelName === 'people' ? 'collaborators' : panelName
       const selector = this.elements[panelName + 'Panel']
       let isVisible = false
-      if (timeout === null) {
-        timeout = this.api.globals.waitForConditionTimeout
-      } else {
-        timeout = parseInt(timeout, 10)
-      }
+      timeout = timeoutHelper.parseTimeout(timeout)
       await this.isVisible(
         { locateStrategy: 'css selector', selector: selector.selector, timeout: timeout },
         result => {

--- a/tests/acceptance/pageObjects/filesPage.js
+++ b/tests/acceptance/pageObjects/filesPage.js
@@ -231,30 +231,6 @@ module.exports = {
         .waitForAjaxCallsToStartAndFinish()
         .waitForElementNotPresent('@dialog')
     },
-    /**
-     * return the complete xpath of the link to the specified tab in the side-bad
-     * @param tab
-     * @returns {string}
-     */
-    getXpathOfLinkToTabInSidePanel: function(tab) {
-      return this.elements.sideBar.selector + util.format(this.elements.tabOfSideBar.selector, tab)
-    },
-    selectTabInSidePanel: async function(tab) {
-      await this.useXpath()
-        .waitForElementVisible('@sideBar')
-        .useCss()
-      const panelVisible = await this.isPanelVisible(
-        tab,
-        this.api.globals.waitForNegativeConditionTimeout
-      )
-      if (panelVisible) {
-        return this
-      } else {
-        return this.useXpath()
-          .click(this.getXpathOfLinkToTabInSidePanel(tab))
-          .useCss()
-      }
-    },
     isSidebarVisible: async function(timeout = null) {
       let isVisible = false
       timeout = timeoutHelper.parseTimeout(timeout)
@@ -269,32 +245,6 @@ module.exports = {
         }
       )
       return isVisible
-    },
-    isPanelVisible: async function(panelName, timeout = null) {
-      panelName = panelName === 'people' ? 'collaborators' : panelName
-      const selector = this.elements[panelName + 'Panel']
-      let isVisible = false
-      timeout = timeoutHelper.parseTimeout(timeout)
-      await this.isVisible(
-        { locateStrategy: 'css selector', selector: selector.selector, timeout: timeout },
-        result => {
-          isVisible = result.status === 0
-        }
-      )
-      return isVisible
-    },
-    getVisibleTabs: async function() {
-      const tabs = []
-      let elements
-      await this.api.elements('@tabsInSideBar', function(result) {
-        elements = result.value
-      })
-      for (const { ELEMENT } of elements) {
-        await this.api.elementIdText(ELEMENT, function(result) {
-          tabs.push(result.value.toLowerCase())
-        })
-      }
-      return tabs
     },
     copyPermalinkFromFilesAppBar: function() {
       return this.waitForElementVisible('@permalinkCopyButton').click('@permalinkCopyButton')
@@ -466,18 +416,6 @@ module.exports = {
     fileUploadProgress: {
       selector: '#files-upload-progress'
     },
-    versionsPanel: {
-      selector: '#oc-file-versions-sidebar'
-    },
-    collaboratorsPanel: {
-      selector: '#oc-files-sharing-sidebar'
-    },
-    linksPanel: {
-      selector: '#oc-files-file-link'
-    },
-    actionsPanel: {
-      selector: '#oc-files-actions-sidebar'
-    },
     sideBar: {
       selector: '//div[@class="sidebar-container"]',
       locateStrategy: 'xpath'
@@ -485,21 +423,8 @@ module.exports = {
     fileOverwriteConfirm: {
       selector: '#files-overwrite-confirm'
     },
-    /**
-     * path from inside the side-bar
-     */
-    tabOfSideBar: {
-      // the translate bit is to make it case-insensitive
-      selector:
-        "//button[contains(translate(.,'ABCDEFGHJIKLMNOPQRSTUVWXYZ','abcdefghjiklmnopqrstuvwxyz'),'%s')]",
-      locateStrategy: 'xpath'
-    },
     sidebarItemName: {
       selector: '#files-sidebar-item-name'
-    },
-    tabsInSideBar: {
-      selector: '//div[@class="sidebar-container"]//li/h3/button',
-      locateStrategy: 'xpath'
     },
     dialog: {
       selector: '.oc-modal'

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -106,13 +106,13 @@ Given('user {string} has uploaded file {string} to {string}', async function(
 })
 
 When('the user browses to display the {string} details of file {string}', async function(
-  versions,
+  tab,
   filename
 ) {
   const api = client.page.FilesPageElement
   await api.filesList().clickRow(filename)
   await client.initAjaxCounters()
-  await api.appSideBar().openVersionsTab()
+  await api.appSideBar().selectTab(tab)
   await client.waitForOutstandingAjaxCalls()
 
   return client
@@ -438,7 +438,7 @@ Then('the versions list for resource {string} should contain {int} entry/entries
   const api = client.page.FilesPageElement
   await api.filesList().clickRow(resourceName)
   await client.initAjaxCounters()
-  await api.appSideBar().openVersionsTab()
+  await api.appSideBar().selectTab('versions')
   await client.waitForOutstandingAjaxCalls()
   const count = await api.versionsDialog().getVersionsCount()
 

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -778,14 +778,6 @@ Then(
   }
 )
 
-Then('no {string} tab should be available in the details panel', function(tab) {
-  const tabSelector = client.page.FilesPageElement.appSideBar().getXpathOfLinkToAccordionItemInSidePanel()
-  return client.page
-    .filesPage()
-    .useXpath()
-    .waitForElementNotPresent(tabSelector)
-})
-
 const assertElementsAreListed = async function(elements) {
   for (const element of elements) {
     const state = await client.page.FilesPageElement.filesList().isElementListed(element)

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -106,13 +106,13 @@ Given('user {string} has uploaded file {string} to {string}', async function(
 })
 
 When('the user browses to display the {string} details of file {string}', async function(
-  tab,
+  accordionItem,
   filename
 ) {
   const api = client.page.FilesPageElement
   await api.filesList().clickRow(filename)
   await client.initAjaxCounters()
-  await api.appSideBar().selectTab(tab)
+  await api.appSideBar().selectAccordionItem(accordionItem)
   await client.waitForOutstandingAjaxCalls()
 
   return client
@@ -438,7 +438,7 @@ Then('the versions list for resource {string} should contain {int} entry/entries
   const api = client.page.FilesPageElement
   await api.filesList().clickRow(resourceName)
   await client.initAjaxCounters()
-  await api.appSideBar().selectTab('versions')
+  await api.appSideBar().selectAccordionItem('versions')
   await client.waitForOutstandingAjaxCalls()
   const count = await api.versionsDialog().getVersionsCount()
 
@@ -517,8 +517,10 @@ When('the user picks the row of file/folder {string} in the webUI', function(ite
   return client.page.FilesPageElement.filesList().clickRow(item)
 })
 
-When('the user switches to {string} tab in details panel using the webUI', function(tab) {
-  return client.page.FilesPageElement.appSideBar().selectTab(tab)
+When('the user switches to {string} accordion item in details panel using the webUI', function(
+  item
+) {
+  return client.page.FilesPageElement.appSideBar().selectAccordionItem(item)
 })
 
 const theseResourcesShouldNotBeListed = async function(table) {
@@ -764,17 +766,20 @@ Then('the {string} details panel should be visible', async function(panel) {
   assert.strictEqual(visible, true, `'${panel}-panel' should be visible, but is not`)
 })
 
-Then('the following tabs should be visible in the details dialog', async function(table) {
-  const visibleTabs = await client.page.FilesPageElement.appSideBar().getVisibleTabs()
-  const expectedVisibleTabs = table.rows()
-  const difference = _.difference(expectedVisibleTabs.flat(), visibleTabs)
-  if (difference.length !== 0) {
-    throw new Error(`${difference} tabs was expected to be visible but not found.`)
+Then(
+  'the following accordion items should be visible in the details dialog on the webUI',
+  async function(table) {
+    const visibleItems = await client.page.FilesPageElement.appSideBar().getVisibleAccordionItems()
+    const expectedVisibleItems = table.rows()
+    const difference = _.difference(expectedVisibleItems.flat(), visibleItems)
+    if (difference.length !== 0) {
+      throw new Error(`${difference} accordion items was expected to be visible but not found.`)
+    }
   }
-})
+)
 
 Then('no {string} tab should be available in the details panel', function(tab) {
-  const tabSelector = client.page.FilesPageElement.appSideBar().getXpathOfLinkToTabInSidePanel()
+  const tabSelector = client.page.FilesPageElement.appSideBar().getXpathOfLinkToAccordionItemInSidePanel()
   return client.page
     .filesPage()
     .useXpath()

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -518,7 +518,7 @@ When('the user picks the row of file/folder {string} in the webUI', function(ite
 })
 
 When('the user switches to {string} tab in details panel using the webUI', function(tab) {
-  return client.page.filesPage().selectTabInSidePanel(tab)
+  return client.page.FilesPageElement.appSideBar().selectTab(tab)
 })
 
 const theseResourcesShouldNotBeListed = async function(table) {
@@ -760,12 +760,12 @@ Then('the app-sidebar should be invisible', async function() {
 })
 
 Then('the {string} details panel should be visible', async function(panel) {
-  const visible = await client.page.filesPage().isPanelVisible(panel)
+  const visible = await client.page.FilesPageElement.appSideBar().isPanelVisible(panel)
   assert.strictEqual(visible, true, `'${panel}-panel' should be visible, but is not`)
 })
 
 Then('the following tabs should be visible in the details dialog', async function(table) {
-  const visibleTabs = await client.page.filesPage().getVisibleTabs()
+  const visibleTabs = await client.page.FilesPageElement.appSideBar().getVisibleTabs()
   const expectedVisibleTabs = table.rows()
   const difference = _.difference(expectedVisibleTabs.flat(), visibleTabs)
   if (difference.length !== 0) {
@@ -774,7 +774,7 @@ Then('the following tabs should be visible in the details dialog', async functio
 })
 
 Then('no {string} tab should be available in the details panel', function(tab) {
-  const tabSelector = client.page.filesPage().getXpathOfLinkToTabInSidePanel()
+  const tabSelector = client.page.FilesPageElement.appSideBar().getXpathOfLinkToTabInSidePanel()
   return client.page
     .filesPage()
     .useXpath()

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -955,7 +955,7 @@ Then(
   'the share {string} shared with user {string} should have no expiration information displayed on the WebUI',
   async function(item, user) {
     await client.page.FilesPageElement.filesList().clickRow(item)
-    await client.page.filesPage().selectTabInSidePanel('people')
+    await client.page.FilesPageElement.appSideBar().selectTab('people')
     const elementID = await client.page.FilesPageElement.SharingDialog.collaboratorsDialog().getCollaboratorExpirationInfo(
       user
     )
@@ -971,7 +971,7 @@ Then(
   'the expiration information displayed on the WebUI of share {string} shared with user {string} should be {string} or {string}',
   async function(item, user, information1, information2) {
     await client.page.FilesPageElement.filesList().clickRow(item)
-    await client.page.filesPage().selectTabInSidePanel('people')
+    await client.page.FilesPageElement.appSideBar().selectTab('people')
     const actualInfo = await client.page.FilesPageElement.SharingDialog.collaboratorsDialog().getCollaboratorExpirationInfo(
       user
     )

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -699,12 +699,15 @@ Then('it should not be possible to share file/folder {string} using the webUI', 
   const state = await filesList.isSharingButtonPresent(resource)
   assert.ok(!state, `Error: Sharing button for resource ${resource} is not in disabled state`)
   await filesList.openSideBar(resource)
-  const sidebarLinkTabState = await appSideBar.isLinksTabPresentOnCurrentSidebar()
-  assert.ok(!sidebarLinkTabState, `Error: Sidebar 'Links' tab for resource ${resource} is present`)
-  const sidebarCollaboratorsTabState = await appSideBar.isCollaboratorsTabPresentOnCurrentSidebar()
+  const linkItemState = await appSideBar.isLinksAccordionItemPresent()
   assert.ok(
-    !sidebarCollaboratorsTabState,
-    `Error: Sidebar 'People' tab for resource ${resource} is present`
+    !linkItemState,
+    `Error: Sidebar 'Links' accordion item for resource ${resource} is present`
+  )
+  const collaboratorsItemState = await appSideBar.isCollaboratorsAccordionItemPresent()
+  assert.ok(
+    !collaboratorsItemState,
+    `Error: Sidebar 'People' accordion item for resource ${resource} is present`
   )
 })
 
@@ -955,7 +958,7 @@ Then(
   'the share {string} shared with user {string} should have no expiration information displayed on the WebUI',
   async function(item, user) {
     await client.page.FilesPageElement.filesList().clickRow(item)
-    await client.page.FilesPageElement.appSideBar().selectTab('people')
+    await client.page.FilesPageElement.appSideBar().selectAccordionItem('people')
     const elementID = await client.page.FilesPageElement.SharingDialog.collaboratorsDialog().getCollaboratorExpirationInfo(
       user
     )
@@ -971,7 +974,7 @@ Then(
   'the expiration information displayed on the WebUI of share {string} shared with user {string} should be {string} or {string}',
   async function(item, user, information1, information2) {
     await client.page.FilesPageElement.filesList().clickRow(item)
-    await client.page.FilesPageElement.appSideBar().selectTab('people')
+    await client.page.FilesPageElement.appSideBar().selectAccordionItem('people')
     const actualInfo = await client.page.FilesPageElement.SharingDialog.collaboratorsDialog().getCollaboratorExpirationInfo(
       user
     )


### PR DESCRIPTION
## Description
fixing a couple of issues I noticed when working on #4355
- [x] parsing timeout and check if its `null` was repeated => DRY the code by moving it to an own helper
- [x] some methods and items that belong into the sideBar PO were still located in the filesPage PO => so move them
- [x] opening tabs could be done by different methods, some of them not used at all => use the same method everyewhere & delete unused methods
- [x] rename tabs to "accordion items" (see https://github.com/owncloud/phoenix/pull/4355#issuecomment-730872892)

## Motivation and Context
cleaner code

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...