### PR TITLE
Bootstrap Vue

### DIFF
--- a/src/phoenix.js
+++ b/src/phoenix.js
@@ -2,7 +2,7 @@
 import 'regenerator-runtime/runtime'
 
 // --- Libraries and Plugins ---
-import Vue from 'vue'
+import Vue from './vue'
 import 'vue-resize/dist/vue-resize.css'
 import VueResize from 'vue-resize'
 
@@ -178,9 +178,6 @@ async function finalizeInit () {
     router,
     render: h => h(Phoenix)
   })
-
-  // externalize Vue - this is not the Vue instance but the class
-  window.Vue = Vue
 }
 
 function fetchTheme() {

--- a/src/vue.js
+++ b/src/vue.js
@@ -1,0 +1,6 @@
+import Vue from 'vue'
+
+// externalize Vue - this is not the Vue instance but the class
+window.Vue = Vue
+
+export default Vue


### PR DESCRIPTION
Previously the Vue class wouldn't be assigned to the window object. To do so, we have to move Vue import into own file and assign the class there.