### PR TITLE
Public link fixes

### DIFF
--- a/apps/files/src/default.js
+++ b/apps/files/src/default.js
@@ -190,7 +190,10 @@ const routes = [
     components: {
       app: FilesApp
     },
-    meta: { auth: false }
+    meta: {
+      auth: false,
+      hasBulkActions: true
+    }
   },
   {
     path: '/files-drop/:token',

--- a/apps/files/src/quickActions.js
+++ b/apps/files/src/quickActions.js
@@ -54,7 +54,11 @@ function openNewCollaboratorsPanel(ctx) {
 }
 
 function canShare(item, store) {
-  return store.state.user.capabilities.files_sharing.api_enabled && item.canShare()
+  return (
+    store.state.user.capabilities.files_sharing &&
+    store.state.user.capabilities.files_sharing.api_enabled &&
+    item.canShare()
+  )
 }
 
 export default {

--- a/changelog/unreleased/fix-public-link-issues
+++ b/changelog/unreleased/fix-public-link-issues
@@ -1,0 +1,10 @@
+Bugfix: Public link glitches
+
+We fixed a couple of glitches with public links:
+- Creating a folder in a public link context was showing an error message although the folder was created correctly. This was happening because reloading the current folder didn't
+take the public link context into account.
+- For public links with editor role the batch actions at the top of the files list were not showing. The public links route didn't have a specific flag for showing the batch actions.
+- Quick actions for sharing are not available in public link contexts by design. The check printed an error in the javascript console though. We made this check silent now.
+
+https://github.com/owncloud/ocis/issues/1028
+https://github.com/owncloud/phoenix/pull/4425


### PR DESCRIPTION
## Description
This PR fixes some public link issues.
- batch actions were not available for public links
- creating a folder in a public link context showed an error
- quick actions for sharing are not available in public links (by design) but showed an error on the capabilities check.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/ocis/issues/1028 https://github.com/owncloud/phoenix/issues/3744

## Motivation and Context
Hardening

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- drone

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 