### PR TITLE
add status text for accepted shares

### DIFF
--- a/apps/files/src/components/Collaborators/SharedFilesList.vue
+++ b/apps/files/src/components/Collaborators/SharedFilesList.vue
@@ -285,7 +285,7 @@ export default {
     },
 
     shareStatus(status) {
-      if (status === 0) return
+      if (status === 0) return this.$gettext('Accepted')
 
       if (status === 1) return this.$gettext('Pending')
 

--- a/changelog/unreleased/accepted-shares-status.md
+++ b/changelog/unreleased/accepted-shares-status.md
@@ -1,0 +1,5 @@
+Enhancement: show status of accepted shares
+
+The status column of accepted shares was blank.
+
+https://github.com/owncloud/ocis/issues/985


### PR DESCRIPTION
We need to add 'Accepted' to the translations.

Fixes https://github.com/owncloud/ocis/issues/985