### PR TITLE
check content length before trying to parse the content

### DIFF
--- a/src/store/app.js
+++ b/src/store/app.js
@@ -34,6 +34,9 @@ const actions = {
         action: 'api/v1/notifications'
       })
       .then(response => {
+        if (response.headers.get('Content-Length') === '0') {
+          return
+        }
         response.json().then(json => {
           if (response.ok) {
             context.commit('UPDATE_NOTIFICATIONS', json.ocs.data)


### PR DESCRIPTION
Every time phoenix calls the notifications endpoint it tries to do a json parse of the response content.
But there is no response content and therefore the parsing fails and log a message to the console.
This pr tries to prevent that so that the console doesn't get spammed with unnecessary logs.

- [ ] Add changelog