### PR TITLE
Fix icon mappings for non-existing icon files.

### DIFF
--- a/apps/files/src/fileTypeIconMappings.json
+++ b/apps/files/src/fileTypeIconMappings.json
@@ -68,7 +68,7 @@
   "psd": "image",
   "py": "text-code",
   "rar": "package-x-generic",
-  "rss": "application-xml",
+  "rss": "file",
   "sh-lib": "text-code",
   "sh": "text-code",
   "swf": "file",
@@ -92,7 +92,7 @@
   "xlt": "x-office-spreadsheet",
   "xltm": "x-office-spreadsheet",
   "xltx": "x-office-spreadsheet",
-  "xml": "text-html",
+  "xml": "text-code",
   "yaml": "text-code",
   "yml": "text-code",
   "zip": "package-x-generic"

--- a/changelog/unreleased/fix-icons
+++ b/changelog/unreleased/fix-icons
@@ -1,0 +1,6 @@
+Bugfix: Icon mappings
+
+The file type icon mappings contained some mappings to non-existing icon files. We fixed those.
+
+https://github.com/owncloud/phoenix/pull/4357
+https://github.com/owncloud/ocis/issues/905


### PR DESCRIPTION
## Description
The file type icon mapping contained two mappings to non-existing icon files. This PR changes those mappings to other, existing icons.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- drone

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
