### PR TITLE
[tests-only] Bump OCIS commit id for CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -330,7 +330,7 @@ config = {
 	'defaults': {
 		'acceptance': {
 			'ocisBranch': 'master',
-			'ocisCommit': '99279379d9ba2d7ce5e815ccbba6e85d7debfc17',
+			'ocisCommit': '76fefa325594c3d58560ca06e0e5311298104832',
 		}
 	},
 


### PR DESCRIPTION
The last update was from 3 Dec 2020, which is ages in the current fast-moving software environment.