### PR TITLE
Text editor file path label

### DIFF
--- a/apps/markdown-editor/src/MarkdownEditor.vue
+++ b/apps/markdown-editor/src/MarkdownEditor.vue
@@ -15,11 +15,11 @@
           name="input"
           full-width
           :value="currentContent"
+          :label="$gettext('Editor')"
           class="uk-height-1-1"
           :rows="20"
           @input="onType"
-        >
-        </oc-textarea>
+        />
       </div>
       <div class="uk-container uk-width-1-2">
         <!-- eslint-disable-next-line vue/no-v-html -->

--- a/apps/markdown-editor/src/MarkdownEditorAppBar.vue
+++ b/apps/markdown-editor/src/MarkdownEditorAppBar.vue
@@ -5,7 +5,7 @@
         <oc-button :disabled="!isTouched" @click="saveContent">
           <oc-icon name="save" aria-hidden="true" />
         </oc-button>
-        <oc-spinner v-if="isLoading" />
+        <oc-spinner v-if="isLoading" :aria-label="$gettext('Loading editor content')" />
       </div>
       <div class="uk-width-expand uk-text-center">
         <span>{{ activeFilePath }}</span>

--- a/apps/markdown-editor/src/MarkdownEditorAppBar.vue
+++ b/apps/markdown-editor/src/MarkdownEditorAppBar.vue
@@ -8,7 +8,7 @@
         <oc-spinner v-if="isLoading" />
       </div>
       <div class="uk-width-expand uk-text-center">
-        <span>{{ activeFile.path.substr(1) }}</span>
+        <span>{{ activeFilePath }}</span>
       </div>
       <div class="uk-width-auto uk-text-right">
         <oc-button @click="closeApp">
@@ -24,7 +24,10 @@ import { mapGetters, mapActions } from 'vuex'
 export default {
   computed: {
     ...mapGetters(['activeFile']),
-    ...mapGetters('MarkdownEditor', ['isTouched', 'isLoading'])
+    ...mapGetters('MarkdownEditor', ['isTouched', 'isLoading']),
+    activeFilePath() {
+      return this.activeFile.path.replace(/^\/+/, '')
+    }
   },
   methods: {
     ...mapActions('MarkdownEditor', ['saveFile']),

--- a/apps/markdown-editor/src/MarkdownEditorAppBar.vue
+++ b/apps/markdown-editor/src/MarkdownEditorAppBar.vue
@@ -26,7 +26,7 @@ export default {
     ...mapGetters(['activeFile']),
     ...mapGetters('MarkdownEditor', ['isTouched', 'isLoading']),
     activeFilePath() {
-      return this.activeFile.path.replace(/^\/+/, '')
+      return this.activeFile.path.replace(/^(\/|\\)+/, '')
     }
   },
   methods: {

--- a/changelog/unreleased/text-editor-file-path-label
+++ b/changelog/unreleased/text-editor-file-path-label
@@ -1,0 +1,5 @@
+Bugfix: Don't break file/folder names in text editor
+
+The label in the text editor that displays the path of the active file was removing the first character instead of trimming leading slashes. This might have lead to situations where actual characters were removed. We fixed this by only removing leading slahes instead of blindly removing the first character.
+
+https://github.com/owncloud/phoenix/pull/4391


### PR DESCRIPTION

## Description
There might be cases where the markdown editor stripped the first actual character of a file or folder name. It was supposed to strip a leading slash/backslash. This PR only trims leading slashes or backslashes. As a quick win it also sets aria labels for components that were complaining in the JS console about not having aria labels.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/ocis/issues/428

## Motivation and Context
Hardening.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- drone

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
