### PR TITLE
Fix edit link view

### DIFF
--- a/apps/files/src/components/FileLinkSidebar.vue
+++ b/apps/files/src/components/FileLinkSidebar.vue
@@ -91,7 +91,7 @@
         leave-active-class="uk-animation-slide-right uk-animation-reverse uk-animation-fast"
         name="custom-classes-transition"
       >
-        <div class="uk-position-cover oc-default-background">
+        <div class="oc-default-background">
           <edit-public-link :params="params" @close="$_showList()" />
         </div>
       </transition>

--- a/changelog/unreleased/fix-edit-link-view
+++ b/changelog/unreleased/fix-edit-link-view
@@ -1,0 +1,5 @@
+Bugfix: Fix edit public link view
+
+We've fixed the issue that edit public link view in the sidebar was overlapping with the versions accordion.
+
+https://github.com/owncloud/phoenix/pull/4374


### PR DESCRIPTION
Do not overlap the edit public link view with the versions accordion.

![image](https://user-images.githubusercontent.com/25989331/99955506-c0e38000-2d84-11eb-887d-db358fdec738.png)