### PR TITLE
add the option to retroactively decline an accepted share

### DIFF
--- a/apps/files/src/components/Collaborators/SharedFilesList.vue
+++ b/apps/files/src/components/Collaborators/SharedFilesList.vue
@@ -73,7 +73,7 @@
           <translate>Accept</translate>
         </oc-button>
         <oc-button
-          v-if="item.status === 1"
+          v-if="item.status === 1 || item.status === 0"
           variation="raw"
           class="file-row-share-status-action uk-text-meta oc-ml"
           @click="pendingShareAction(item, 'DELETE')"

--- a/changelog/unreleased/accepted-shares-decline.md
+++ b/changelog/unreleased/accepted-shares-decline.md
@@ -1,0 +1,6 @@
+Enhancement: add the option to decline accepted shares
+
+Declined shares could be accepted retroactively but accepted shares could not be declined.
+
+https://github.com/owncloud/ocis/issues/985
+


### PR DESCRIPTION
Declined shares could be accepted retroactively but accepted shares could not be declined.
Implements https://github.com/owncloud/ocis/issues/985