### PR TITLE
Fix file editor actions

### DIFF
--- a/apps/files/src/mixins/fileActions.js
+++ b/apps/files/src/mixins/fileActions.js
@@ -41,7 +41,7 @@ export default {
     },
 
     $_fileActions_editorActions() {
-      const actions = this.apps.fileEditors.map(editor => {
+      return this.apps.fileEditors.map(editor => {
         return {
           ariaLabel: () => {
             return `Open in ${this.apps.meta[editor.app].name}`
@@ -49,7 +49,7 @@ export default {
           icon: this.apps.meta[editor.app].icon,
           handler: item => this.$_fileActions_openEditor(editor, item.path, item.id),
           isEnabled: ({ resource }) => {
-            if (editor.routes && checkRoute(editor.routes, this.$route.name)) {
+            if (editor.routes && !checkRoute(editor.routes, this.$route.name)) {
               return false
             }
 
@@ -58,8 +58,6 @@ export default {
           canBeDefault: true
         }
       })
-
-      return actions
     }
   },
 

--- a/changelog/unreleased/fix-file-action-route-checks
+++ b/changelog/unreleased/fix-file-action-route-checks
@@ -1,0 +1,6 @@
+Bugfix: Enable route checks for file actions
+
+The checks on which route an extension is enabled were not active (and inverted). We fixed this so that editors only appear on configured routes now.
+
+https://github.com/owncloud/ocis/issues/986
+https://github.com/owncloud/phoenix/pull/4436

--- a/src/store/apps.js
+++ b/src/store/apps.js
@@ -52,6 +52,7 @@ const mutations = {
           icon: e.icon,
           newTab: e.newTab || false,
           routeName: e.routeName,
+          routes: e.routes || [],
           extension: e.extension,
           handler: e.handler
         }


### PR DESCRIPTION

## Description
The checks on which route an extension is enabled were not active (and inverted). We fixed this so that editors only appear on configured routes now.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes  https://github.com/owncloud/ocis/issues/986

## Motivation and Context
Hardening

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- drone

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
